### PR TITLE
Fix API Docker image missing dist/

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,6 +12,7 @@ RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @glantri/database exec prisma generate
 RUN pnpm --filter @glantri/api... run build
 RUN pnpm --filter @glantri/api deploy --prod /deploy
+RUN cp -r /build/apps/api/dist /deploy/dist
 RUN find /build/node_modules -name ".prisma" -type d | while IFS= read -r src; do \
       rel="${src#/build/node_modules/}"; \
       dst="/deploy/node_modules/${rel}"; \


### PR DESCRIPTION
## Summary
- `pnpm deploy` excludes files listed in `.gitignore`, which includes `dist/`
- The API container was crashing on startup with `Cannot find module '/app/dist/server.js'`
- Fix: explicitly copy `dist/` to `/deploy/dist/` after `pnpm deploy` in the Dockerfile

## Test plan
- [ ] Deploy job completes successfully
- [ ] `https://glantri-dev-api.azurewebsites.net/health` responds
- [ ] Web app no longer shows "Fail to fetch"

🤖 Generated with [Claude Code](https://claude.com/claude-code)