### PR TITLE
Fix API tsconfig build output path

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,7 +12,7 @@ RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @glantri/database exec prisma generate
 RUN pnpm --filter @glantri/api... run build
 RUN pnpm --filter @glantri/api deploy --prod /deploy
-RUN cp -r /build/apps/api/dist /deploy/dist
+RUN cp -r /build/apps/api/dist /deploy/dist && ls /deploy/dist/server.js
 RUN find /build/node_modules -name ".prisma" -type d | while IFS= read -r src; do \
       rel="${src#/build/node_modules/}"; \
       dst="/deploy/node_modules/${rel}"; \

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "src",
+    "paths": {}
   }
 }


### PR DESCRIPTION
## Summary
- `rootDir: \"../.."` caused TypeScript to output `dist/apps/api/src/server.js` instead of `dist/server.js`
- Fixed by setting `rootDir: "src"` and `paths: {}` in `tsconfig.build.json`
- Added `ls /deploy/dist/server.js` safeguard in Dockerfile to fail fast if file is missing

## Test plan
- [ ] Docker build passes the `ls` check (file exists at `dist/server.js`)
- [ ] API responds at `https://glantri-dev-api.azurewebsites.net/health`
- [ ] Web app no longer shows "Fail to fetch"

🤖 Generated with [Claude Code](https://claude.com/claude-code)