### PR TITLE
Fix API CMD: use correct tsc output path

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,7 +12,7 @@ RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @glantri/database exec prisma generate
 RUN pnpm --filter @glantri/api... run build
 RUN pnpm --filter @glantri/api deploy --prod /deploy
-RUN cp -r /build/apps/api/dist /deploy/dist && ls /deploy/dist/server.js
+RUN cp -r /build/apps/api/dist /deploy/dist && ls /deploy/dist/apps/api/src/server.js
 RUN find /build/node_modules -name ".prisma" -type d | while IFS= read -r src; do \
       rel="${src#/build/node_modules/}"; \
       dst="/deploy/node_modules/${rel}"; \
@@ -25,4 +25,4 @@ WORKDIR /app
 COPY --from=builder /deploy ./
 ENV NODE_ENV=production
 EXPOSE 4000
-CMD ["node", "dist/server.js"]
+CMD ["node", "dist/apps/api/src/server.js"]

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -2,8 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "outDir": "dist",
-    "rootDir": "src",
-    "paths": {}
+    "outDir": "dist"
   }
 }


### PR DESCRIPTION
## Summary
- Reverts the broken `paths: {}` tsconfig change from the previous PR
- Fixes the Docker `CMD` to match the actual TypeScript output path
- With `rootDir: "../.."` and `outDir: "dist"`, tsc outputs to `dist/apps/api/src/server.js`
- Added `ls` safeguard to fail fast if the file is missing

## Test plan
- [ ] Docker build passes the `ls` verification step
- [ ] API responds at `https://glantri-dev-api.azurewebsites.net/health`
- [ ] Web app no longer shows "Fail to fetch"

🤖 Generated with [Claude Code](https://claude.com/claude-code)