### PR TITLE
fix: strakstiltak produksjonsstabilitet (Failed to fetch, CORS, porter, smoke test)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/glantri"
 
+# Base-URL til API-tjenesten — brukes av frontend for alle API-kall.
+# Produksjon: https://<din-api-app>.azurewebsites.net
+NEXT_PUBLIC_API_BASE_URL="http://localhost:4000"
+
 # URL til frontend-applikasjonen — brukes av API for CORS-tillating.
 # Produksjon: https://<din-web-app>.azurewebsites.net
 WEB_ORIGIN="http://localhost:3000"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,9 @@ jobs:
 
       - name: Build and push Web image
         run: |
-          docker build -t ${{ env.WEB_IMAGE }}:${{ github.sha }} -t ${{ env.WEB_IMAGE }}:latest \
+          docker build \
+            --build-arg NEXT_PUBLIC_API_BASE_URL=https://${{ secrets.AZURE_API_APP_NAME }}.azurewebsites.net \
+            -t ${{ env.WEB_IMAGE }}:${{ github.sha }} -t ${{ env.WEB_IMAGE }}:latest \
             -f apps/web/Dockerfile .
           docker push ${{ env.WEB_IMAGE }}:${{ github.sha }}
           docker push ${{ env.WEB_IMAGE }}:latest
@@ -99,3 +101,8 @@ jobs:
         with:
           app-name: ${{ secrets.AZURE_WEB_APP_NAME }}
           images: ${{ env.WEB_IMAGE }}:${{ github.sha }}
+
+      - name: Smoke test API health
+        run: |
+          sleep 30
+          curl -fsS https://${{ secrets.AZURE_API_APP_NAME }}.azurewebsites.net/health

--- a/apps/api/src/lib/sessionAuth.ts
+++ b/apps/api/src/lib/sessionAuth.ts
@@ -33,7 +33,7 @@ export function applyLocalCors(app: FastifyInstance): void {
     if (requestOrigin === allowedOrigin) {
       reply.header("access-control-allow-origin", allowedOrigin);
       reply.header("access-control-allow-credentials", "true");
-      reply.header("access-control-allow-methods", "GET,POST,PUT,OPTIONS");
+      reply.header("access-control-allow-methods", "GET,POST,PUT,DELETE,OPTIONS");
       reply.header("access-control-allow-headers", "content-type");
       reply.header("vary", "origin");
     }

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -9,6 +9,8 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc turbo.json tsconfig.
 COPY packages/ ./packages/
 COPY apps/web/ ./apps/web/
 RUN pnpm install --frozen-lockfile
+ARG NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
 RUN pnpm --filter @glantri/web... run build
 
 FROM node:22-alpine AS runner

--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -33,11 +33,15 @@ resource apiApp 'Microsoft.Web/sites@2023-12-01' = {
           value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/web-origin/)'
         }
         {
+          name: 'WEBSITES_PORT'
+          value: '4000'
+        }
+        {
           name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
           value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/appinsights-connection-string/)'
         }
       ]
-      appCommandLine: 'node dist/server.js'
+      appCommandLine: ''
     }
   }
 }
@@ -57,15 +61,15 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
           value: 'production'
         }
         {
-          name: 'NEXT_PUBLIC_API_URL'
-          value: 'https://${prefix}-api.azurewebsites.net'
+          name: 'WEBSITES_PORT'
+          value: '3000'
         }
         {
           name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
           value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/appinsights-connection-string/)'
         }
       ]
-      appCommandLine: 'node apps/web/server.js'
+      appCommandLine: ''
     }
   }
 }


### PR DESCRIPTION
## Summary

Implementerer alle strakstiltak fra teknisk gjennomgang 2026-05-07.

- **Fikser `Failed to fetch`**: `NEXT_PUBLIC_API_BASE_URL` sendes nå som `--build-arg` ved Docker build og bakes inn i Next.js-bundlen med riktig API-URL
- **Fikser portrouting**: `WEBSITES_PORT` satt til `3000` (web) og `4000` (API) i Bicep
- **Fikser CORS**: `DELETE` lagt til i `access-control-allow-methods`
- **Post-deploy smoke test**: `curl /health` etter deploy — deploy feiler hvis API ikke svarer

## Endrede filer

| Fil | Endring |
|---|---|
| `apps/web/Dockerfile` | `ARG`/`ENV NEXT_PUBLIC_API_BASE_URL` før `next build` |
| `.github/workflows/deploy.yml` | `--build-arg NEXT_PUBLIC_API_BASE_URL=...` + smoke test |
| `infra/modules/appservice.bicep` | `WEBSITES_PORT` for begge apps, fjernet feil `NEXT_PUBLIC_API_URL` og `appCommandLine` |
| `apps/api/src/lib/sessionAuth.ts` | `DELETE` i CORS |
| `.env.example` | `NEXT_PUBLIC_API_BASE_URL` dokumentert |

## Lukker

Closes #39, #40, #41, #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)