### PR TITLE
fix: smoke test retry-loop (Azure container trenger >30s å starte)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,5 +104,13 @@ jobs:
 
       - name: Smoke test API health
         run: |
-          sleep 30
-          curl -fsS https://${{ secrets.AZURE_API_APP_NAME }}.azurewebsites.net/health
+          for i in $(seq 1 12); do
+            if curl -fsS https://${{ secrets.AZURE_API_APP_NAME }}.azurewebsites.net/health; then
+              echo "Health check passed"
+              exit 0
+            fi
+            echo "Attempt $i/12 failed, retrying in 15s..."
+            sleep 15
+          done
+          echo "Health check failed after 3 minutes"
+          exit 1


### PR DESCRIPTION
## Problem

Smoke test etter deploy brukte `sleep 30` + én `curl`-sjekk. Azure container trenger 60–90 sek å starte etter deploy — 30 sekunder gav 503 og feilet deployen.

## Fix

Retry-loop: prøver 12 ganger med 15 sekunders mellomrom (maks 3 min totalt).

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)