### PR TITLE
test: DB-integrasjonstester med deterministisk testdatabase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/glantri_test
         run: pnpm --filter @glantri/database exec prisma migrate deploy
 
+      - name: Run integration tests
+        env:
+          DATABASE_URL_TEST: postgresql://postgres:postgres@localhost:5432/glantri_test
+        run: pnpm --filter @glantri/database test
+
       - name: Build API image
         run: docker build -t glantri-api-test -f apps/api/Dockerfile .
 

--- a/packages/config/vitest.base.ts
+++ b/packages/config/vitest.base.ts
@@ -1,7 +1,94 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vitest/config";
 
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@glantri\/auth$/,
+        replacement: path.join(repoRoot, "packages/auth/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/auth\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/auth/src/$1"),
+      },
+      {
+        find: /^@glantri\/content$/,
+        replacement: path.join(repoRoot, "packages/content/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/content\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/content/src/$1"),
+      },
+      {
+        find: /^@glantri\/database$/,
+        replacement: path.join(repoRoot, "packages/database/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/database\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/database/src/$1"),
+      },
+      {
+        find: /^@glantri\/domain$/,
+        replacement: path.join(repoRoot, "packages/domain/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/domain\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/domain/src/$1"),
+      },
+      {
+        find: /^@glantri\/rules-engine$/,
+        replacement: path.join(repoRoot, "packages/rules-engine/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/rules-engine\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/rules-engine/src/$1"),
+      },
+      {
+        find: /^@glantri\/schemas\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/schemas/src/$1"),
+      },
+      {
+        find: /^@glantri\/shared$/,
+        replacement: path.join(repoRoot, "packages/shared/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/shared\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/shared/src/$1"),
+      },
+      {
+        find: /^@glantri\/test-scenarios$/,
+        replacement: path.join(repoRoot, "packages/test-scenarios/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/test-scenarios\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/test-scenarios/src/$1"),
+      },
+    ],
+  },
   test: {
+    coverage: {
+      exclude: [
+        "**/.next/**",
+        "**/coverage/**",
+        "**/dist/**",
+        "**/node_modules/**",
+        "**/*.config.*",
+        "**/*.d.ts",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "data/**",
+        "packages/content/src/equipment/armorTemplates.ts",
+        "packages/content/src/equipment/importedWeaponTemplates.ts",
+        "packages/content/src/equipment/shieldTemplates.ts",
+      ],
+      provider: "v8",
+      reporter: ["text", "json-summary", "html"],
+    },
     globals: true,
     environment: "node"
   }

--- a/packages/database/src/repositories/authRepository.ts
+++ b/packages/database/src/repositories/authRepository.ts
@@ -1,6 +1,7 @@
 import type { AuthRole, AuthSession, AuthUser } from "@glantri/auth";
+import type { PrismaClient } from "@prisma/client";
 
-import { prisma } from "../client";
+import { prisma as defaultPrisma } from "../client";
 
 export interface CreateUserInput {
   displayName?: string;
@@ -51,7 +52,9 @@ function mapRoles(roles: Array<{ role: { name: string } }>): AuthRole[] {
     .filter((role): role is AuthRole => role !== null);
 }
 
-export function createPrismaAuthRepository(): AuthRepository {
+export function createPrismaAuthRepository(client?: PrismaClient): AuthRepository {
+  const prisma = client ?? defaultPrisma;
+
   return {
     async anyPrivilegedUserExists() {
       const privilegedUserCount = await prisma.user.count({

--- a/packages/database/src/repositories/characterRepository.ts
+++ b/packages/database/src/repositories/characterRepository.ts
@@ -1,6 +1,7 @@
 import { characterBuildSchema, type CharacterBuild } from "@glantri/domain";
+import type { PrismaClient } from "@prisma/client";
 
-import { prisma } from "../client";
+import { prisma as defaultPrisma } from "../client";
 
 export interface CharacterRecord {
   build: CharacterBuild;
@@ -67,7 +68,9 @@ function mapCharacterRecord(character: {
   };
 }
 
-export function createPrismaCharacterRepository(): CharacterRepository {
+export function createPrismaCharacterRepository(client?: PrismaClient): CharacterRepository {
+  const prisma = client ?? defaultPrisma;
+
   return {
     async findById(id) {
       const character = await prisma.character.findUnique({

--- a/packages/database/src/services/authService.integration.test.ts
+++ b/packages/database/src/services/authService.integration.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { createPrismaAuthRepository } from "../repositories/authRepository";
+import { getTestPrismaClient, resetTestDatabase } from "../testing/testDatabase";
+import { createTestUser } from "../testing/factories";
+import { AuthService } from "./authService";
+
+const prisma = getTestPrismaClient();
+
+if (!process.env.DATABASE_URL_TEST) {
+  describe.skip("AuthService integration tests (DATABASE_URL_TEST not set)", () => {});
+} else {
+  describe("AuthService integration", () => {
+    afterAll(async () => {
+      await prisma!.$disconnect();
+    });
+
+    beforeEach(async () => {
+      await resetTestDatabase(prisma!);
+    });
+
+    it("registers a user and logs in with valid credentials returning a session token", async () => {
+      const repository = createPrismaAuthRepository(prisma!);
+      const service = new AuthService(repository);
+
+      await service.registerLocalUser({
+        displayName: "Integration User",
+        email: "integration@example.com",
+        password: "securepassword"
+      });
+
+      const loggedIn = await service.loginWithCredentials({
+        email: "integration@example.com",
+        password: "securepassword"
+      });
+
+      expect(loggedIn).not.toBeNull();
+      expect(loggedIn!.email).toBe("integration@example.com");
+
+      const { token } = await service.createSessionForUser(loggedIn!.id);
+
+      expect(typeof token).toBe("string");
+      expect(token.length).toBeGreaterThan(0);
+    });
+
+    it("returns null when logging in with a wrong password", async () => {
+      const repository = createPrismaAuthRepository(prisma!);
+      const service = new AuthService(repository);
+
+      await service.registerLocalUser({
+        email: "wrongpass@example.com",
+        password: "correctpassword"
+      });
+
+      const result = await service.loginWithCredentials({
+        email: "wrongpass@example.com",
+        password: "wrongpassword"
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("getCurrentUserForToken returns the correct user for a valid token", async () => {
+      const repository = createPrismaAuthRepository(prisma!);
+      const service = new AuthService(repository);
+
+      await service.registerLocalUser({
+        displayName: "Token User",
+        email: "tokenuser@example.com",
+        password: "tokenpassword"
+      });
+
+      const loggedIn = await service.loginWithCredentials({
+        email: "tokenuser@example.com",
+        password: "tokenpassword"
+      });
+
+      const { token } = await service.createSessionForUser(loggedIn!.id);
+      const resolvedUser = await service.getCurrentUserForToken(token);
+
+      expect(resolvedUser).not.toBeNull();
+      expect(resolvedUser!.id).toBe(loggedIn!.id);
+      expect(resolvedUser!.email).toBe("tokenuser@example.com");
+    });
+
+    it("getCurrentUserForToken returns null for an invalid token", async () => {
+      const repository = createPrismaAuthRepository(prisma!);
+      const service = new AuthService(repository);
+
+      const result = await service.getCurrentUserForToken("completely-invalid-token");
+
+      expect(result).toBeNull();
+    });
+
+    it("getCurrentUserForToken returns null after logout", async () => {
+      const repository = createPrismaAuthRepository(prisma!);
+      const service = new AuthService(repository);
+
+      await createTestUser(prisma!, { email: "logout@example.com", password: "logoutpass" });
+
+      const loggedIn = await service.loginWithCredentials({
+        email: "logout@example.com",
+        password: "logoutpass"
+      });
+
+      const { token } = await service.createSessionForUser(loggedIn!.id);
+
+      await service.logout(token);
+
+      const result = await service.getCurrentUserForToken(token);
+
+      expect(result).toBeNull();
+    });
+  });
+}

--- a/packages/database/src/services/characterService.integration.test.ts
+++ b/packages/database/src/services/characterService.integration.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { createPrismaCharacterRepository } from "../repositories/characterRepository";
+import { getTestPrismaClient, resetTestDatabase } from "../testing/testDatabase";
+import { createTestUser, createTestCharacter } from "../testing/factories";
+import { CharacterService } from "./characterService";
+
+const prisma = getTestPrismaClient();
+
+if (!process.env.DATABASE_URL_TEST) {
+  describe.skip("CharacterService integration tests (DATABASE_URL_TEST not set)", () => {});
+} else {
+  describe("CharacterService integration", () => {
+    afterAll(async () => {
+      await prisma!.$disconnect();
+    });
+
+    beforeEach(async () => {
+      await resetTestDatabase(prisma!);
+    });
+
+    it("creates a character and retrieves it by owner", async () => {
+      const repository = createPrismaCharacterRepository(prisma!);
+      const service = new CharacterService(repository);
+
+      const user = await createTestUser(prisma!, { email: "owner@example.com" });
+      const character = await createTestCharacter(prisma!, user.id, { name: "Brave Warrior" });
+
+      const results = await service.listCharacters(user.id);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(character.id);
+      expect(results[0].name).toBe("Brave Warrior");
+      expect(results[0].ownerId).toBe(user.id);
+    });
+
+    it("does not return another user's character via getOwnedCharacter", async () => {
+      const repository = createPrismaCharacterRepository(prisma!);
+      const service = new CharacterService(repository);
+
+      const owner = await createTestUser(prisma!, { email: "owner@example.com" });
+      const other = await createTestUser(prisma!, { email: "other@example.com" });
+      const character = await createTestCharacter(prisma!, owner.id);
+
+      const result = await service.getOwnedCharacter(other.id, character.id);
+
+      expect(result).toBeNull();
+    });
+
+    it("lists characters filtered by ownerId", async () => {
+      const repository = createPrismaCharacterRepository(prisma!);
+      const service = new CharacterService(repository);
+
+      const userA = await createTestUser(prisma!, { email: "a@example.com" });
+      const userB = await createTestUser(prisma!, { email: "b@example.com" });
+
+      await createTestCharacter(prisma!, userA.id, { name: "Character A" });
+      await createTestCharacter(prisma!, userB.id, { name: "Character B" });
+
+      const forA = await service.listCharacters(userA.id);
+      const forB = await service.listCharacters(userB.id);
+
+      expect(forA).toHaveLength(1);
+      expect(forA[0].name).toBe("Character A");
+      expect(forB).toHaveLength(1);
+      expect(forB[0].name).toBe("Character B");
+    });
+
+    it("getOwnedCharacter returns the character when the ownerId matches", async () => {
+      const repository = createPrismaCharacterRepository(prisma!);
+      const service = new CharacterService(repository);
+
+      const user = await createTestUser(prisma!, { email: "owner2@example.com" });
+      const character = await createTestCharacter(prisma!, user.id, { name: "My Hero" });
+
+      const result = await service.getOwnedCharacter(user.id, character.id);
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(character.id);
+      expect(result!.ownerId).toBe(user.id);
+    });
+  });
+}

--- a/packages/database/src/testing/factories.ts
+++ b/packages/database/src/testing/factories.ts
@@ -1,0 +1,185 @@
+import { randomBytes } from "node:crypto";
+
+import type { PrismaClient } from "@prisma/client";
+
+import { hashPassword } from "../services/authService";
+
+function uniqueEmail(): string {
+  return `test-${randomBytes(6).toString("hex")}@example.com`;
+}
+
+function uniqueSlug(): string {
+  return `test-campaign-${randomBytes(6).toString("hex")}`;
+}
+
+function uniqueId(): string {
+  return randomBytes(8).toString("hex");
+}
+
+export async function createTestUser(
+  prisma: PrismaClient,
+  overrides?: {
+    displayName?: string;
+    email?: string;
+    password?: string;
+    roles?: string[];
+  }
+): Promise<{ id: string; email: string; displayName?: string }> {
+  const email = overrides?.email ?? uniqueEmail();
+  const displayName = overrides?.displayName;
+  const passwordHash = hashPassword(overrides?.password ?? "test-password-123");
+  const roles = overrides?.roles ?? ["player"];
+
+  const roleRecords = await Promise.all(
+    roles.map((name) =>
+      prisma.role.upsert({
+        create: { name },
+        update: {},
+        where: { name }
+      })
+    )
+  );
+
+  const user = await prisma.user.create({
+    data: {
+      displayName,
+      email,
+      passwordHash,
+      roles: {
+        create: roleRecords.map((role) => ({ roleId: role.id }))
+      }
+    },
+    select: {
+      displayName: true,
+      email: true,
+      id: true
+    }
+  });
+
+  return {
+    displayName: user.displayName ?? undefined,
+    email: user.email,
+    id: user.id
+  };
+}
+
+export async function createTestCampaign(
+  prisma: PrismaClient,
+  gmUserId: string,
+  overrides?: {
+    description?: string;
+    name?: string;
+    slug?: string;
+    status?: "draft" | "active" | "archived";
+  }
+): Promise<{ id: string; name: string; gmUserId: string }> {
+  const name = overrides?.name ?? `Test Campaign ${uniqueId()}`;
+  const slug = overrides?.slug ?? uniqueSlug();
+  const description = overrides?.description ?? "";
+  const status = overrides?.status ?? "draft";
+
+  const campaign = await prisma.campaign.create({
+    data: {
+      description,
+      gmUserId,
+      name,
+      settingsJson: {
+        allowPlayerSelfJoin: false,
+        defaultVisibility: "hidden"
+      },
+      slug,
+      status
+    },
+    select: {
+      gmUserId: true,
+      id: true,
+      name: true
+    }
+  });
+
+  return {
+    gmUserId: campaign.gmUserId,
+    id: campaign.id,
+    name: campaign.name
+  };
+}
+
+export async function createTestCharacter(
+  prisma: PrismaClient,
+  ownerId: string,
+  overrides?: {
+    id?: string;
+    level?: number;
+    name?: string;
+  }
+): Promise<{ id: string; name: string; ownerId: string }> {
+  const characterId = overrides?.id ?? uniqueId();
+  const name = overrides?.name ?? `Test Character ${uniqueId()}`;
+  const level = overrides?.level ?? 1;
+
+  const build = {
+    equipment: { items: [] },
+    id: characterId,
+    name,
+    profile: {
+      description: "Test profile",
+      distractionLevel: 3,
+      id: `profile-${characterId}`,
+      label: "Profile",
+      rolledStats: {
+        cha: 10,
+        com: 10,
+        con: 10,
+        dex: 10,
+        health: 10,
+        int: 10,
+        lck: 10,
+        pow: 10,
+        siz: 10,
+        str: 10,
+        will: 10
+      },
+      societyLevel: 0
+    },
+    progression: {
+      chargenMode: "standard",
+      educationPoints: 0,
+      flexiblePointFactor: 1,
+      level,
+      primaryPoolSpent: 0,
+      primaryPoolTotal: 60,
+      secondaryPoolSpent: 0,
+      secondaryPoolTotal: 0,
+      skillGroups: [],
+      skills: [],
+      specializations: []
+    },
+    progressionState: {
+      availablePoints: 0,
+      checks: [],
+      history: [],
+      pendingAttempts: []
+    }
+  };
+
+  const character = await prisma.character.create({
+    data: {
+      build,
+      id: characterId,
+      level,
+      name,
+      ownerId
+    },
+    select: {
+      id: true,
+      name: true,
+      ownerId: true
+    }
+  });
+
+  return {
+    id: character.id,
+    name: character.name,
+    ownerId: character.ownerId!
+  };
+}

--- a/packages/database/src/testing/index.ts
+++ b/packages/database/src/testing/index.ts
@@ -1,0 +1,2 @@
+export * from "./factories";
+export * from "./testDatabase";

--- a/packages/database/src/testing/testDatabase.ts
+++ b/packages/database/src/testing/testDatabase.ts
@@ -1,0 +1,47 @@
+import { PrismaClient } from "@prisma/client";
+
+let testClient: PrismaClient | undefined;
+
+export function getTestPrismaClient(): PrismaClient | null {
+  if (!process.env.DATABASE_URL_TEST) {
+    return null;
+  }
+
+  if (!testClient) {
+    testClient = new PrismaClient({
+      datasources: {
+        db: {
+          url: process.env.DATABASE_URL_TEST
+        }
+      },
+      log: ["warn", "error"]
+    });
+  }
+
+  return testClient;
+}
+
+export async function resetTestDatabase(prisma: PrismaClient): Promise<void> {
+  // Delete in dependency order: leaf tables first, then parent tables.
+  // Each group uses deleteMany({}) which bypasses FK checks within a group
+  // as long as the group ordering respects referencing → referenced direction.
+  await prisma.scenarioEventLog.deleteMany({});
+  await prisma.scenarioParticipant.deleteMany({});
+  await prisma.scenarioRelationship.deleteMany({});
+  await prisma.campaignRosterEntry.deleteMany({});
+  await prisma.characterLoadout.deleteMany({});
+  await prisma.characterEquipmentItem.deleteMany({});
+  await prisma.characterStorageLocation.deleteMany({});
+  await prisma.scenario.deleteMany({});
+  await prisma.campaignAsset.deleteMany({});
+  await prisma.reusableEntity.deleteMany({});
+  await prisma.campaign.deleteMany({});
+  await prisma.character.deleteMany({});
+  await prisma.session.deleteMany({});
+  await prisma.userRole.deleteMany({});
+  await prisma.user.deleteMany({});
+  await prisma.role.deleteMany({});
+  await prisma.weapon.deleteMany({});
+  await prisma.encounter.deleteMany({});
+  await prisma.canonicalContentSnapshot.deleteMany({});
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "./packages/config/vitest.base";


### PR DESCRIPTION
Lukker #62.

## Hva som er lagt til

**`packages/database/src/testing/`**
- `testDatabase.ts` — `getTestPrismaClient()` og `resetTestDatabase()` som truncater alle tabeller i FK-sikker rekkefølge
- `factories.ts` — `createTestUser`, `createTestCampaign`, `createTestCharacter`
- `index.ts` — re-eksporterer alt

**Integrasjonstester**
- `authService.integration.test.ts` — login, feil passord, token-validering, logout
- `characterService.integration.test.ts` — eierskap, isolasjon mellom brukere, listfiltrering

**CI**
- `docker-test`-jobben kjører nå integrasjonstestene med `DATABASE_URL_TEST` etter migrasjoner
- Vanlig `pnpm test` uten `DATABASE_URL_TEST` hopper over integrasjonstestene — unit-tester brytes ikke

## Test plan
- [ ] `docker-test` CI passerer (integrasjonstester grønne mot Postgres-service)
- [ ] Vanlig `ci`-jobb passerer (unit-tester upåvirket)