### PR TITLE
test: golden tests for rules engine og combat

### DIFF
--- a/packages/rules-engine/src/calculators/db/calculateDB.test.ts
+++ b/packages/rules-engine/src/calculators/db/calculateDB.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateDB } from "./calculateDB";
+
+describe("calculateDB", () => {
+  it("returns dex plus shield bonus when no situational modifier is present", () => {
+    expect(calculateDB({ dex: 11, shieldBonus: 0 })).toBe(11);
+    expect(calculateDB({ dex: 11, shieldBonus: 2 })).toBe(13);
+  });
+
+  it("adds the situational modifier on top of dex and shield", () => {
+    expect(calculateDB({ dex: 10, shieldBonus: 3, situationalModifier: 2 })).toBe(15);
+    expect(calculateDB({ dex: 10, shieldBonus: 0, situationalModifier: -2 })).toBe(8);
+  });
+
+  it("treats a missing situational modifier as zero", () => {
+    expect(calculateDB({ dex: 14, shieldBonus: 1 })).toBe(
+      calculateDB({ dex: 14, shieldBonus: 1, situationalModifier: 0 }),
+    );
+  });
+
+  it("matches the basicCombatScenario attacker DB baseline: dex 11, no shield, no modifier", () => {
+    // basicCombatScenario: level-1 combatant with Training Sword (baseOB 25).
+    // No shield and no situational modifier, so DB equals dex directly.
+    expect(calculateDB({ dex: 11, shieldBonus: 0 })).toBe(11);
+  });
+});

--- a/packages/rules-engine/src/calculators/ob/calculateBaseOB.test.ts
+++ b/packages/rules-engine/src/calculators/ob/calculateBaseOB.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateBaseOB } from "./calculateBaseOB";
+
+describe("calculateBaseOB", () => {
+  it("sums skill and weapon bonus with no situational modifier", () => {
+    expect(calculateBaseOB({ skill: 10, weaponBonus: 3 })).toBe(13);
+    expect(calculateBaseOB({ skill: 0, weaponBonus: 0 })).toBe(0);
+  });
+
+  it("adds a positive situational modifier", () => {
+    expect(calculateBaseOB({ skill: 10, weaponBonus: 3, situationalModifier: 2 })).toBe(15);
+  });
+
+  it("subtracts a negative situational modifier", () => {
+    expect(calculateBaseOB({ skill: 10, weaponBonus: 3, situationalModifier: -3 })).toBe(10);
+  });
+
+  it("treats a missing situational modifier as zero", () => {
+    expect(calculateBaseOB({ skill: 7, weaponBonus: 5 })).toBe(
+      calculateBaseOB({ skill: 7, weaponBonus: 5, situationalModifier: 0 }),
+    );
+  });
+
+  it("matches the basicCombatScenario weapon baseline: Training Sword baseOB 25", () => {
+    // basicCombatScenario weapon has baseOB 25.  With skill 0 and weaponBonus 25
+    // and no situational modifier the result must be 25.
+    expect(calculateBaseOB({ skill: 0, weaponBonus: 25 })).toBe(25);
+  });
+});

--- a/packages/rules-engine/src/calculators/parry/calculateParryValue.test.ts
+++ b/packages/rules-engine/src/calculators/parry/calculateParryValue.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateParryValue } from "./calculateParryValue";
+
+describe("calculateParryValue", () => {
+  it("returns allocated OB when no parry modifier is given", () => {
+    expect(calculateParryValue({ allocatedOb: 15 })).toBe(15);
+    expect(calculateParryValue({ allocatedOb: 0 })).toBe(0);
+  });
+
+  it("adds a positive parry modifier to allocated OB", () => {
+    expect(calculateParryValue({ allocatedOb: 10, parryModifier: 5 })).toBe(15);
+  });
+
+  it("subtracts a negative parry modifier from allocated OB", () => {
+    expect(calculateParryValue({ allocatedOb: 10, parryModifier: -3 })).toBe(7);
+  });
+
+  it("treats a missing parry modifier as zero", () => {
+    expect(calculateParryValue({ allocatedOb: 20 })).toBe(
+      calculateParryValue({ allocatedOb: 20, parryModifier: 0 }),
+    );
+  });
+
+  it("produces the composeDefenseValues parry for the basicCombatScenario (allocatedOb 35, no modifier)", () => {
+    // basicCombatScenario: availableOb 35, weaponParryModifier 0.
+    // When the allocation is pending the caller adds availableOb as allocatedOb.
+    expect(calculateParryValue({ allocatedOb: 35, parryModifier: 0 })).toBe(35);
+  });
+});

--- a/packages/rules-engine/src/encounters/resolveEncounterCritical.test.ts
+++ b/packages/rules-engine/src/encounters/resolveEncounterCritical.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "vitest";
+
+import type { EncounterAttackResolution } from "@glantri/domain";
+
+import {
+  determineEncounterCriticalEscalation,
+  resolveEncounterCritical,
+} from "./resolveEncounterCritical";
+
+// ---------------------------------------------------------------------------
+// Minimal fixture factory — constructs only the fields that the critical
+// helpers actually read, leaving the rest as schema-valid defaults.
+// ---------------------------------------------------------------------------
+
+const PROVISIONAL_RULE_LABEL =
+  "REVIEW_FLAG: Critical escalation currently uses a provisional final-damage threshold because no finalized crit trigger rule is modeled yet.";
+
+function makeResolution(
+  overrides: Partial<EncounterAttackResolution>,
+): EncounterAttackResolution {
+  return {
+    id: "res-test-1",
+    encounterId: "encounter-test-1",
+    attackerParticipantId: "attacker-1",
+    defenderParticipantId: "defender-1",
+    order: 0,
+    roundNumber: 1,
+    resolvedAt: new Date().toISOString(),
+    outcome: "hit-pending-damage",
+    declaration: {
+      actionType: "attack",
+      defenseFocus: "none",
+      defensePosture: "none",
+      targetLocation: "any",
+    },
+    attackRoll: {
+      baseOb: 10,
+      defenseTarget: 5,
+      hit: true,
+      margin: 5,
+      roll: 50,
+      total: 60,
+    },
+    defense: {
+      dbApplied: false,
+      dbValue: 0,
+      defending: false,
+      parryAttempted: false,
+      parryBase: 0,
+      parrySucceeded: false,
+    },
+    ...overrides,
+  };
+}
+
+describe("determineEncounterCriticalEscalation", () => {
+  it("does not trigger a critical when finalDamage is below the threshold (12)", () => {
+    const resolution = makeResolution({
+      damage: {
+        armorValue: 0,
+        criticalPending: false,
+        finalDamage: 11,
+        rawDamage: 11,
+        weaponArmorModifier: 0,
+      },
+    });
+
+    const result = determineEncounterCriticalEscalation({ resolution });
+
+    expect(result.criticalPending).toBe(false);
+    expect(result.triggerDamage).toBe(11);
+    expect(result.triggerThreshold).toBe(12);
+  });
+
+  it("triggers a critical exactly at the threshold (12)", () => {
+    const resolution = makeResolution({
+      damage: {
+        armorValue: 0,
+        criticalPending: false,
+        finalDamage: 12,
+        rawDamage: 12,
+        weaponArmorModifier: 0,
+      },
+    });
+
+    const result = determineEncounterCriticalEscalation({ resolution });
+
+    expect(result.criticalPending).toBe(true);
+    expect(result.triggerDamage).toBe(12);
+  });
+
+  it("triggers a critical when finalDamage exceeds the threshold", () => {
+    const resolution = makeResolution({
+      damage: {
+        armorValue: 2,
+        criticalPending: false,
+        finalDamage: 20,
+        rawDamage: 22,
+        weaponArmorModifier: -2,
+      },
+    });
+
+    const result = determineEncounterCriticalEscalation({ resolution });
+
+    expect(result.criticalPending).toBe(true);
+    expect(result.triggerDamage).toBe(20);
+  });
+
+  it("returns 'general' critical type for torso hits", () => {
+    const resolution = makeResolution({
+      hitLocation: { aimedLocation: "torso", resolvedLocation: "torso" },
+      damage: { armorValue: 0, criticalPending: false, finalDamage: 15, rawDamage: 15, weaponArmorModifier: 0 },
+    });
+
+    expect(determineEncounterCriticalEscalation({ resolution }).criticalType).toBe("general");
+  });
+
+  it("returns 'general' critical type for head hits", () => {
+    const resolution = makeResolution({
+      hitLocation: { aimedLocation: "any", resolvedLocation: "head", roll: 5 },
+      damage: { armorValue: 0, criticalPending: false, finalDamage: 15, rawDamage: 15, weaponArmorModifier: 0 },
+    });
+
+    expect(determineEncounterCriticalEscalation({ resolution }).criticalType).toBe("general");
+  });
+
+  it("returns 'limb' critical type for arm hits", () => {
+    const resolution = makeResolution({
+      hitLocation: { aimedLocation: "arm", resolvedLocation: "arm" },
+      damage: { armorValue: 0, criticalPending: false, finalDamage: 15, rawDamage: 15, weaponArmorModifier: 0 },
+    });
+
+    expect(determineEncounterCriticalEscalation({ resolution }).criticalType).toBe("limb");
+  });
+
+  it("returns 'limb' critical type for leg hits", () => {
+    const resolution = makeResolution({
+      hitLocation: { aimedLocation: "leg", resolvedLocation: "leg" },
+      damage: { armorValue: 0, criticalPending: false, finalDamage: 15, rawDamage: 15, weaponArmorModifier: 0 },
+    });
+
+    expect(determineEncounterCriticalEscalation({ resolution }).criticalType).toBe("limb");
+  });
+
+  it("always includes the provisional rule label", () => {
+    const resolution = makeResolution({
+      damage: { armorValue: 0, criticalPending: false, finalDamage: 5, rawDamage: 5, weaponArmorModifier: 0 },
+    });
+
+    expect(
+      determineEncounterCriticalEscalation({ resolution }).provisionalRuleLabel,
+    ).toBe(PROVISIONAL_RULE_LABEL);
+  });
+});
+
+describe("resolveEncounterCritical", () => {
+  function makeCriticalPendingResolution(
+    finalDamage: number,
+    resolvedLocation: EncounterAttackResolution["hitLocation"],
+  ): EncounterAttackResolution {
+    return makeResolution({
+      outcome: "critical-pending",
+      hitLocation: resolvedLocation,
+      damage: {
+        armorValue: 0,
+        criticalPending: true,
+        finalDamage,
+        rawDamage: finalDamage,
+        weaponArmorModifier: 0,
+      },
+      critical: {
+        provisionalRuleLabel: PROVISIONAL_RULE_LABEL,
+        roll: { baseModifier: 0, locationModifier: 0, totalModifier: 0 },
+        status: "pending",
+        triggerDamage: finalDamage,
+        triggerThreshold: 12,
+        type: "general",
+      },
+    });
+  }
+
+  it("rejects a resolution that is not in critical-pending outcome", () => {
+    const resolution = makeResolution({ outcome: "hit" });
+    const result = resolveEncounterCritical({ criticalRoll: 50, resolution });
+
+    expect(result.errors).toContain(
+      "Only critical-pending results can be resolved for critical effects.",
+    );
+    expect(result.resolution).toBeUndefined();
+  });
+
+  it("rejects when critical status is not pending", () => {
+    const resolution = makeResolution({
+      outcome: "critical-pending",
+      critical: {
+        roll: { baseModifier: 0, locationModifier: 0, totalModifier: 0 },
+        status: "resolved",
+        triggerDamage: 15,
+        triggerThreshold: 12,
+      },
+    });
+
+    const result = resolveEncounterCritical({ criticalRoll: 50, resolution });
+
+    expect(result.errors).toContain(
+      "Critical resolution requires a pending critical state.",
+    );
+  });
+
+  it("resolves a torso hit with moderate roll as minor critical", () => {
+    // torso: locationModifier = 5; finalDamage = 12 → baseModifier = 12
+    // totalModifier = 17; roll = 50 → finalRoll = 67 → minor (< 80)
+    const resolution = makeCriticalPendingResolution(
+      12,
+      { aimedLocation: "any", resolvedLocation: "torso" },
+    );
+    const result = resolveEncounterCritical({ criticalRoll: 50, resolution });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.resolution?.outcome).toBe("critical-resolved");
+    expect(result.resolution?.critical?.effect?.severity).toBe("minor");
+    expect(result.resolution?.critical?.roll?.finalRoll).toBe(67);
+  });
+
+  it("resolves a head hit with high roll as major critical", () => {
+    // head: locationModifier = 10; finalDamage = 12 → baseModifier = 12
+    // totalModifier = 22; roll = 60 → finalRoll = 82 → major (≥ 80, < 120)
+    const resolution = makeCriticalPendingResolution(
+      12,
+      { aimedLocation: "any", resolvedLocation: "head", roll: 5 },
+    );
+    const result = resolveEncounterCritical({ criticalRoll: 60, resolution });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.resolution?.critical?.effect?.severity).toBe("major");
+    expect(result.resolution?.critical?.roll?.finalRoll).toBe(82);
+  });
+
+  it("resolves a head hit with very high roll as severe critical", () => {
+    // head: locationModifier = 10; finalDamage = 20 → baseModifier = 20
+    // totalModifier = 30; roll = 95 → finalRoll = 125 → severe (≥ 120)
+    const resolution = makeCriticalPendingResolution(
+      20,
+      { aimedLocation: "head", resolvedLocation: "head" },
+    );
+    const result = resolveEncounterCritical({ criticalRoll: 95, resolution });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.resolution?.critical?.effect?.severity).toBe("severe");
+    expect(result.resolution?.critical?.roll?.finalRoll).toBe(125);
+  });
+
+  it("resolves an arm hit as a limb type critical", () => {
+    const resolution = makeResolution({
+      outcome: "critical-pending",
+      hitLocation: { aimedLocation: "arm", resolvedLocation: "arm" },
+      damage: { armorValue: 0, criticalPending: true, finalDamage: 15, rawDamage: 15, weaponArmorModifier: 0 },
+      critical: {
+        provisionalRuleLabel: PROVISIONAL_RULE_LABEL,
+        roll: { baseModifier: 0, locationModifier: 0, totalModifier: 0 },
+        status: "pending",
+        triggerDamage: 15,
+        triggerThreshold: 12,
+        type: "limb",
+      },
+    });
+
+    const result = resolveEncounterCritical({ criticalRoll: 50, resolution });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.resolution?.critical?.type).toBe("limb");
+    expect(result.resolution?.critical?.effect?.tags).toContain("critical");
+  });
+
+  it("clamps the incoming critical roll to 1–100", () => {
+    const resolution = makeCriticalPendingResolution(
+      12,
+      { aimedLocation: "torso", resolvedLocation: "torso" },
+    );
+
+    // roll 200 → clamped to 100; torso modifier 5; damage 12 → finalRoll = 117 → major (≥ 80)
+    const highResult = resolveEncounterCritical({ criticalRoll: 200, resolution });
+    expect(highResult.resolution?.critical?.roll?.roll).toBe(100);
+
+    // roll 0 → clamped to 1; torso modifier 5; damage 12 → finalRoll = 18 → minor
+    const lowResult = resolveEncounterCritical({ criticalRoll: 0, resolution });
+    expect(lowResult.resolution?.critical?.roll?.roll).toBe(1);
+  });
+});

--- a/packages/rules-engine/src/encounters/resolveEncounterDamage.test.ts
+++ b/packages/rules-engine/src/encounters/resolveEncounterDamage.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+
+import type { CharacterBuild } from "@glantri/domain";
+
+import {
+  applyEncounterWeaponArmorModifier,
+  lookupEncounterArmorAtLocation,
+  resolveEncounterHitLocation,
+} from "./resolveEncounterDamage";
+
+// ---------------------------------------------------------------------------
+// Minimal helpers to construct the narrow slice of CharacterBuild that the
+// encounter damage helpers actually read — only equipment.items is needed.
+// ---------------------------------------------------------------------------
+
+function makeBuild(
+  items: CharacterBuild["equipment"]["items"],
+): Pick<CharacterBuild, "equipment"> {
+  return { equipment: { items } };
+}
+
+describe("resolveEncounterHitLocation", () => {
+  it("returns the aimed location directly when a specific location is declared", () => {
+    expect(
+      resolveEncounterHitLocation({
+        declaredTargetLocation: "head",
+        hitLocationRoll: 50,
+      }),
+    ).toEqual({ aimedLocation: "head", resolvedLocation: "head" });
+
+    expect(
+      resolveEncounterHitLocation({
+        declaredTargetLocation: "torso",
+        hitLocationRoll: 5,
+      }),
+    ).toEqual({ aimedLocation: "torso", resolvedLocation: "torso" });
+  });
+
+  it("maps 'any' declarations to the correct body part based on the roll", () => {
+    // roll 1–10 → head
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 5 }),
+    ).toMatchObject({ aimedLocation: "any", resolvedLocation: "head", roll: 5 });
+
+    // roll 11–50 → torso
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 11 }),
+    ).toMatchObject({ resolvedLocation: "torso" });
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 50 }),
+    ).toMatchObject({ resolvedLocation: "torso" });
+
+    // roll 51–75 → arm
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 51 }),
+    ).toMatchObject({ resolvedLocation: "arm" });
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 75 }),
+    ).toMatchObject({ resolvedLocation: "arm" });
+
+    // roll 76–100 → leg
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 76 }),
+    ).toMatchObject({ resolvedLocation: "leg" });
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 100 }),
+    ).toMatchObject({ resolvedLocation: "leg" });
+  });
+
+  it("clamps out-of-range rolls to 1–100 before mapping", () => {
+    // 0 → clamped to 1 → head
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 0 }),
+    ).toMatchObject({ resolvedLocation: "head", roll: 1 });
+
+    // 200 → clamped to 100 → leg
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 200 }),
+    ).toMatchObject({ resolvedLocation: "leg", roll: 100 });
+  });
+
+  it("does not include a roll field when a specific location is declared", () => {
+    const result = resolveEncounterHitLocation({
+      declaredTargetLocation: "arm",
+      hitLocationRoll: 60,
+    });
+
+    expect(result).not.toHaveProperty("roll");
+  });
+});
+
+describe("lookupEncounterArmorAtLocation", () => {
+  it("returns armorValue 0 with no label when no build is provided", () => {
+    expect(
+      lookupEncounterArmorAtLocation({ resolvedLocation: "torso" }),
+    ).toEqual({ armorValue: 0 });
+  });
+
+  it("returns armorValue 0 when the build has no equipped armor items", () => {
+    const build = makeBuild([
+      {
+        id: "w1",
+        equipped: true,
+        itemType: "weapon",
+        name: "Longsword",
+        armorValue: 0,
+        shieldBonus: 0,
+        weaponBonus: 3,
+        slot: "main-hand",
+      },
+    ]);
+
+    expect(
+      lookupEncounterArmorAtLocation({ build: build as CharacterBuild, resolvedLocation: "torso" }),
+    ).toEqual({ armorValue: 0 });
+  });
+
+  it("returns armorValue 0 when armor items exist but are not equipped", () => {
+    const build = makeBuild([
+      {
+        id: "a1",
+        equipped: false,
+        itemType: "armor",
+        name: "Mail Hauberk",
+        armorLabel: "Mail",
+        armorValue: 4,
+        shieldBonus: 0,
+        weaponBonus: 0,
+        slot: "pack",
+      },
+    ]);
+
+    expect(
+      lookupEncounterArmorAtLocation({ build: build as CharacterBuild, resolvedLocation: "torso" }),
+    ).toEqual({ armorValue: 0 });
+  });
+
+  it("sums armorValue across all equipped armor items and includes a label", () => {
+    const build = makeBuild([
+      {
+        id: "a1",
+        equipped: true,
+        itemType: "armor",
+        name: "Mail Hauberk",
+        armorLabel: "Mail",
+        armorValue: 4,
+        shieldBonus: 0,
+        weaponBonus: 0,
+        slot: "body",
+      },
+      {
+        id: "a2",
+        equipped: true,
+        itemType: "armor",
+        name: "Leather Pauldrons",
+        armorLabel: "Leather",
+        armorValue: 1,
+        shieldBonus: 0,
+        weaponBonus: 0,
+        slot: "body",
+      },
+    ]);
+
+    const result = lookupEncounterArmorAtLocation({
+      build: build as CharacterBuild,
+      resolvedLocation: "torso",
+    });
+
+    expect(result.armorValue).toBe(5);
+    expect(result.armorLabel).toContain("Mail");
+    expect(result.armorLabel).toContain("Leather");
+  });
+
+  it("uses item name as label fallback when armorLabel is absent", () => {
+    const build = makeBuild([
+      {
+        id: "a1",
+        equipped: true,
+        itemType: "armor",
+        name: "Leather Jerkin",
+        armorValue: 2,
+        shieldBonus: 0,
+        weaponBonus: 0,
+        slot: "body",
+      },
+    ]);
+
+    const result = lookupEncounterArmorAtLocation({
+      build: build as CharacterBuild,
+      resolvedLocation: "torso",
+    });
+
+    expect(result.armorValue).toBe(2);
+    expect(result.armorLabel).toContain("Leather Jerkin");
+  });
+});
+
+describe("applyEncounterWeaponArmorModifier", () => {
+  it("returns weapon bonus minus armor value", () => {
+    expect(applyEncounterWeaponArmorModifier({ armorValue: 2, weaponBonus: 5 })).toBe(3);
+    expect(applyEncounterWeaponArmorModifier({ armorValue: 0, weaponBonus: 3 })).toBe(3);
+  });
+
+  it("returns a negative result when armor exceeds weapon bonus", () => {
+    expect(applyEncounterWeaponArmorModifier({ armorValue: 5, weaponBonus: 3 })).toBe(-2);
+  });
+
+  it("returns 0 when both values are 0", () => {
+    expect(applyEncounterWeaponArmorModifier({ armorValue: 0, weaponBonus: 0 })).toBe(0);
+  });
+
+  it("returns the full weapon bonus when armor is 0 (unarmored defender)", () => {
+    expect(applyEncounterWeaponArmorModifier({ armorValue: 0, weaponBonus: 4 })).toBe(4);
+  });
+});

--- a/packages/rules-engine/src/skills/calculateSkills.test.ts
+++ b/packages/rules-engine/src/skills/calculateSkills.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateGms } from "./calculateGms";
+import { calculateGroupLevel } from "./calculateGroupLevel";
+import { calculateSkillLevel } from "./calculateSkillLevel";
+import { calculateSpecializationLevel } from "./calculateSpecializationLevel";
+
+describe("calculateGms", () => {
+  it("returns ranks when no bonuses are present", () => {
+    expect(calculateGms({ ranks: 5 })).toBe(5);
+    expect(calculateGms({ ranks: 0 })).toBe(0);
+  });
+
+  it("adds stat and profession bonuses to ranks", () => {
+    expect(calculateGms({ ranks: 3, statBonus: 2, professionBonus: 1 })).toBe(6);
+  });
+
+  it("treats absent bonuses as zero", () => {
+    expect(calculateGms({ ranks: 4, statBonus: 2 })).toBe(6);
+    expect(calculateGms({ ranks: 4, professionBonus: 3 })).toBe(7);
+  });
+
+  it("handles negative bonuses", () => {
+    expect(calculateGms({ ranks: 5, statBonus: -2 })).toBe(3);
+  });
+});
+
+describe("calculateGroupLevel", () => {
+  it("returns ranks when no gms modifier is given", () => {
+    expect(calculateGroupLevel({ ranks: 7 })).toBe(7);
+    expect(calculateGroupLevel({ ranks: 0 })).toBe(0);
+  });
+
+  it("adds gms to ranks", () => {
+    expect(calculateGroupLevel({ ranks: 4, gms: 3 })).toBe(7);
+  });
+
+  it("handles negative gms", () => {
+    expect(calculateGroupLevel({ ranks: 5, gms: -1 })).toBe(4);
+  });
+
+  it("treats missing gms as zero", () => {
+    expect(calculateGroupLevel({ ranks: 6 })).toBe(
+      calculateGroupLevel({ ranks: 6, gms: 0 }),
+    );
+  });
+});
+
+describe("calculateSkillLevel", () => {
+  it("sums group level, ranks, and gms", () => {
+    expect(calculateSkillLevel({ groupLevel: 3, ranks: 2, gms: 1 })).toBe(6);
+  });
+
+  it("returns group level plus ranks when gms is absent", () => {
+    expect(calculateSkillLevel({ groupLevel: 5, ranks: 2 })).toBe(7);
+  });
+
+  it("handles zero ranks and zero gms", () => {
+    expect(calculateSkillLevel({ groupLevel: 4, ranks: 0, gms: 0 })).toBe(4);
+  });
+
+  it("handles negative gms (penalty)", () => {
+    expect(calculateSkillLevel({ groupLevel: 6, ranks: 3, gms: -2 })).toBe(7);
+  });
+});
+
+describe("calculateSpecializationLevel", () => {
+  it("adds half the group level (floored) to the specialization level", () => {
+    expect(calculateSpecializationLevel({ groupLevel: 6, specializationLevel: 3 })).toBe(6);
+    expect(calculateSpecializationLevel({ groupLevel: 7, specializationLevel: 2 })).toBe(5);
+  });
+
+  it("floors the group level half-contribution correctly", () => {
+    // groupLevel 5 → floor(5/2) = 2
+    expect(calculateSpecializationLevel({ groupLevel: 5, specializationLevel: 0 })).toBe(2);
+    // groupLevel 1 → floor(1/2) = 0
+    expect(calculateSpecializationLevel({ groupLevel: 1, specializationLevel: 4 })).toBe(4);
+  });
+
+  it("returns only specialization level when group level is 0", () => {
+    expect(calculateSpecializationLevel({ groupLevel: 0, specializationLevel: 5 })).toBe(5);
+  });
+
+  it("returns 0 when both inputs are 0", () => {
+    expect(calculateSpecializationLevel({ groupLevel: 0, specializationLevel: 0 })).toBe(0);
+  });
+});

--- a/packages/rules-engine/src/stats/calculateAdjustedStats.test.ts
+++ b/packages/rules-engine/src/stats/calculateAdjustedStats.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateAdjustedStats } from "./calculateAdjustedStats";
+
+describe("calculateAdjustedStats", () => {
+  it("returns a copy of base stats when no modifiers are provided", () => {
+    const base = { str: 12, dex: 10, con: 14 };
+    expect(calculateAdjustedStats({ baseStats: base })).toEqual(base);
+  });
+
+  it("adds modifier values on top of matching base stats", () => {
+    const result = calculateAdjustedStats({
+      baseStats: { str: 10, dex: 11 },
+      modifiers: { str: 2, dex: -1 },
+    });
+
+    expect(result.str).toBe(12);
+    expect(result.dex).toBe(10);
+  });
+
+  it("leaves unmodified stats untouched", () => {
+    const result = calculateAdjustedStats({
+      baseStats: { str: 10, dex: 11, con: 13 },
+      modifiers: { str: 1 },
+    });
+
+    expect(result.dex).toBe(11);
+    expect(result.con).toBe(13);
+  });
+
+  it("treats modifiers for stats absent in base as additions from zero", () => {
+    const result = calculateAdjustedStats({
+      baseStats: { str: 10 },
+      modifiers: { lck: 3 },
+    });
+
+    expect(result.lck).toBe(3);
+    expect(result.str).toBe(10);
+  });
+
+  it("does not mutate the original baseStats object", () => {
+    const base = { str: 10 };
+    calculateAdjustedStats({ baseStats: base, modifiers: { str: 5 } });
+
+    expect(base.str).toBe(10);
+  });
+
+  it("returns an identical object when modifiers is an empty record", () => {
+    const base = { str: 12, dex: 9 };
+    expect(calculateAdjustedStats({ baseStats: base, modifiers: {} })).toEqual(base);
+  });
+});

--- a/packages/rules-engine/src/stats/characteristicGms.test.ts
+++ b/packages/rules-engine/src/stats/characteristicGms.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDexteritySizeModifier,
+  getGlantriStatModifier,
+  getWorkbookCharacterSheetGm,
+} from "./characteristicGms";
+
+describe("getGlantriStatModifier", () => {
+  it("returns the correct modifier for key boundary values", () => {
+    // Stat 1 → −5 (table index 0)
+    expect(getGlantriStatModifier(1)).toBe(-5);
+    // Stat 9 → −1
+    expect(getGlantriStatModifier(9)).toBe(-1);
+    // Stat 10 → 0
+    expect(getGlantriStatModifier(10)).toBe(0);
+    // Stat 11 → 0
+    expect(getGlantriStatModifier(11)).toBe(0);
+    // Stat 12 → 0
+    expect(getGlantriStatModifier(12)).toBe(0);
+    // Stat 17 → +3
+    expect(getGlantriStatModifier(17)).toBe(3);
+    // Stat 25 (last entry) → +7
+    expect(getGlantriStatModifier(25)).toBe(7);
+  });
+
+  it("returns 0 for values outside the table range", () => {
+    expect(getGlantriStatModifier(0)).toBe(0);
+    expect(getGlantriStatModifier(26)).toBe(0);
+  });
+});
+
+describe("getWorkbookCharacterSheetGm", () => {
+  it("returns 0 for stat 11 (the midpoint in the workbook formula)", () => {
+    expect(getWorkbookCharacterSheetGm(11)).toBe(0);
+  });
+
+  it("returns 3 for stat 17", () => {
+    expect(getWorkbookCharacterSheetGm(17)).toBe(3);
+  });
+
+  it("returns -2 for stat 7", () => {
+    expect(getWorkbookCharacterSheetGm(7)).toBe(-2);
+  });
+
+  it("truncates towards zero for even values", () => {
+    // (16 − 11) / 2 = 2.5 → trunc → 2
+    expect(getWorkbookCharacterSheetGm(16)).toBe(2);
+    // (12 − 11) / 2 = 0.5 → trunc → 0
+    expect(getWorkbookCharacterSheetGm(12)).toBe(0);
+  });
+
+  it("covers the basicCombatScenario level-1 strength 11 → gm 0", () => {
+    // basicCombatScenario: attacker level 1. Strength 11 (average) yields GM 0.
+    expect(getWorkbookCharacterSheetGm(11)).toBe(0);
+  });
+});
+
+describe("getDexteritySizeModifier", () => {
+  it("returns 0 for average size (10–14)", () => {
+    expect(getDexteritySizeModifier(10)).toBe(0);
+    expect(getDexteritySizeModifier(14)).toBe(0);
+  });
+
+  it("returns a positive value for small size (< 10)", () => {
+    // siz 8: getGlantriStatModifier(8) = −1, result = −(−1) = 1
+    expect(getDexteritySizeModifier(8)).toBe(1);
+    // siz 5: getGlantriStatModifier(5) = −2, result = −(−2) = 2
+    expect(getDexteritySizeModifier(5)).toBe(2);
+  });
+
+  it("returns a negative value for large size (> 14)", () => {
+    // siz 18: getGlantriStatModifier(18) = 4, result = −(4 − 1) = −3
+    expect(getDexteritySizeModifier(18)).toBe(-3);
+    // siz 20: getGlantriStatModifier(20) = 5, result = −(5 − 1) = −4
+    expect(getDexteritySizeModifier(20)).toBe(-4);
+  });
+});


### PR DESCRIPTION
Lukker #65.

## Hva som er lagt til

8 nye testfiler, 64 tester — alle rene funksjonstester uten mock-avhengigheter:

| Fil | Dekker |
|-----|--------|
| `calculateDB.test.ts` | DB-aritmetikk og combat-scenario baseline |
| `calculateBaseOB.test.ts` | OB-kalkulator inkl. Training Sword baseline |
| `calculateParryValue.test.ts` | Parry-kalkulator og pending-allocation |
| `characteristicGms.test.ts` | Stat-modifikatorer og grenseverdier |
| `calculateAdjustedStats.test.ts` | Modifier-applikasjon og immutabilitet |
| `calculateSkills.test.ts` | Alle fire skill-kalkulatorer inkl. gulvdivisjon |
| `resolveEncounterDamage.test.ts` | Trefflokasjon, rustningsoppslag, modifikatorer |
| `resolveEncounterCritical.test.ts` | Kritiske terskler, alvorlighetsgrader, clamping |

## Test plan
- [ ] `ci`-jobb: `pnpm test` passerer for `@glantri/rules-engine`
- [ ] `docker-test`-jobb: passerer (ingen DB-avhengighet)