### PR TITLE
fix: produksjonsstabilitet, SameSite-cookie og testfundament [skip cd]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Coverage
+        run: pnpm coverage
+
+      - name: Build
+        run: pnpm build
+
   docker-test:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/glantri_test
         run: pnpm --filter @glantri/database exec prisma migrate deploy
 
+      - name: Run integration tests
+        env:
+          DATABASE_URL_TEST: postgresql://postgres:postgres@localhost:5432/glantri_test
+        run: pnpm --filter @glantri/database test
+
       - name: Build API image
         run: docker build -t glantri-api-test -f apps/api/Dockerfile .
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip cd]')"
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -12,7 +12,7 @@ RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @glantri/database exec prisma generate
 RUN pnpm --filter @glantri/api... run build
 RUN pnpm --filter @glantri/api deploy --prod /deploy
-RUN cp -r /build/apps/api/dist /deploy/dist && ls /deploy/dist/apps/api/src/server.js
+RUN cp -r /build/apps/api/dist /deploy/dist && ls /deploy/dist/server.js
 RUN find /build/node_modules -name ".prisma" -type d | while IFS= read -r src; do \
       rel="${src#/build/node_modules/}"; \
       dst="/deploy/node_modules/${rel}"; \
@@ -25,4 +25,4 @@ WORKDIR /app
 COPY --from=builder /deploy ./
 ENV NODE_ENV=production
 EXPOSE 4000
-CMD ["node", "dist/apps/api/src/server.js"]
+CMD ["node", "dist/server.js"]

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildApiServer } from "./app";
+
+describe("api app health contract", () => {
+  it("reports process liveness on /health", async () => {
+    vi.stubEnv("LOG_LEVEL", "silent");
+    const app = buildApiServer();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/health",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      service: "@glantri/api",
+      status: "ok",
+    });
+    vi.unstubAllEnvs();
+  });
+});

--- a/apps/api/src/lib/sessionAuth.test.ts
+++ b/apps/api/src/lib/sessionAuth.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Fastify from "fastify";
+
+import { applyLocalCors } from "./sessionAuth";
+
+describe("session auth HTTP contract", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("allows credentialed CORS preflight for DELETE from the configured web origin", async () => {
+    vi.stubEnv("WEB_ORIGIN", "https://web.example.test");
+    const app = Fastify();
+    applyLocalCors(app);
+
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/health",
+      headers: {
+        "access-control-request-method": "DELETE",
+        origin: "https://web.example.test",
+      },
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(204);
+    expect(response.headers["access-control-allow-origin"]).toBe("https://web.example.test");
+    expect(response.headers["access-control-allow-credentials"]).toBe("true");
+    expect(response.headers["access-control-allow-methods"]).toBe("GET,POST,PUT,DELETE,OPTIONS");
+    expect(response.headers["access-control-allow-headers"]).toBe("content-type");
+    expect(response.headers.vary).toBe("origin");
+  });
+
+  it("does not emit credentialed CORS headers for an unconfigured origin", async () => {
+    vi.stubEnv("WEB_ORIGIN", "https://web.example.test");
+    const app = Fastify();
+    applyLocalCors(app);
+
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/health",
+      headers: {
+        "access-control-request-method": "DELETE",
+        origin: "https://other.example.test",
+      },
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(204);
+    expect(response.headers["access-control-allow-origin"]).toBeUndefined();
+    expect(response.headers["access-control-allow-credentials"]).toBeUndefined();
+  });
+
+  it("uses lax session cookies outside production", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.setSystemTime(new Date("2026-05-09T12:00:00.000Z"));
+    const { buildSessionCookie } = await import("./sessionAuth");
+
+    expect(buildSessionCookie("token value", "2026-05-09T13:00:00.000Z")).toBe(
+      "glantri_session=token%20value; HttpOnly; Path=/; SameSite=Lax; Max-Age=3600",
+    );
+  });
+
+  it("uses secure cross-site session cookies in production", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.setSystemTime(new Date("2026-05-09T12:00:00.000Z"));
+    const { buildSessionCookie } = await import("./sessionAuth");
+
+    expect(buildSessionCookie("token value", "2026-05-09T13:00:00.000Z")).toBe(
+      "glantri_session=token%20value; HttpOnly; Path=/; SameSite=None; Max-Age=3600; Secure",
+    );
+  });
+});

--- a/apps/api/src/routes/scenarios.test.ts
+++ b/apps/api/src/routes/scenarios.test.ts
@@ -1,0 +1,202 @@
+import Fastify from "fastify";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const adminUser = {
+    email: "gm@example.test",
+    id: "gm-1",
+    roles: ["game_master"],
+  };
+  const playerUser = {
+    email: "player@example.test",
+    id: "player-1",
+    roles: ["player"],
+  };
+  const characterService = {};
+  const encounterService = {
+    listEncountersByScenario: vi.fn(),
+  };
+  const scenarioService = {
+    createCampaign: vi.fn(),
+    createScenario: vi.fn(),
+    getCampaignById: vi.fn(),
+    getScenarioById: vi.fn(),
+    listCampaignsByGameMaster: vi.fn(),
+    listScenariosByCampaign: vi.fn(),
+    listScenarioParticipants: vi.fn(),
+    updateScenario: vi.fn(),
+    userHasPlayerScenarioAccess: vi.fn(),
+  };
+  return {
+    adminUser,
+    characterService,
+    encounterService,
+    playerUser,
+    requireAdminUser: vi.fn(),
+    requireAuthenticatedUser: vi.fn(),
+    scenarioService,
+  };
+});
+
+vi.mock("@glantri/database", () => ({
+  CharacterService: vi.fn(() => mocks.characterService),
+  EncounterService: vi.fn(() => mocks.encounterService),
+  ScenarioService: vi.fn(() => mocks.scenarioService),
+}));
+
+vi.mock("../lib/sessionAuth", () => ({
+  requireAdminUser: mocks.requireAdminUser,
+  requireAuthenticatedUser: mocks.requireAuthenticatedUser,
+}));
+
+import { scenariosRoutes } from "./scenarios";
+
+async function buildScenarioTestApp() {
+  const app = Fastify({
+    logger: false,
+  });
+  await app.register(scenariosRoutes);
+  return app;
+}
+
+describe("scenarios route contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAdminUser.mockResolvedValue(mocks.adminUser);
+    mocks.requireAuthenticatedUser.mockResolvedValue(mocks.playerUser);
+  });
+
+  it("lists campaigns for the authenticated game master", async () => {
+    const campaign = {
+      createdAt: "2026-05-09T12:00:00.000Z",
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+      updatedAt: "2026-05-09T12:00:00.000Z",
+    };
+    mocks.scenarioService.listCampaignsByGameMaster.mockResolvedValue([campaign]);
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/campaigns",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      campaigns: [campaign],
+    });
+    expect(mocks.scenarioService.listCampaignsByGameMaster).toHaveBeenCalledWith("gm-1");
+  });
+
+  it("returns a validation error instead of calling the service for invalid campaign creation", async () => {
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "POST",
+      payload: {
+        status: "active",
+      },
+      url: "/campaigns",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({
+      error: "name is required.",
+    });
+    expect(mocks.scenarioService.createCampaign).not.toHaveBeenCalled();
+  });
+
+  it("creates a scenario under a campaign owned by the game master", async () => {
+    const campaign = {
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    };
+    const scenario = {
+      campaignId: "campaign-1",
+      id: "scenario-1",
+      kind: "combat",
+      name: "Bridge Ambush",
+      status: "prepared",
+    };
+    mocks.scenarioService.getCampaignById.mockResolvedValue(campaign);
+    mocks.scenarioService.createScenario.mockResolvedValue(scenario);
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "POST",
+      payload: {
+        kind: "combat",
+        name: "Bridge Ambush",
+        status: "prepared",
+      },
+      url: "/campaigns/campaign-1/scenarios",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      scenario,
+    });
+    expect(mocks.scenarioService.createScenario).toHaveBeenCalledWith({
+      campaignId: "campaign-1",
+      continuesFromScenarioId: undefined,
+      description: undefined,
+      kind: "combat",
+      mapAssetId: undefined,
+      name: "Bridge Ambush",
+      status: "prepared",
+    });
+  });
+
+  it("lists encounters for a player with scenario workspace access", async () => {
+    const scenario = {
+      campaignId: "campaign-1",
+      id: "scenario-1",
+      kind: "combat",
+      name: "Bridge Ambush",
+      status: "live",
+    };
+    const campaign = {
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    };
+    const encounter = {
+      id: "encounter-1",
+      name: "Courtyard",
+      scenarioId: "scenario-1",
+    };
+    mocks.scenarioService.getScenarioById.mockResolvedValue(scenario);
+    mocks.scenarioService.getCampaignById.mockResolvedValue(campaign);
+    mocks.scenarioService.userHasPlayerScenarioAccess.mockResolvedValue(true);
+    mocks.encounterService.listEncountersByScenario.mockResolvedValue([encounter]);
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/scenarios/scenario-1/encounters",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      encounters: [encounter],
+    });
+    expect(mocks.scenarioService.userHasPlayerScenarioAccess).toHaveBeenCalledWith({
+      scenarioId: "scenario-1",
+      userId: "player-1",
+    });
+    expect(mocks.encounterService.listEncountersByScenario).toHaveBeenCalledWith("scenario-1");
+  });
+});

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,9 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "noEmit": false,
     "outDir": "dist",
     "rootDir": "src",
     "paths": {}
-  }
+  },
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
 }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,8 +1,11 @@
 import path from "node:path";
 import type { NextConfig } from "next";
 
+const outputMode =
+  process.env.NEXT_OUTPUT_MODE ?? (process.platform === "win32" ? undefined : "standalone");
+
 const nextConfig: NextConfig = {
-  output: "standalone",
+  ...(outputMode ? { output: outputMode as NextConfig["output"] } : {}),
   outputFileTracingRoot: path.join(__dirname, "../.."),
   transpilePackages: [
     "@glantri/auth",

--- a/apps/web/src/lib/api/localServiceClient.test.ts
+++ b/apps/web/src/lib/api/localServiceClient.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type LocalServiceClientModule = typeof import("./localServiceClient");
+type FetchMock = ReturnType<typeof vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>>;
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      "content-type": "application/json",
+    },
+    status,
+  });
+}
+
+function stubFetch(payload: unknown, status = 200): FetchMock {
+  const fetchMock = vi
+    .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+    .mockResolvedValue(jsonResponse(payload, status));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+async function loadClient(baseUrl = "https://api.example.test"): Promise<LocalServiceClientModule> {
+  vi.resetModules();
+  vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", baseUrl);
+  return import("./localServiceClient");
+}
+
+function expectFetchCall(
+  fetchMock: FetchMock,
+  expected: {
+    body?: unknown;
+    method?: string;
+    url: string;
+  },
+): void {
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchMock.mock.calls[0];
+  expect(String(url)).toBe(expected.url);
+  expect(init?.credentials).toBe("include");
+
+  if (expected.method) {
+    expect(init?.method).toBe(expected.method);
+  }
+
+  if (expected.body !== undefined) {
+    expect(init?.headers).toMatchObject({
+      "content-type": "application/json",
+    });
+    expect(init?.body).toBe(JSON.stringify(expected.body));
+  }
+}
+
+describe("localServiceClient wire contract", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("uses the configured API base URL for auth session lookup", async () => {
+    const fetchMock = stubFetch({
+      user: {
+        email: "player@example.test",
+        id: "user-1",
+        roles: ["player"],
+      },
+    });
+    const client = await loadClient("https://api.example.test");
+
+    await expect(client.getCurrentSessionUser()).resolves.toMatchObject({
+      id: "user-1",
+    });
+
+    expectFetchCall(fetchMock, {
+      url: "https://api.example.test/auth/me",
+    });
+  });
+
+  it("posts auth credentials as JSON and returns the user payload", async () => {
+    const fetchMock = stubFetch({
+      user: {
+        email: "gm@example.test",
+        id: "user-gm",
+        roles: ["game_master"],
+      },
+    });
+    const client = await loadClient();
+
+    await expect(
+      client.loginLocalUser({
+        email: "gm@example.test",
+        password: "secret",
+      }),
+    ).resolves.toMatchObject({
+      id: "user-gm",
+    });
+
+    expectFetchCall(fetchMock, {
+      body: {
+        email: "gm@example.test",
+        password: "secret",
+      },
+      method: "POST",
+      url: "https://api.example.test/auth/login",
+    });
+  });
+
+  it("posts character builds under the characters domain", async () => {
+    const character = {
+      build: {
+        name: "Ada",
+      },
+      createdAt: "2026-05-09T12:00:00.000Z",
+      id: "character-1",
+      level: 1,
+      name: "Ada",
+      updatedAt: "2026-05-09T12:00:00.000Z",
+    };
+    const fetchMock = stubFetch({ character });
+    const client = await loadClient();
+    const build = character.build as unknown as Parameters<
+      LocalServiceClientModule["saveCharacterToServer"]
+    >[0];
+
+    await expect(client.saveCharacterToServer(build)).resolves.toEqual(character);
+
+    expectFetchCall(fetchMock, {
+      body: {
+        build,
+      },
+      method: "POST",
+      url: "https://api.example.test/characters",
+    });
+  });
+
+  it("posts campaign creation under the campaign domain", async () => {
+    const campaign = {
+      createdAt: "2026-05-09T12:00:00.000Z",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+      updatedAt: "2026-05-09T12:00:00.000Z",
+    };
+    const fetchMock = stubFetch({ campaign });
+    const client = await loadClient();
+
+    await expect(
+      client.createCampaignOnServer({
+        description: "Frontier campaign",
+        name: "Border Trouble",
+      }),
+    ).resolves.toEqual(campaign);
+
+    expectFetchCall(fetchMock, {
+      body: {
+        description: "Frontier campaign",
+        name: "Border Trouble",
+      },
+      method: "POST",
+      url: "https://api.example.test/campaigns",
+    });
+  });
+
+  it("puts scenario updates under the scenario domain", async () => {
+    const scenario = {
+      campaignId: "campaign-1",
+      createdAt: "2026-05-09T12:00:00.000Z",
+      id: "scenario-1",
+      kind: "combat",
+      name: "Bridge Ambush",
+      status: "draft",
+      updatedAt: "2026-05-09T12:00:00.000Z",
+    };
+    const fetchMock = stubFetch({ scenario });
+    const client = await loadClient();
+
+    await expect(
+      client.updateScenarioOnServer({
+        name: "Bridge Ambush",
+        scenarioId: "scenario-1",
+        status: "live",
+      }),
+    ).resolves.toEqual(scenario);
+
+    expectFetchCall(fetchMock, {
+      body: {
+        description: undefined,
+        kind: undefined,
+        mapAssetId: undefined,
+        name: "Bridge Ambush",
+        status: "live",
+      },
+      method: "PUT",
+      url: "https://api.example.test/scenarios/scenario-1",
+    });
+  });
+
+  it("loads encounters from the encounter domain", async () => {
+    const encounter = {
+      id: "encounter-1",
+      name: "Courtyard",
+      scenarioId: "scenario-1",
+    };
+    const fetchMock = stubFetch({ encounter });
+    const client = await loadClient();
+
+    await expect(client.loadEncounterById("encounter-1")).resolves.toEqual(encounter);
+
+    expectFetchCall(fetchMock, {
+      method: "GET",
+      url: "https://api.example.test/encounters/encounter-1",
+    });
+  });
+
+  it("posts equipment moves under the character equipment domain", async () => {
+    const state = {
+      inventory: [],
+    };
+    const fetchMock = stubFetch({ state });
+    const client = await loadClient();
+
+    await expect(
+      client.moveCharacterEquipmentItemOnServer({
+        carryMode: "backpack",
+        characterId: "character-1",
+        itemId: "item-1",
+        locationId: "location-1",
+      }),
+    ).resolves.toEqual(state);
+
+    expectFetchCall(fetchMock, {
+      body: {
+        carryMode: "backpack",
+        itemId: "item-1",
+        locationId: "location-1",
+      },
+      method: "POST",
+      url: "https://api.example.test/characters/character-1/equipment/move",
+    });
+  });
+
+  it("puts admin content through the admin content endpoint", async () => {
+    const saved = {
+      content: {
+        skills: [],
+      },
+      savedAt: "2026-05-09T12:00:00.000Z",
+    };
+    const input = {
+      content: {
+        skills: [],
+      },
+      expectedVersion: "version-1",
+    } as unknown as Parameters<LocalServiceClientModule["saveAdminCanonicalContentToServer"]>[0];
+    const fetchMock = stubFetch(saved);
+    const client = await loadClient();
+
+    await expect(client.saveAdminCanonicalContentToServer(input)).resolves.toEqual(saved);
+
+    expectFetchCall(fetchMock, {
+      body: input,
+      method: "PUT",
+      url: "https://api.example.test/api/admin/content",
+    });
+  });
+
+  it("maps API error payloads into ApiRequestError", async () => {
+    const fetchMock = stubFetch(
+      {
+        error: "Invalid request.",
+        issues: ["Name is required."],
+      },
+      400,
+    );
+    const client = await loadClient();
+
+    await expect(client.loadCampaignById("missing")).rejects.toMatchObject({
+      message: "Invalid request. Name is required.",
+      payload: {
+        error: "Invalid request.",
+        issues: ["Name is required."],
+      },
+      status: 400,
+    });
+
+    expectFetchCall(fetchMock, {
+      method: "GET",
+      url: "https://api.example.test/campaigns/missing",
+    });
+  });
+});

--- a/docs/testing-regression-matrix.md
+++ b/docs/testing-regression-matrix.md
@@ -1,0 +1,70 @@
+# Testing And Refactor Safety
+
+This document is the pre-refactor safety map for the Glantri monorepo. It tracks
+which product workflows are protected by automated tests, where manual smoke
+checks are still needed, and which areas should get characterization tests before
+large structural changes.
+
+## Pre-Refactor Verification
+
+Run these commands before and after broad refactors:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+Use this command when you need a coverage snapshot:
+
+```bash
+pnpm coverage
+```
+
+Coverage is intentionally report-only for now. The first goal is to make weak
+spots visible without blocking useful cleanup because of old test debt.
+
+## Refactor-Critical Areas
+
+Treat these paths as high-value coverage targets:
+
+- `packages/rules-engine/src/**`
+- `packages/domain/src/**`
+- `packages/content/src/**`
+- `packages/database/src/services/**`
+- `packages/database/src/repositories/**`
+- `apps/api/src/lib/**`
+- `apps/api/src/routes/**`
+- `apps/web/src/lib/**`
+- `apps/web/src/features/**`
+- `apps/web/app/(app)/**`
+
+## Functional Regression Matrix
+
+| Workflow | Primary role | Main modules | Current automated coverage | Remaining gap | Refactor risk |
+| --- | --- | --- | --- | --- | --- |
+| Auth/session | Player, GM, admin | `packages/auth`, `apps/api/src/lib/sessionAuth.ts`, `apps/web/src/lib/auth` | `packages/auth/src/session.test.ts`, `apps/api/src/lib/sessionAuth.test.ts`, `apps/web/src/lib/auth/authBootstrap.test.ts` | Browser-level login/logout smoke test | Moderate |
+| API health/runtime | System | `apps/api/src/app.ts`, deploy workflows | `apps/api/src/app.test.ts`, Docker smoke in CI | `/ready` with DB check is not implemented yet | Moderate |
+| CORS/cookie contract | Browser, API | `apps/api/src/lib/sessionAuth.ts` | `apps/api/src/lib/sessionAuth.test.ts` | Same-origin proxy strategy is not covered until chosen | Moderate |
+| Chargen rules | Player | `packages/rules-engine/src/chargen`, `packages/domain/src/character` | `primaryAllocation.test.ts`, `selectionStructure.test.ts`, `statResolution.test.ts`, `importedContentIntegration.test.ts` | UI-level component tests for real user interaction | High |
+| Chargen UI/helpers | Player | `apps/web/app/(app)/chargen/ChargenWizard.tsx`, `apps/web/src/lib/chargen` | `ChargenWizard.test.ts`, `chargenBrowse.test.ts` | Rendered React interaction tests | High |
+| Character browser/sheet/edit | Player, GM | `apps/web/src/lib/characters`, `packages/database/src/services/characterService.ts` | `characterBrowser.test.ts`, `characterSheet.test.ts`, `characterEdit.test.ts`, `characterService.test.ts` | E2E route smoke for browser rendering | Moderate |
+| Character advancement | Player | `packages/rules-engine/src/advancement`, `apps/web/src/lib/characters` | `advanceCharacter.test.ts`, `loadLocalCharacterAdvancementContext.test.ts` | UI smoke test for advancement workflow | High |
+| Equipment/loadout/combat stats | Player, GM | `apps/web/src/features/equipment`, `packages/database/src/services/characterEquipment*`, `packages/content/src/equipment` | Equipment selector/loadout/movement/combat panel tests, importer/content tests, database equipment write test | Service read-model integration breadth | High |
+| Combat calculations | Player, GM | `packages/rules-engine/src/combat`, `apps/web/src/features/equipment` | `workbookCombatMath.test.ts`, `combatVerification.test.ts`, `composeDefenseValues.test.ts`, `combatStateDerivation.test.ts` | More spreadsheet-backed golden rows for varied loadouts | High |
+| Campaign workspace | GM, player | `apps/web/src/lib/campaigns`, `apps/web/app/(app)/campaigns`, `apps/api/src/routes/scenarios.ts` | Campaign workspace/detail tests, `scenarios.test.ts`, service tests | Browser smoke with seeded campaign | High |
+| Scenario/encounter API | GM, player | `apps/api/src/routes/scenarios.ts`, `packages/database/src/services/scenarioService.ts` | `apps/api/src/routes/scenarios.test.ts`, `packages/database/src/services/scenarioService.test.ts` | More endpoint coverage before splitting every route group | High |
+| Encounter/roleplay screens | GM, player | `apps/web/app/(app)/encounters`, `packages/domain/src/encounter` | `EncounterDetail.test.ts`, `RoleplayEncounterScreens.test.ts`, `roleplay.test.ts` | Browser smoke for active encounter | Moderate |
+| Admin content/rules docs/players | Admin, GM | `apps/web/app/(app)/admin`, `apps/web/src/lib/admin`, `apps/api/src/routes/adminContent.ts` | `admin-ui.test.ts`, `PlayersAdminPage.test.ts`, `MarkdownRenderer.test.ts`, `viewModels.test.ts` | API route characterization for admin content save conflicts | Moderate |
+| Web API client | Browser | `apps/web/src/lib/api/localServiceClient.ts` | `apps/web/src/lib/api/localServiceClient.test.ts` | More methods can be added as domains are split | High |
+
+## Test Policy For Large Refactors
+
+- Add characterization tests before moving code when behavior is not obvious.
+- Prefer service/helper tests for logic and a few browser/e2e smoke tests for
+  wiring.
+- Keep spreadsheet-derived tests tied to exact workbook/sheet/cell references.
+- Do not use coverage percentage alone as a quality signal; use this matrix to
+  decide whether the touched workflow has the right kind of coverage.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "turbo typecheck --force",
     "lint": "turbo lint --force",
     "test": "turbo test --force",
+    "coverage": "vitest run --coverage --passWithNoTests",
     "db:up": "docker compose up -d postgres",
     "db:down": "docker compose down",
     "db:migrate": "pnpm --filter @glantri/database db:migrate",
@@ -22,16 +23,17 @@
     "db:reset:local": "pnpm --filter @glantri/database db:reset:local"
   },
   "devDependencies": {
-    "@next/eslint-plugin-next": "^15.2.4",
     "@eslint/js": "^9.39.1",
+    "@next/eslint-plugin-next": "^15.2.4",
     "@types/node": "^22.14.0",
+    "@vitest/coverage-v8": "2.1.9",
     "eslint": "^9.39.4",
     "globals": "^15.15.0",
     "prettier": "^3.8.1",
     "tsx": "^4.19.0",
     "turbo": "^2.8.15",
-    "typescript-eslint": "^8.46.3",
     "typescript": "^5.9.3",
+    "typescript-eslint": "^8.46.3",
     "vitest": "^2.1.0"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -11,7 +11,7 @@
     "./vitest": "./vitest.base.ts"
   },
   "scripts": {
-    "build": "mkdir -p dist && cp eslint.base.cjs prettier.base.cjs vitest.base.ts tsconfig.package.json dist/",
+    "build": "node -e \"const fs=require('fs'); fs.rmSync('dist',{recursive:true,force:true}); fs.mkdirSync('dist',{recursive:true}); for (const file of ['eslint.base.cjs','prettier.base.cjs','vitest.base.ts','tsconfig.package.json']) fs.copyFileSync(file, 'dist/'+file);\"",
     "typecheck": "tsc -p tsconfig.package.json --noEmit",
     "lint": "eslint .",
     "test": "vitest run --passWithNoTests"

--- a/packages/config/vitest.base.ts
+++ b/packages/config/vitest.base.ts
@@ -1,7 +1,94 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vitest/config";
 
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@glantri\/auth$/,
+        replacement: path.join(repoRoot, "packages/auth/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/auth\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/auth/src/$1"),
+      },
+      {
+        find: /^@glantri\/content$/,
+        replacement: path.join(repoRoot, "packages/content/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/content\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/content/src/$1"),
+      },
+      {
+        find: /^@glantri\/database$/,
+        replacement: path.join(repoRoot, "packages/database/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/database\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/database/src/$1"),
+      },
+      {
+        find: /^@glantri\/domain$/,
+        replacement: path.join(repoRoot, "packages/domain/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/domain\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/domain/src/$1"),
+      },
+      {
+        find: /^@glantri\/rules-engine$/,
+        replacement: path.join(repoRoot, "packages/rules-engine/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/rules-engine\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/rules-engine/src/$1"),
+      },
+      {
+        find: /^@glantri\/schemas\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/schemas/src/$1"),
+      },
+      {
+        find: /^@glantri\/shared$/,
+        replacement: path.join(repoRoot, "packages/shared/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/shared\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/shared/src/$1"),
+      },
+      {
+        find: /^@glantri\/test-scenarios$/,
+        replacement: path.join(repoRoot, "packages/test-scenarios/src/index.ts"),
+      },
+      {
+        find: /^@glantri\/test-scenarios\/(.*)$/,
+        replacement: path.join(repoRoot, "packages/test-scenarios/src/$1"),
+      },
+    ],
+  },
   test: {
+    coverage: {
+      exclude: [
+        "**/.next/**",
+        "**/coverage/**",
+        "**/dist/**",
+        "**/node_modules/**",
+        "**/*.config.*",
+        "**/*.d.ts",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "data/**",
+        "packages/content/src/equipment/armorTemplates.ts",
+        "packages/content/src/equipment/importedWeaponTemplates.ts",
+        "packages/content/src/equipment/shieldTemplates.ts",
+      ],
+      provider: "v8",
+      reporter: ["text", "json-summary", "html"],
+    },
     globals: true,
     environment: "node"
   }

--- a/packages/database/src/repositories/authRepository.ts
+++ b/packages/database/src/repositories/authRepository.ts
@@ -1,6 +1,7 @@
 import type { AuthRole, AuthSession, AuthUser } from "@glantri/auth";
+import type { PrismaClient } from "@prisma/client";
 
-import { prisma } from "../client";
+import { prisma as defaultPrisma } from "../client";
 
 export interface CreateUserInput {
   displayName?: string;
@@ -51,7 +52,9 @@ function mapRoles(roles: Array<{ role: { name: string } }>): AuthRole[] {
     .filter((role): role is AuthRole => role !== null);
 }
 
-export function createPrismaAuthRepository(): AuthRepository {
+export function createPrismaAuthRepository(client?: PrismaClient): AuthRepository {
+  const prisma = client ?? defaultPrisma;
+
   return {
     async anyPrivilegedUserExists() {
       const privilegedUserCount = await prisma.user.count({

--- a/packages/database/src/repositories/characterRepository.ts
+++ b/packages/database/src/repositories/characterRepository.ts
@@ -1,6 +1,7 @@
 import { characterBuildSchema, type CharacterBuild } from "@glantri/domain";
+import type { PrismaClient } from "@prisma/client";
 
-import { prisma } from "../client";
+import { prisma as defaultPrisma } from "../client";
 
 export interface CharacterRecord {
   build: CharacterBuild;
@@ -67,7 +68,9 @@ function mapCharacterRecord(character: {
   };
 }
 
-export function createPrismaCharacterRepository(): CharacterRepository {
+export function createPrismaCharacterRepository(client?: PrismaClient): CharacterRepository {
+  const prisma = client ?? defaultPrisma;
+
   return {
     async findById(id) {
       const character = await prisma.character.findUnique({

--- a/packages/database/src/services/authService.integration.test.ts
+++ b/packages/database/src/services/authService.integration.test.ts
@@ -1,0 +1,115 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { createPrismaAuthRepository } from "../repositories/authRepository";
+import { getTestPrismaClient, resetTestDatabase } from "../testing/testDatabase";
+import { createTestUser } from "../testing/factories";
+import { AuthService } from "./authService";
+
+const prisma = getTestPrismaClient();
+
+if (!process.env.DATABASE_URL_TEST) {
+  describe.skip("AuthService integration tests (DATABASE_URL_TEST not set)", () => {});
+} else {
+  describe("AuthService integration", () => {
+    afterAll(async () => {
+      await prisma!.$disconnect();
+    });
+
+    beforeEach(async () => {
+      await resetTestDatabase(prisma!);
+    });
+
+    it("registers a user and logs in with valid credentials returning a session token", async () => {
+      const repository = createPrismaAuthRepository(prisma!);
+      const service = new AuthService(repository);
+
+      await service.registerLocalUser({
+        displayName: "Integration User",
+        email: "integration@example.com",
+        password: "securepassword"
+      });
+
+      const loggedIn = await service.loginWithCredentials({
+        email: "integration@example.com",
+        password: "securepassword"
+      });
+
+      expect(loggedIn).not.toBeNull();
+      expect(loggedIn!.email).toBe("integration@example.com");
+
+      const { token } = await service.createSessionForUser(loggedIn!.id);
+
+      expect(typeof token).toBe("string");
+      expect(token.length).toBeGreaterThan(0);
+    });
+
+    it("returns null when logging in with a wrong password", async () => {
+      const repository = createPrismaAuthRepository(prisma!);
+      const service = new AuthService(repository);
+
+      await service.registerLocalUser({
+        email: "wrongpass@example.com",
+        password: "correctpassword"
+      });
+
+      const result = await service.loginWithCredentials({
+        email: "wrongpass@example.com",
+        password: "wrongpassword"
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("getCurrentUserForToken returns the correct user for a valid token", async () => {
+      const repository = createPrismaAuthRepository(prisma!);
+      const service = new AuthService(repository);
+
+      await service.registerLocalUser({
+        displayName: "Token User",
+        email: "tokenuser@example.com",
+        password: "tokenpassword"
+      });
+
+      const loggedIn = await service.loginWithCredentials({
+        email: "tokenuser@example.com",
+        password: "tokenpassword"
+      });
+
+      const { token } = await service.createSessionForUser(loggedIn!.id);
+      const resolvedUser = await service.getCurrentUserForToken(token);
+
+      expect(resolvedUser).not.toBeNull();
+      expect(resolvedUser!.id).toBe(loggedIn!.id);
+      expect(resolvedUser!.email).toBe("tokenuser@example.com");
+    });
+
+    it("getCurrentUserForToken returns null for an invalid token", async () => {
+      const repository = createPrismaAuthRepository(prisma!);
+      const service = new AuthService(repository);
+
+      const result = await service.getCurrentUserForToken("completely-invalid-token");
+
+      expect(result).toBeNull();
+    });
+
+    it("getCurrentUserForToken returns null after logout", async () => {
+      const repository = createPrismaAuthRepository(prisma!);
+      const service = new AuthService(repository);
+
+      await createTestUser(prisma!, { email: "logout@example.com", password: "logoutpass" });
+
+      const loggedIn = await service.loginWithCredentials({
+        email: "logout@example.com",
+        password: "logoutpass"
+      });
+
+      const { token } = await service.createSessionForUser(loggedIn!.id);
+
+      await service.logout(token);
+
+      const result = await service.getCurrentUserForToken(token);
+
+      expect(result).toBeNull();
+    });
+  });
+}

--- a/packages/database/src/services/characterService.integration.test.ts
+++ b/packages/database/src/services/characterService.integration.test.ts
@@ -1,0 +1,83 @@
+import { afterAll, beforeEach, describe, expect, it } from "vitest";
+
+import { createPrismaCharacterRepository } from "../repositories/characterRepository";
+import { getTestPrismaClient, resetTestDatabase } from "../testing/testDatabase";
+import { createTestUser, createTestCharacter } from "../testing/factories";
+import { CharacterService } from "./characterService";
+
+const prisma = getTestPrismaClient();
+
+if (!process.env.DATABASE_URL_TEST) {
+  describe.skip("CharacterService integration tests (DATABASE_URL_TEST not set)", () => {});
+} else {
+  describe("CharacterService integration", () => {
+    afterAll(async () => {
+      await prisma!.$disconnect();
+    });
+
+    beforeEach(async () => {
+      await resetTestDatabase(prisma!);
+    });
+
+    it("creates a character and retrieves it by owner", async () => {
+      const repository = createPrismaCharacterRepository(prisma!);
+      const service = new CharacterService(repository);
+
+      const user = await createTestUser(prisma!, { email: "owner@example.com" });
+      const character = await createTestCharacter(prisma!, user.id, { name: "Brave Warrior" });
+
+      const results = await service.listCharacters(user.id);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(character.id);
+      expect(results[0].name).toBe("Brave Warrior");
+      expect(results[0].ownerId).toBe(user.id);
+    });
+
+    it("does not return another user's character via getOwnedCharacter", async () => {
+      const repository = createPrismaCharacterRepository(prisma!);
+      const service = new CharacterService(repository);
+
+      const owner = await createTestUser(prisma!, { email: "owner@example.com" });
+      const other = await createTestUser(prisma!, { email: "other@example.com" });
+      const character = await createTestCharacter(prisma!, owner.id);
+
+      const result = await service.getOwnedCharacter(other.id, character.id);
+
+      expect(result).toBeNull();
+    });
+
+    it("lists characters filtered by ownerId", async () => {
+      const repository = createPrismaCharacterRepository(prisma!);
+      const service = new CharacterService(repository);
+
+      const userA = await createTestUser(prisma!, { email: "a@example.com" });
+      const userB = await createTestUser(prisma!, { email: "b@example.com" });
+
+      await createTestCharacter(prisma!, userA.id, { name: "Character A" });
+      await createTestCharacter(prisma!, userB.id, { name: "Character B" });
+
+      const forA = await service.listCharacters(userA.id);
+      const forB = await service.listCharacters(userB.id);
+
+      expect(forA).toHaveLength(1);
+      expect(forA[0].name).toBe("Character A");
+      expect(forB).toHaveLength(1);
+      expect(forB[0].name).toBe("Character B");
+    });
+
+    it("getOwnedCharacter returns the character when the ownerId matches", async () => {
+      const repository = createPrismaCharacterRepository(prisma!);
+      const service = new CharacterService(repository);
+
+      const user = await createTestUser(prisma!, { email: "owner2@example.com" });
+      const character = await createTestCharacter(prisma!, user.id, { name: "My Hero" });
+
+      const result = await service.getOwnedCharacter(user.id, character.id);
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(character.id);
+      expect(result!.ownerId).toBe(user.id);
+    });
+  });
+}

--- a/packages/database/src/testing/factories.ts
+++ b/packages/database/src/testing/factories.ts
@@ -1,0 +1,185 @@
+import { randomBytes } from "node:crypto";
+
+import type { PrismaClient } from "@prisma/client";
+
+import { hashPassword } from "../services/authService";
+
+function uniqueEmail(): string {
+  return `test-${randomBytes(6).toString("hex")}@example.com`;
+}
+
+function uniqueSlug(): string {
+  return `test-campaign-${randomBytes(6).toString("hex")}`;
+}
+
+function uniqueId(): string {
+  return randomBytes(8).toString("hex");
+}
+
+export async function createTestUser(
+  prisma: PrismaClient,
+  overrides?: {
+    displayName?: string;
+    email?: string;
+    password?: string;
+    roles?: string[];
+  }
+): Promise<{ id: string; email: string; displayName?: string }> {
+  const email = overrides?.email ?? uniqueEmail();
+  const displayName = overrides?.displayName;
+  const passwordHash = hashPassword(overrides?.password ?? "test-password-123");
+  const roles = overrides?.roles ?? ["player"];
+
+  const roleRecords = await Promise.all(
+    roles.map((name) =>
+      prisma.role.upsert({
+        create: { name },
+        update: {},
+        where: { name }
+      })
+    )
+  );
+
+  const user = await prisma.user.create({
+    data: {
+      displayName,
+      email,
+      passwordHash,
+      roles: {
+        create: roleRecords.map((role) => ({ roleId: role.id }))
+      }
+    },
+    select: {
+      displayName: true,
+      email: true,
+      id: true
+    }
+  });
+
+  return {
+    displayName: user.displayName ?? undefined,
+    email: user.email,
+    id: user.id
+  };
+}
+
+export async function createTestCampaign(
+  prisma: PrismaClient,
+  gmUserId: string,
+  overrides?: {
+    description?: string;
+    name?: string;
+    slug?: string;
+    status?: "draft" | "active" | "archived";
+  }
+): Promise<{ id: string; name: string; gmUserId: string }> {
+  const name = overrides?.name ?? `Test Campaign ${uniqueId()}`;
+  const slug = overrides?.slug ?? uniqueSlug();
+  const description = overrides?.description ?? "";
+  const status = overrides?.status ?? "draft";
+
+  const campaign = await prisma.campaign.create({
+    data: {
+      description,
+      gmUserId,
+      name,
+      settingsJson: {
+        allowPlayerSelfJoin: false,
+        defaultVisibility: "hidden"
+      },
+      slug,
+      status
+    },
+    select: {
+      gmUserId: true,
+      id: true,
+      name: true
+    }
+  });
+
+  return {
+    gmUserId: campaign.gmUserId,
+    id: campaign.id,
+    name: campaign.name
+  };
+}
+
+export async function createTestCharacter(
+  prisma: PrismaClient,
+  ownerId: string,
+  overrides?: {
+    id?: string;
+    level?: number;
+    name?: string;
+  }
+): Promise<{ id: string; name: string; ownerId: string }> {
+  const characterId = overrides?.id ?? uniqueId();
+  const name = overrides?.name ?? `Test Character ${uniqueId()}`;
+  const level = overrides?.level ?? 1;
+
+  const build = {
+    equipment: { items: [] },
+    id: characterId,
+    name,
+    profile: {
+      description: "Test profile",
+      distractionLevel: 3,
+      id: `profile-${characterId}`,
+      label: "Profile",
+      rolledStats: {
+        cha: 10,
+        com: 10,
+        con: 10,
+        dex: 10,
+        health: 10,
+        int: 10,
+        lck: 10,
+        pow: 10,
+        siz: 10,
+        str: 10,
+        will: 10
+      },
+      societyLevel: 0
+    },
+    progression: {
+      chargenMode: "standard",
+      educationPoints: 0,
+      flexiblePointFactor: 1,
+      level,
+      primaryPoolSpent: 0,
+      primaryPoolTotal: 60,
+      secondaryPoolSpent: 0,
+      secondaryPoolTotal: 0,
+      skillGroups: [],
+      skills: [],
+      specializations: []
+    },
+    progressionState: {
+      availablePoints: 0,
+      checks: [],
+      history: [],
+      pendingAttempts: []
+    }
+  };
+
+  const character = await prisma.character.create({
+    data: {
+      build,
+      id: characterId,
+      level,
+      name,
+      ownerId
+    },
+    select: {
+      id: true,
+      name: true,
+      ownerId: true
+    }
+  });
+
+  return {
+    id: character.id,
+    name: character.name,
+    ownerId: character.ownerId!
+  };
+}

--- a/packages/database/src/testing/index.ts
+++ b/packages/database/src/testing/index.ts
@@ -1,0 +1,2 @@
+export * from "./factories";
+export * from "./testDatabase";

--- a/packages/database/src/testing/testDatabase.ts
+++ b/packages/database/src/testing/testDatabase.ts
@@ -1,0 +1,47 @@
+import { PrismaClient } from "@prisma/client";
+
+let testClient: PrismaClient | undefined;
+
+export function getTestPrismaClient(): PrismaClient | null {
+  if (!process.env.DATABASE_URL_TEST) {
+    return null;
+  }
+
+  if (!testClient) {
+    testClient = new PrismaClient({
+      datasources: {
+        db: {
+          url: process.env.DATABASE_URL_TEST
+        }
+      },
+      log: ["warn", "error"]
+    });
+  }
+
+  return testClient;
+}
+
+export async function resetTestDatabase(prisma: PrismaClient): Promise<void> {
+  // Delete in dependency order: leaf tables first, then parent tables.
+  // Each group uses deleteMany({}) which bypasses FK checks within a group
+  // as long as the group ordering respects referencing → referenced direction.
+  await prisma.scenarioEventLog.deleteMany({});
+  await prisma.scenarioParticipant.deleteMany({});
+  await prisma.scenarioRelationship.deleteMany({});
+  await prisma.campaignRosterEntry.deleteMany({});
+  await prisma.characterLoadout.deleteMany({});
+  await prisma.characterEquipmentItem.deleteMany({});
+  await prisma.characterStorageLocation.deleteMany({});
+  await prisma.scenario.deleteMany({});
+  await prisma.campaignAsset.deleteMany({});
+  await prisma.reusableEntity.deleteMany({});
+  await prisma.campaign.deleteMany({});
+  await prisma.character.deleteMany({});
+  await prisma.session.deleteMany({});
+  await prisma.userRole.deleteMany({});
+  await prisma.user.deleteMany({});
+  await prisma.role.deleteMany({});
+  await prisma.weapon.deleteMany({});
+  await prisma.encounter.deleteMany({});
+  await prisma.canonicalContentSnapshot.deleteMany({});
+}

--- a/packages/importers/src/themistogenes/importArmor.ts
+++ b/packages/importers/src/themistogenes/importArmor.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 
 import type {
@@ -9,6 +8,7 @@ import type {
   ImportedArmorSourceMetadata,
   MaterialType,
 } from "@glantri/domain/equipment";
+import { readZipEntryUtf8 } from "./readZipEntryUtf8";
 
 const THEMISTOGENES_WORKBOOK_PATH = path.resolve(
   __dirname,
@@ -61,12 +61,6 @@ export interface ImportedArmorReport {
 export interface ImportedArmorResult {
   report: ImportedArmorReport;
   templates: ArmorTemplate[];
-}
-
-function readZipEntryUtf8(workbookPath: string, entryPath: string): string {
-  return execFileSync("unzip", ["-p", workbookPath, entryPath], {
-    encoding: "utf8",
-  });
 }
 
 function decodeXmlText(value: string): string {

--- a/packages/importers/src/themistogenes/importShields.ts
+++ b/packages/importers/src/themistogenes/importShields.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 
 import type {
@@ -6,6 +5,7 @@ import type {
   ShieldTemplate,
   WeaponAttackMode,
 } from "@glantri/domain/equipment";
+import { readZipEntryUtf8 } from "./readZipEntryUtf8";
 
 const THEMISTOGENES_WORKBOOK_PATH = path.resolve(
   __dirname,
@@ -69,12 +69,6 @@ export interface ImportedShieldsReport {
 export interface ImportedShieldsResult {
   report: ImportedShieldsReport;
   templates: ShieldTemplate[];
-}
-
-function readZipEntryUtf8(workbookPath: string, entryPath: string): string {
-  return execFileSync("unzip", ["-p", workbookPath, entryPath], {
-    encoding: "utf8",
-  });
 }
 
 function decodeXmlText(value: string): string {

--- a/packages/importers/src/themistogenes/importWeapons.ts
+++ b/packages/importers/src/themistogenes/importWeapons.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import * as path from "node:path";
 
 import {
@@ -12,6 +11,7 @@ import type {
   WeaponHandlingClass,
   WeaponTemplate,
 } from "@glantri/domain/equipment";
+import { readZipEntryUtf8 } from "./readZipEntryUtf8";
 
 const THEMISTOGENES_WORKBOOK_PATH = path.resolve(
   __dirname,
@@ -173,12 +173,6 @@ function mergeThrownWeaponTemplates(templates: WeaponTemplate[]): WeaponTemplate
         ],
       },
     ];
-  });
-}
-
-function readZipEntryUtf8(workbookPath: string, entryPath: string): string {
-  return execFileSync("unzip", ["-p", workbookPath, entryPath], {
-    encoding: "utf8",
   });
 }
 

--- a/packages/importers/src/themistogenes/readZipEntryUtf8.ts
+++ b/packages/importers/src/themistogenes/readZipEntryUtf8.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { inflateRawSync } from "node:zlib";
+
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE = 0x02014b50;
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const MAX_ZIP_COMMENT_LENGTH = 0xffff;
+
+interface ZipEntryMetadata {
+  compressedSize: number;
+  compressionMethod: number;
+  localHeaderOffset: number;
+}
+
+function findEndOfCentralDirectory(buffer: Buffer): number {
+  const minimumOffset = Math.max(0, buffer.length - MAX_ZIP_COMMENT_LENGTH - 22);
+
+  for (let offset = buffer.length - 22; offset >= minimumOffset; offset -= 1) {
+    if (buffer.readUInt32LE(offset) === END_OF_CENTRAL_DIRECTORY_SIGNATURE) {
+      return offset;
+    }
+  }
+
+  throw new Error("Could not find ZIP end of central directory record.");
+}
+
+function findZipEntry(buffer: Buffer, entryPath: string): ZipEntryMetadata {
+  const endOfCentralDirectoryOffset = findEndOfCentralDirectory(buffer);
+  const entryCount = buffer.readUInt16LE(endOfCentralDirectoryOffset + 10);
+  let centralDirectoryOffset = buffer.readUInt32LE(endOfCentralDirectoryOffset + 16);
+  const normalizedEntryPath = entryPath.replace(/\\/g, "/");
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (buffer.readUInt32LE(centralDirectoryOffset) !== CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE) {
+      throw new Error("Invalid ZIP central directory file header.");
+    }
+
+    const compressionMethod = buffer.readUInt16LE(centralDirectoryOffset + 10);
+    const compressedSize = buffer.readUInt32LE(centralDirectoryOffset + 20);
+    const fileNameLength = buffer.readUInt16LE(centralDirectoryOffset + 28);
+    const extraFieldLength = buffer.readUInt16LE(centralDirectoryOffset + 30);
+    const fileCommentLength = buffer.readUInt16LE(centralDirectoryOffset + 32);
+    const localHeaderOffset = buffer.readUInt32LE(centralDirectoryOffset + 42);
+    const fileNameStart = centralDirectoryOffset + 46;
+    const fileName = buffer.toString("utf8", fileNameStart, fileNameStart + fileNameLength);
+
+    if (fileName === normalizedEntryPath) {
+      return {
+        compressedSize,
+        compressionMethod,
+        localHeaderOffset,
+      };
+    }
+
+    centralDirectoryOffset =
+      fileNameStart + fileNameLength + extraFieldLength + fileCommentLength;
+  }
+
+  throw new Error(`Could not find ZIP entry '${entryPath}'.`);
+}
+
+export function readZipEntryUtf8(workbookPath: string, entryPath: string): string {
+  const buffer = readFileSync(workbookPath);
+  const entry = findZipEntry(buffer, entryPath);
+
+  if (buffer.readUInt32LE(entry.localHeaderOffset) !== LOCAL_FILE_HEADER_SIGNATURE) {
+    throw new Error(`Invalid ZIP local file header for '${entryPath}'.`);
+  }
+
+  const fileNameLength = buffer.readUInt16LE(entry.localHeaderOffset + 26);
+  const extraFieldLength = buffer.readUInt16LE(entry.localHeaderOffset + 28);
+  const dataStart = entry.localHeaderOffset + 30 + fileNameLength + extraFieldLength;
+  const compressedData = buffer.subarray(dataStart, dataStart + entry.compressedSize);
+
+  if (entry.compressionMethod === 0) {
+    return compressedData.toString("utf8");
+  }
+
+  if (entry.compressionMethod === 8) {
+    return inflateRawSync(compressedData).toString("utf8");
+  }
+
+  throw new Error(
+    `Unsupported ZIP compression method ${entry.compressionMethod} for '${entryPath}'.`,
+  );
+}

--- a/packages/rules-engine/src/calculators/db/calculateDB.test.ts
+++ b/packages/rules-engine/src/calculators/db/calculateDB.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateDB } from "./calculateDB";
+
+describe("calculateDB", () => {
+  it("returns dex plus shield bonus when no situational modifier is present", () => {
+    expect(calculateDB({ dex: 11, shieldBonus: 0 })).toBe(11);
+    expect(calculateDB({ dex: 11, shieldBonus: 2 })).toBe(13);
+  });
+
+  it("adds the situational modifier on top of dex and shield", () => {
+    expect(calculateDB({ dex: 10, shieldBonus: 3, situationalModifier: 2 })).toBe(15);
+    expect(calculateDB({ dex: 10, shieldBonus: 0, situationalModifier: -2 })).toBe(8);
+  });
+
+  it("treats a missing situational modifier as zero", () => {
+    expect(calculateDB({ dex: 14, shieldBonus: 1 })).toBe(
+      calculateDB({ dex: 14, shieldBonus: 1, situationalModifier: 0 }),
+    );
+  });
+
+  it("matches the basicCombatScenario attacker DB baseline: dex 11, no shield, no modifier", () => {
+    // basicCombatScenario: level-1 combatant with Training Sword (baseOB 25).
+    // No shield and no situational modifier, so DB equals dex directly.
+    expect(calculateDB({ dex: 11, shieldBonus: 0 })).toBe(11);
+  });
+});

--- a/packages/rules-engine/src/calculators/ob/calculateBaseOB.test.ts
+++ b/packages/rules-engine/src/calculators/ob/calculateBaseOB.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateBaseOB } from "./calculateBaseOB";
+
+describe("calculateBaseOB", () => {
+  it("sums skill and weapon bonus with no situational modifier", () => {
+    expect(calculateBaseOB({ skill: 10, weaponBonus: 3 })).toBe(13);
+    expect(calculateBaseOB({ skill: 0, weaponBonus: 0 })).toBe(0);
+  });
+
+  it("adds a positive situational modifier", () => {
+    expect(calculateBaseOB({ skill: 10, weaponBonus: 3, situationalModifier: 2 })).toBe(15);
+  });
+
+  it("subtracts a negative situational modifier", () => {
+    expect(calculateBaseOB({ skill: 10, weaponBonus: 3, situationalModifier: -3 })).toBe(10);
+  });
+
+  it("treats a missing situational modifier as zero", () => {
+    expect(calculateBaseOB({ skill: 7, weaponBonus: 5 })).toBe(
+      calculateBaseOB({ skill: 7, weaponBonus: 5, situationalModifier: 0 }),
+    );
+  });
+
+  it("matches the basicCombatScenario weapon baseline: Training Sword baseOB 25", () => {
+    // basicCombatScenario weapon has baseOB 25.  With skill 0 and weaponBonus 25
+    // and no situational modifier the result must be 25.
+    expect(calculateBaseOB({ skill: 0, weaponBonus: 25 })).toBe(25);
+  });
+});

--- a/packages/rules-engine/src/calculators/parry/calculateParryValue.test.ts
+++ b/packages/rules-engine/src/calculators/parry/calculateParryValue.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateParryValue } from "./calculateParryValue";
+
+describe("calculateParryValue", () => {
+  it("returns allocated OB when no parry modifier is given", () => {
+    expect(calculateParryValue({ allocatedOb: 15 })).toBe(15);
+    expect(calculateParryValue({ allocatedOb: 0 })).toBe(0);
+  });
+
+  it("adds a positive parry modifier to allocated OB", () => {
+    expect(calculateParryValue({ allocatedOb: 10, parryModifier: 5 })).toBe(15);
+  });
+
+  it("subtracts a negative parry modifier from allocated OB", () => {
+    expect(calculateParryValue({ allocatedOb: 10, parryModifier: -3 })).toBe(7);
+  });
+
+  it("treats a missing parry modifier as zero", () => {
+    expect(calculateParryValue({ allocatedOb: 20 })).toBe(
+      calculateParryValue({ allocatedOb: 20, parryModifier: 0 }),
+    );
+  });
+
+  it("produces the composeDefenseValues parry for the basicCombatScenario (allocatedOb 35, no modifier)", () => {
+    // basicCombatScenario: availableOb 35, weaponParryModifier 0.
+    // When the allocation is pending the caller adds availableOb as allocatedOb.
+    expect(calculateParryValue({ allocatedOb: 35, parryModifier: 0 })).toBe(35);
+  });
+});

--- a/packages/rules-engine/src/encounters/resolveEncounterCritical.test.ts
+++ b/packages/rules-engine/src/encounters/resolveEncounterCritical.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "vitest";
+
+import type { EncounterAttackResolution } from "@glantri/domain";
+
+import {
+  determineEncounterCriticalEscalation,
+  resolveEncounterCritical,
+} from "./resolveEncounterCritical";
+
+// ---------------------------------------------------------------------------
+// Minimal fixture factory — constructs only the fields that the critical
+// helpers actually read, leaving the rest as schema-valid defaults.
+// ---------------------------------------------------------------------------
+
+const PROVISIONAL_RULE_LABEL =
+  "REVIEW_FLAG: Critical escalation currently uses a provisional final-damage threshold because no finalized crit trigger rule is modeled yet.";
+
+function makeResolution(
+  overrides: Partial<EncounterAttackResolution>,
+): EncounterAttackResolution {
+  return {
+    id: "res-test-1",
+    encounterId: "encounter-test-1",
+    attackerParticipantId: "attacker-1",
+    defenderParticipantId: "defender-1",
+    order: 0,
+    roundNumber: 1,
+    resolvedAt: new Date().toISOString(),
+    outcome: "hit-pending-damage",
+    declaration: {
+      actionType: "attack",
+      defenseFocus: "none",
+      defensePosture: "none",
+      targetLocation: "any",
+    },
+    attackRoll: {
+      baseOb: 10,
+      defenseTarget: 5,
+      hit: true,
+      margin: 5,
+      roll: 50,
+      total: 60,
+    },
+    defense: {
+      dbApplied: false,
+      dbValue: 0,
+      defending: false,
+      parryAttempted: false,
+      parryBase: 0,
+      parrySucceeded: false,
+    },
+    ...overrides,
+  };
+}
+
+describe("determineEncounterCriticalEscalation", () => {
+  it("does not trigger a critical when finalDamage is below the threshold (12)", () => {
+    const resolution = makeResolution({
+      damage: {
+        armorValue: 0,
+        criticalPending: false,
+        finalDamage: 11,
+        rawDamage: 11,
+        weaponArmorModifier: 0,
+      },
+    });
+
+    const result = determineEncounterCriticalEscalation({ resolution });
+
+    expect(result.criticalPending).toBe(false);
+    expect(result.triggerDamage).toBe(11);
+    expect(result.triggerThreshold).toBe(12);
+  });
+
+  it("triggers a critical exactly at the threshold (12)", () => {
+    const resolution = makeResolution({
+      damage: {
+        armorValue: 0,
+        criticalPending: false,
+        finalDamage: 12,
+        rawDamage: 12,
+        weaponArmorModifier: 0,
+      },
+    });
+
+    const result = determineEncounterCriticalEscalation({ resolution });
+
+    expect(result.criticalPending).toBe(true);
+    expect(result.triggerDamage).toBe(12);
+  });
+
+  it("triggers a critical when finalDamage exceeds the threshold", () => {
+    const resolution = makeResolution({
+      damage: {
+        armorValue: 2,
+        criticalPending: false,
+        finalDamage: 20,
+        rawDamage: 22,
+        weaponArmorModifier: -2,
+      },
+    });
+
+    const result = determineEncounterCriticalEscalation({ resolution });
+
+    expect(result.criticalPending).toBe(true);
+    expect(result.triggerDamage).toBe(20);
+  });
+
+  it("returns 'general' critical type for torso hits", () => {
+    const resolution = makeResolution({
+      hitLocation: { aimedLocation: "torso", resolvedLocation: "torso" },
+      damage: { armorValue: 0, criticalPending: false, finalDamage: 15, rawDamage: 15, weaponArmorModifier: 0 },
+    });
+
+    expect(determineEncounterCriticalEscalation({ resolution }).criticalType).toBe("general");
+  });
+
+  it("returns 'general' critical type for head hits", () => {
+    const resolution = makeResolution({
+      hitLocation: { aimedLocation: "any", resolvedLocation: "head", roll: 5 },
+      damage: { armorValue: 0, criticalPending: false, finalDamage: 15, rawDamage: 15, weaponArmorModifier: 0 },
+    });
+
+    expect(determineEncounterCriticalEscalation({ resolution }).criticalType).toBe("general");
+  });
+
+  it("returns 'limb' critical type for arm hits", () => {
+    const resolution = makeResolution({
+      hitLocation: { aimedLocation: "arm", resolvedLocation: "arm" },
+      damage: { armorValue: 0, criticalPending: false, finalDamage: 15, rawDamage: 15, weaponArmorModifier: 0 },
+    });
+
+    expect(determineEncounterCriticalEscalation({ resolution }).criticalType).toBe("limb");
+  });
+
+  it("returns 'limb' critical type for leg hits", () => {
+    const resolution = makeResolution({
+      hitLocation: { aimedLocation: "leg", resolvedLocation: "leg" },
+      damage: { armorValue: 0, criticalPending: false, finalDamage: 15, rawDamage: 15, weaponArmorModifier: 0 },
+    });
+
+    expect(determineEncounterCriticalEscalation({ resolution }).criticalType).toBe("limb");
+  });
+
+  it("always includes the provisional rule label", () => {
+    const resolution = makeResolution({
+      damage: { armorValue: 0, criticalPending: false, finalDamage: 5, rawDamage: 5, weaponArmorModifier: 0 },
+    });
+
+    expect(
+      determineEncounterCriticalEscalation({ resolution }).provisionalRuleLabel,
+    ).toBe(PROVISIONAL_RULE_LABEL);
+  });
+});
+
+describe("resolveEncounterCritical", () => {
+  function makeCriticalPendingResolution(
+    finalDamage: number,
+    resolvedLocation: EncounterAttackResolution["hitLocation"],
+  ): EncounterAttackResolution {
+    return makeResolution({
+      outcome: "critical-pending",
+      hitLocation: resolvedLocation,
+      damage: {
+        armorValue: 0,
+        criticalPending: true,
+        finalDamage,
+        rawDamage: finalDamage,
+        weaponArmorModifier: 0,
+      },
+      critical: {
+        provisionalRuleLabel: PROVISIONAL_RULE_LABEL,
+        roll: { baseModifier: 0, locationModifier: 0, totalModifier: 0 },
+        status: "pending",
+        triggerDamage: finalDamage,
+        triggerThreshold: 12,
+        type: "general",
+      },
+    });
+  }
+
+  it("rejects a resolution that is not in critical-pending outcome", () => {
+    const resolution = makeResolution({ outcome: "hit" });
+    const result = resolveEncounterCritical({ criticalRoll: 50, resolution });
+
+    expect(result.errors).toContain(
+      "Only critical-pending results can be resolved for critical effects.",
+    );
+    expect(result.resolution).toBeUndefined();
+  });
+
+  it("rejects when critical status is not pending", () => {
+    const resolution = makeResolution({
+      outcome: "critical-pending",
+      critical: {
+        roll: { baseModifier: 0, locationModifier: 0, totalModifier: 0 },
+        status: "resolved",
+        triggerDamage: 15,
+        triggerThreshold: 12,
+      },
+    });
+
+    const result = resolveEncounterCritical({ criticalRoll: 50, resolution });
+
+    expect(result.errors).toContain(
+      "Critical resolution requires a pending critical state.",
+    );
+  });
+
+  it("resolves a torso hit with moderate roll as minor critical", () => {
+    // torso: locationModifier = 5; finalDamage = 12 → baseModifier = 12
+    // totalModifier = 17; roll = 50 → finalRoll = 67 → minor (< 80)
+    const resolution = makeCriticalPendingResolution(
+      12,
+      { aimedLocation: "any", resolvedLocation: "torso" },
+    );
+    const result = resolveEncounterCritical({ criticalRoll: 50, resolution });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.resolution?.outcome).toBe("critical-resolved");
+    expect(result.resolution?.critical?.effect?.severity).toBe("minor");
+    expect(result.resolution?.critical?.roll?.finalRoll).toBe(67);
+  });
+
+  it("resolves a head hit with high roll as major critical", () => {
+    // head: locationModifier = 10; finalDamage = 12 → baseModifier = 12
+    // totalModifier = 22; roll = 60 → finalRoll = 82 → major (≥ 80, < 120)
+    const resolution = makeCriticalPendingResolution(
+      12,
+      { aimedLocation: "any", resolvedLocation: "head", roll: 5 },
+    );
+    const result = resolveEncounterCritical({ criticalRoll: 60, resolution });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.resolution?.critical?.effect?.severity).toBe("major");
+    expect(result.resolution?.critical?.roll?.finalRoll).toBe(82);
+  });
+
+  it("resolves a head hit with very high roll as severe critical", () => {
+    // head: locationModifier = 10; finalDamage = 20 → baseModifier = 20
+    // totalModifier = 30; roll = 95 → finalRoll = 125 → severe (≥ 120)
+    const resolution = makeCriticalPendingResolution(
+      20,
+      { aimedLocation: "head", resolvedLocation: "head" },
+    );
+    const result = resolveEncounterCritical({ criticalRoll: 95, resolution });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.resolution?.critical?.effect?.severity).toBe("severe");
+    expect(result.resolution?.critical?.roll?.finalRoll).toBe(125);
+  });
+
+  it("resolves an arm hit as a limb type critical", () => {
+    const resolution = makeResolution({
+      outcome: "critical-pending",
+      hitLocation: { aimedLocation: "arm", resolvedLocation: "arm" },
+      damage: { armorValue: 0, criticalPending: true, finalDamage: 15, rawDamage: 15, weaponArmorModifier: 0 },
+      critical: {
+        provisionalRuleLabel: PROVISIONAL_RULE_LABEL,
+        roll: { baseModifier: 0, locationModifier: 0, totalModifier: 0 },
+        status: "pending",
+        triggerDamage: 15,
+        triggerThreshold: 12,
+        type: "limb",
+      },
+    });
+
+    const result = resolveEncounterCritical({ criticalRoll: 50, resolution });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.resolution?.critical?.type).toBe("limb");
+    expect(result.resolution?.critical?.effect?.tags).toContain("critical");
+  });
+
+  it("clamps the incoming critical roll to 1–100", () => {
+    const resolution = makeCriticalPendingResolution(
+      12,
+      { aimedLocation: "torso", resolvedLocation: "torso" },
+    );
+
+    // roll 200 → clamped to 100; torso modifier 5; damage 12 → finalRoll = 117 → major (≥ 80)
+    const highResult = resolveEncounterCritical({ criticalRoll: 200, resolution });
+    expect(highResult.resolution?.critical?.roll?.roll).toBe(100);
+
+    // roll 0 → clamped to 1; torso modifier 5; damage 12 → finalRoll = 18 → minor
+    const lowResult = resolveEncounterCritical({ criticalRoll: 0, resolution });
+    expect(lowResult.resolution?.critical?.roll?.roll).toBe(1);
+  });
+});

--- a/packages/rules-engine/src/encounters/resolveEncounterDamage.test.ts
+++ b/packages/rules-engine/src/encounters/resolveEncounterDamage.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+
+import type { CharacterBuild } from "@glantri/domain";
+
+import {
+  applyEncounterWeaponArmorModifier,
+  lookupEncounterArmorAtLocation,
+  resolveEncounterHitLocation,
+} from "./resolveEncounterDamage";
+
+// ---------------------------------------------------------------------------
+// Minimal helpers to construct the narrow slice of CharacterBuild that the
+// encounter damage helpers actually read — only equipment.items is needed.
+// ---------------------------------------------------------------------------
+
+function makeBuild(
+  items: CharacterBuild["equipment"]["items"],
+): Pick<CharacterBuild, "equipment"> {
+  return { equipment: { items } };
+}
+
+describe("resolveEncounterHitLocation", () => {
+  it("returns the aimed location directly when a specific location is declared", () => {
+    expect(
+      resolveEncounterHitLocation({
+        declaredTargetLocation: "head",
+        hitLocationRoll: 50,
+      }),
+    ).toEqual({ aimedLocation: "head", resolvedLocation: "head" });
+
+    expect(
+      resolveEncounterHitLocation({
+        declaredTargetLocation: "torso",
+        hitLocationRoll: 5,
+      }),
+    ).toEqual({ aimedLocation: "torso", resolvedLocation: "torso" });
+  });
+
+  it("maps 'any' declarations to the correct body part based on the roll", () => {
+    // roll 1–10 → head
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 5 }),
+    ).toMatchObject({ aimedLocation: "any", resolvedLocation: "head", roll: 5 });
+
+    // roll 11–50 → torso
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 11 }),
+    ).toMatchObject({ resolvedLocation: "torso" });
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 50 }),
+    ).toMatchObject({ resolvedLocation: "torso" });
+
+    // roll 51–75 → arm
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 51 }),
+    ).toMatchObject({ resolvedLocation: "arm" });
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 75 }),
+    ).toMatchObject({ resolvedLocation: "arm" });
+
+    // roll 76–100 → leg
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 76 }),
+    ).toMatchObject({ resolvedLocation: "leg" });
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 100 }),
+    ).toMatchObject({ resolvedLocation: "leg" });
+  });
+
+  it("clamps out-of-range rolls to 1–100 before mapping", () => {
+    // 0 → clamped to 1 → head
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 0 }),
+    ).toMatchObject({ resolvedLocation: "head", roll: 1 });
+
+    // 200 → clamped to 100 → leg
+    expect(
+      resolveEncounterHitLocation({ declaredTargetLocation: "any", hitLocationRoll: 200 }),
+    ).toMatchObject({ resolvedLocation: "leg", roll: 100 });
+  });
+
+  it("does not include a roll field when a specific location is declared", () => {
+    const result = resolveEncounterHitLocation({
+      declaredTargetLocation: "arm",
+      hitLocationRoll: 60,
+    });
+
+    expect(result).not.toHaveProperty("roll");
+  });
+});
+
+describe("lookupEncounterArmorAtLocation", () => {
+  it("returns armorValue 0 with no label when no build is provided", () => {
+    expect(
+      lookupEncounterArmorAtLocation({ resolvedLocation: "torso" }),
+    ).toEqual({ armorValue: 0 });
+  });
+
+  it("returns armorValue 0 when the build has no equipped armor items", () => {
+    const build = makeBuild([
+      {
+        id: "w1",
+        equipped: true,
+        itemType: "weapon",
+        name: "Longsword",
+        armorValue: 0,
+        shieldBonus: 0,
+        weaponBonus: 3,
+        slot: "main-hand",
+      },
+    ]);
+
+    expect(
+      lookupEncounterArmorAtLocation({ build: build as CharacterBuild, resolvedLocation: "torso" }),
+    ).toEqual({ armorValue: 0 });
+  });
+
+  it("returns armorValue 0 when armor items exist but are not equipped", () => {
+    const build = makeBuild([
+      {
+        id: "a1",
+        equipped: false,
+        itemType: "armor",
+        name: "Mail Hauberk",
+        armorLabel: "Mail",
+        armorValue: 4,
+        shieldBonus: 0,
+        weaponBonus: 0,
+        slot: "pack",
+      },
+    ]);
+
+    expect(
+      lookupEncounterArmorAtLocation({ build: build as CharacterBuild, resolvedLocation: "torso" }),
+    ).toEqual({ armorValue: 0 });
+  });
+
+  it("sums armorValue across all equipped armor items and includes a label", () => {
+    const build = makeBuild([
+      {
+        id: "a1",
+        equipped: true,
+        itemType: "armor",
+        name: "Mail Hauberk",
+        armorLabel: "Mail",
+        armorValue: 4,
+        shieldBonus: 0,
+        weaponBonus: 0,
+        slot: "body",
+      },
+      {
+        id: "a2",
+        equipped: true,
+        itemType: "armor",
+        name: "Leather Pauldrons",
+        armorLabel: "Leather",
+        armorValue: 1,
+        shieldBonus: 0,
+        weaponBonus: 0,
+        slot: "body",
+      },
+    ]);
+
+    const result = lookupEncounterArmorAtLocation({
+      build: build as CharacterBuild,
+      resolvedLocation: "torso",
+    });
+
+    expect(result.armorValue).toBe(5);
+    expect(result.armorLabel).toContain("Mail");
+    expect(result.armorLabel).toContain("Leather");
+  });
+
+  it("uses item name as label fallback when armorLabel is absent", () => {
+    const build = makeBuild([
+      {
+        id: "a1",
+        equipped: true,
+        itemType: "armor",
+        name: "Leather Jerkin",
+        armorValue: 2,
+        shieldBonus: 0,
+        weaponBonus: 0,
+        slot: "body",
+      },
+    ]);
+
+    const result = lookupEncounterArmorAtLocation({
+      build: build as CharacterBuild,
+      resolvedLocation: "torso",
+    });
+
+    expect(result.armorValue).toBe(2);
+    expect(result.armorLabel).toContain("Leather Jerkin");
+  });
+});
+
+describe("applyEncounterWeaponArmorModifier", () => {
+  it("returns weapon bonus minus armor value", () => {
+    expect(applyEncounterWeaponArmorModifier({ armorValue: 2, weaponBonus: 5 })).toBe(3);
+    expect(applyEncounterWeaponArmorModifier({ armorValue: 0, weaponBonus: 3 })).toBe(3);
+  });
+
+  it("returns a negative result when armor exceeds weapon bonus", () => {
+    expect(applyEncounterWeaponArmorModifier({ armorValue: 5, weaponBonus: 3 })).toBe(-2);
+  });
+
+  it("returns 0 when both values are 0", () => {
+    expect(applyEncounterWeaponArmorModifier({ armorValue: 0, weaponBonus: 0 })).toBe(0);
+  });
+
+  it("returns the full weapon bonus when armor is 0 (unarmored defender)", () => {
+    expect(applyEncounterWeaponArmorModifier({ armorValue: 0, weaponBonus: 4 })).toBe(4);
+  });
+});

--- a/packages/rules-engine/src/skills/calculateSkills.test.ts
+++ b/packages/rules-engine/src/skills/calculateSkills.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateGms } from "./calculateGms";
+import { calculateGroupLevel } from "./calculateGroupLevel";
+import { calculateSkillLevel } from "./calculateSkillLevel";
+import { calculateSpecializationLevel } from "./calculateSpecializationLevel";
+
+describe("calculateGms", () => {
+  it("returns ranks when no bonuses are present", () => {
+    expect(calculateGms({ ranks: 5 })).toBe(5);
+    expect(calculateGms({ ranks: 0 })).toBe(0);
+  });
+
+  it("adds stat and profession bonuses to ranks", () => {
+    expect(calculateGms({ ranks: 3, statBonus: 2, professionBonus: 1 })).toBe(6);
+  });
+
+  it("treats absent bonuses as zero", () => {
+    expect(calculateGms({ ranks: 4, statBonus: 2 })).toBe(6);
+    expect(calculateGms({ ranks: 4, professionBonus: 3 })).toBe(7);
+  });
+
+  it("handles negative bonuses", () => {
+    expect(calculateGms({ ranks: 5, statBonus: -2 })).toBe(3);
+  });
+});
+
+describe("calculateGroupLevel", () => {
+  it("returns ranks when no gms modifier is given", () => {
+    expect(calculateGroupLevel({ ranks: 7 })).toBe(7);
+    expect(calculateGroupLevel({ ranks: 0 })).toBe(0);
+  });
+
+  it("adds gms to ranks", () => {
+    expect(calculateGroupLevel({ ranks: 4, gms: 3 })).toBe(7);
+  });
+
+  it("handles negative gms", () => {
+    expect(calculateGroupLevel({ ranks: 5, gms: -1 })).toBe(4);
+  });
+
+  it("treats missing gms as zero", () => {
+    expect(calculateGroupLevel({ ranks: 6 })).toBe(
+      calculateGroupLevel({ ranks: 6, gms: 0 }),
+    );
+  });
+});
+
+describe("calculateSkillLevel", () => {
+  it("sums group level, ranks, and gms", () => {
+    expect(calculateSkillLevel({ groupLevel: 3, ranks: 2, gms: 1 })).toBe(6);
+  });
+
+  it("returns group level plus ranks when gms is absent", () => {
+    expect(calculateSkillLevel({ groupLevel: 5, ranks: 2 })).toBe(7);
+  });
+
+  it("handles zero ranks and zero gms", () => {
+    expect(calculateSkillLevel({ groupLevel: 4, ranks: 0, gms: 0 })).toBe(4);
+  });
+
+  it("handles negative gms (penalty)", () => {
+    expect(calculateSkillLevel({ groupLevel: 6, ranks: 3, gms: -2 })).toBe(7);
+  });
+});
+
+describe("calculateSpecializationLevel", () => {
+  it("adds half the group level (floored) to the specialization level", () => {
+    expect(calculateSpecializationLevel({ groupLevel: 6, specializationLevel: 3 })).toBe(6);
+    expect(calculateSpecializationLevel({ groupLevel: 7, specializationLevel: 2 })).toBe(5);
+  });
+
+  it("floors the group level half-contribution correctly", () => {
+    // groupLevel 5 → floor(5/2) = 2
+    expect(calculateSpecializationLevel({ groupLevel: 5, specializationLevel: 0 })).toBe(2);
+    // groupLevel 1 → floor(1/2) = 0
+    expect(calculateSpecializationLevel({ groupLevel: 1, specializationLevel: 4 })).toBe(4);
+  });
+
+  it("returns only specialization level when group level is 0", () => {
+    expect(calculateSpecializationLevel({ groupLevel: 0, specializationLevel: 5 })).toBe(5);
+  });
+
+  it("returns 0 when both inputs are 0", () => {
+    expect(calculateSpecializationLevel({ groupLevel: 0, specializationLevel: 0 })).toBe(0);
+  });
+});

--- a/packages/rules-engine/src/stats/calculateAdjustedStats.test.ts
+++ b/packages/rules-engine/src/stats/calculateAdjustedStats.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { calculateAdjustedStats } from "./calculateAdjustedStats";
+
+describe("calculateAdjustedStats", () => {
+  it("returns a copy of base stats when no modifiers are provided", () => {
+    const base = { str: 12, dex: 10, con: 14 };
+    expect(calculateAdjustedStats({ baseStats: base })).toEqual(base);
+  });
+
+  it("adds modifier values on top of matching base stats", () => {
+    const result = calculateAdjustedStats({
+      baseStats: { str: 10, dex: 11 },
+      modifiers: { str: 2, dex: -1 },
+    });
+
+    expect(result.str).toBe(12);
+    expect(result.dex).toBe(10);
+  });
+
+  it("leaves unmodified stats untouched", () => {
+    const result = calculateAdjustedStats({
+      baseStats: { str: 10, dex: 11, con: 13 },
+      modifiers: { str: 1 },
+    });
+
+    expect(result.dex).toBe(11);
+    expect(result.con).toBe(13);
+  });
+
+  it("treats modifiers for stats absent in base as additions from zero", () => {
+    const result = calculateAdjustedStats({
+      baseStats: { str: 10 },
+      modifiers: { lck: 3 },
+    });
+
+    expect(result.lck).toBe(3);
+    expect(result.str).toBe(10);
+  });
+
+  it("does not mutate the original baseStats object", () => {
+    const base = { str: 10 };
+    calculateAdjustedStats({ baseStats: base, modifiers: { str: 5 } });
+
+    expect(base.str).toBe(10);
+  });
+
+  it("returns an identical object when modifiers is an empty record", () => {
+    const base = { str: 12, dex: 9 };
+    expect(calculateAdjustedStats({ baseStats: base, modifiers: {} })).toEqual(base);
+  });
+});

--- a/packages/rules-engine/src/stats/characteristicGms.test.ts
+++ b/packages/rules-engine/src/stats/characteristicGms.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDexteritySizeModifier,
+  getGlantriStatModifier,
+  getWorkbookCharacterSheetGm,
+} from "./characteristicGms";
+
+describe("getGlantriStatModifier", () => {
+  it("returns the correct modifier for key boundary values", () => {
+    // Stat 1 → −5 (table index 0)
+    expect(getGlantriStatModifier(1)).toBe(-5);
+    // Stat 9 → −1
+    expect(getGlantriStatModifier(9)).toBe(-1);
+    // Stat 10 → 0
+    expect(getGlantriStatModifier(10)).toBe(0);
+    // Stat 11 → 0
+    expect(getGlantriStatModifier(11)).toBe(0);
+    // Stat 12 → 0
+    expect(getGlantriStatModifier(12)).toBe(0);
+    // Stat 17 → +3
+    expect(getGlantriStatModifier(17)).toBe(3);
+    // Stat 25 (last entry) → +7
+    expect(getGlantriStatModifier(25)).toBe(7);
+  });
+
+  it("returns 0 for values outside the table range", () => {
+    expect(getGlantriStatModifier(0)).toBe(0);
+    expect(getGlantriStatModifier(26)).toBe(0);
+  });
+});
+
+describe("getWorkbookCharacterSheetGm", () => {
+  it("returns 0 for stat 11 (the midpoint in the workbook formula)", () => {
+    expect(getWorkbookCharacterSheetGm(11)).toBe(0);
+  });
+
+  it("returns 3 for stat 17", () => {
+    expect(getWorkbookCharacterSheetGm(17)).toBe(3);
+  });
+
+  it("returns -2 for stat 7", () => {
+    expect(getWorkbookCharacterSheetGm(7)).toBe(-2);
+  });
+
+  it("truncates towards zero for even values", () => {
+    // (16 − 11) / 2 = 2.5 → trunc → 2
+    expect(getWorkbookCharacterSheetGm(16)).toBe(2);
+    // (12 − 11) / 2 = 0.5 → trunc → 0
+    expect(getWorkbookCharacterSheetGm(12)).toBe(0);
+  });
+
+  it("covers the basicCombatScenario level-1 strength 11 → gm 0", () => {
+    // basicCombatScenario: attacker level 1. Strength 11 (average) yields GM 0.
+    expect(getWorkbookCharacterSheetGm(11)).toBe(0);
+  });
+});
+
+describe("getDexteritySizeModifier", () => {
+  it("returns 0 for average size (10–14)", () => {
+    expect(getDexteritySizeModifier(10)).toBe(0);
+    expect(getDexteritySizeModifier(14)).toBe(0);
+  });
+
+  it("returns a positive value for small size (< 10)", () => {
+    // siz 8: getGlantriStatModifier(8) = −1, result = −(−1) = 1
+    expect(getDexteritySizeModifier(8)).toBe(1);
+    // siz 5: getGlantriStatModifier(5) = −2, result = −(−2) = 2
+    expect(getDexteritySizeModifier(5)).toBe(2);
+  });
+
+  it("returns a negative value for large size (> 14)", () => {
+    // siz 18: getGlantriStatModifier(18) = 4, result = −(4 − 1) = −3
+    expect(getDexteritySizeModifier(18)).toBe(-3);
+    // siz 20: getGlantriStatModifier(20) = 5, result = −(5 − 1) = −4
+    expect(getDexteritySizeModifier(20)).toBe(-4);
+  });
+});

--- a/packages/rules-engine/src/stats/characteristicGms.test.ts
+++ b/packages/rules-engine/src/stats/characteristicGms.test.ts
@@ -65,14 +65,14 @@ describe("getDexteritySizeModifier", () => {
   it("returns a positive value for small size (< 10)", () => {
     // siz 8: getGlantriStatModifier(8) = −1, result = −(−1) = 1
     expect(getDexteritySizeModifier(8)).toBe(1);
-    // siz 5: getGlantriStatModifier(5) = −2, result = −(−2) = 2
-    expect(getDexteritySizeModifier(5)).toBe(2);
+    // siz 5: getGlantriStatModifier(5) = −3, result = −(−3) = 3
+    expect(getDexteritySizeModifier(5)).toBe(3);
   });
 
   it("returns a negative value for large size (> 14)", () => {
-    // siz 18: getGlantriStatModifier(18) = 4, result = −(4 − 1) = −3
-    expect(getDexteritySizeModifier(18)).toBe(-3);
-    // siz 20: getGlantriStatModifier(20) = 5, result = −(5 − 1) = −4
-    expect(getDexteritySizeModifier(20)).toBe(-4);
+    // siz 18: getGlantriStatModifier(18) = 3, result = −(3 − 1) = −2
+    expect(getDexteritySizeModifier(18)).toBe(-2);
+    // siz 20: getGlantriStatModifier(20) = 4, result = −(4 − 1) = −3
+    expect(getDexteritySizeModifier(20)).toBe(-3);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@types/node':
         specifier: ^22.14.0
         version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 2.1.9
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.15))
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
@@ -156,11 +159,11 @@ importers:
         version: link:../test-scenarios
       '@prisma/client':
         specifier: ^6.6.0
-        version: 6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)
+        version: 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       prisma:
         specifier: ^6.6.0
-        version: 6.19.2(typescript@5.9.3)
+        version: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
 
   packages/domain:
     dependencies:
@@ -216,6 +219,30 @@ importers:
         version: link:../rules-engine
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
@@ -723,8 +750,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@next/env@15.5.12':
     resolution: {integrity: sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==}
@@ -794,6 +839,10 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@prisma/client@6.19.2':
     resolution: {integrity: sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==}
@@ -1032,6 +1081,15 @@ packages:
     resolution: {integrity: sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+    peerDependencies:
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -1088,9 +1146,21 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1115,6 +1185,9 @@ packages:
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
@@ -1237,8 +1310,17 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -1384,6 +1466,10 @@ packages:
   flatted@3.4.1:
     resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1404,6 +1490,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -1415,6 +1506,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1440,6 +1534,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -1450,6 +1548,25 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1494,8 +1611,18 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1511,6 +1638,14 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1571,6 +1706,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1582,6 +1720,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -1753,6 +1895,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -1769,6 +1915,22 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1790,6 +1952,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
@@ -1974,6 +2140,14 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1982,6 +2156,26 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@emnapi/runtime@1.8.1':
     dependencies:
@@ -2312,7 +2506,30 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@next/env@15.5.12': {}
 
@@ -2358,14 +2575,17 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
-  '@prisma/client@6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)':
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
-      prisma: 6.19.2(typescript@5.9.3)
+      prisma: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@prisma/config@6.19.2':
+  '@prisma/config@6.19.2(magicast@0.3.5)':
     dependencies:
-      c12: 3.1.0
+      c12: 3.1.0(magicast@0.3.5)
       deepmerge-ts: 7.1.5
       effect: 3.18.4
       empathic: 2.0.0
@@ -2581,6 +2801,24 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.15))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -2647,9 +2885,15 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
@@ -2671,6 +2915,10 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
   brace-expansion@5.0.4:
     dependencies:
       balanced-match: 4.0.4
@@ -2679,7 +2927,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  c12@3.1.0:
+  c12@3.1.0(magicast@0.3.5):
     dependencies:
       chokidar: 4.0.3
       confbox: 0.2.4
@@ -2693,6 +2941,8 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 2.3.0
       rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.3.5
 
   cac@6.7.14: {}
 
@@ -2772,10 +3022,16 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  eastasianwidth@0.2.0: {}
+
   effect@3.18.4:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
 
@@ -3003,6 +3259,11 @@ snapshots:
 
   flatted@3.4.1: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -3027,11 +3288,22 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   globals@14.0.0: {}
 
   globals@15.15.0: {}
 
   has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
 
   ignore@5.3.2: {}
 
@@ -3048,6 +3320,8 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -3055,6 +3329,33 @@ snapshots:
   is-number@7.0.0: {}
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@2.6.1: {}
 
@@ -3097,9 +3398,21 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   merge2@1.4.1: {}
 
@@ -3115,6 +3428,12 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minipass@7.1.3: {}
 
   ms@2.1.3: {}
 
@@ -3174,6 +3493,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -3181,6 +3502,11 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@1.1.2: {}
 
@@ -3238,9 +3564,9 @@ snapshots:
 
   prettier@3.8.1: {}
 
-  prisma@6.19.2(typescript@5.9.3):
+  prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3):
     dependencies:
-      '@prisma/config': 6.19.2
+      '@prisma/config': 6.19.2(magicast@0.3.5)
       '@prisma/engines': 6.19.2
     optionalDependencies:
       typescript: 5.9.3
@@ -3376,6 +3702,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -3388,6 +3716,26 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(react@19.2.4):
@@ -3398,6 +3746,12 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.4
 
   thread-stream@4.0.0:
     dependencies:
@@ -3561,6 +3915,18 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   yocto-queue@0.1.0: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,1 @@
+export { default } from "./packages/config/vitest.base";


### PR DESCRIPTION
## Hva som er inkludert

**Produksjonsfikser:**
- `SameSite=None` i produksjon — session-cookie sendes nå korrekt i cross-site fetch (web → API)
- `appCommandLine` tømmes i deploy — Azure bruker Dockerfile CMD, ikke gammel Bicep-override
- `CMD` i API Dockerfile rettet til faktisk tsc-outputsti
- `WEBSITES_PORT` settes eksplisitt via `az webapp config` i deploy

**CI-forbedringer:**
- `docker-test`: bygger og starter begge Docker-images, kjører migrasjoner og DB-integrasjonstester
- `[skip cd]`-støtte i deploy.yml
- `pnpm coverage` og `pnpm build` kjøres i CI (Codex)

**Testdekning (Codex):**
- Vitest workspace-aliaser peker på `src`, ikke stale `dist`
- `/health`, CORS, cookie og scenarios kontraktstester
- `localServiceClient` klienttester
- Regresjonsmatrise i `docs/`

## Merknader
Denne PR-en inneholder `[skip cd]` — CD trigges ikke ved merge. Deploy kjøres separat når CI er bekreftet grønn på main.