### PR TITLE
Add stable flow characterization tests

### DIFF
--- a/docs/testing-regression-matrix.md
+++ b/docs/testing-regression-matrix.md
@@ -71,6 +71,27 @@ Treat these paths as high-value coverage targets:
 - `apps/web/src/features/**`
 - `apps/web/app/(app)/**`
 
+## Stable vs Actively Evolving Areas
+
+Stable/protected workflows should get the strongest characterization tests before
+large refactors:
+
+- Chargen
+- Character Sheet
+- Character Progression
+- Admin Skills/Professions/content screens
+- Rules Docs
+- Campaign roster basics
+
+Encounter workflows are still in active product design. Protect stable
+invariants there, but avoid brittle tests that freeze current layout, section
+order, table order, or exact button placement:
+
+- GM Scenario screen
+- GM/Player Encounter screens
+- Roleplay encounter roll UI
+- Combat encounter UI
+
 ## Functional Regression Matrix
 
 | Workflow | Primary role | Main modules | Current automated coverage | Remaining gap | Refactor risk |
@@ -78,16 +99,16 @@ Treat these paths as high-value coverage targets:
 | Auth/session | Player, GM, admin | `packages/auth`, `apps/api/src/lib/sessionAuth.ts`, `apps/web/src/lib/auth` | `packages/auth/src/session.test.ts`, `apps/api/src/lib/sessionAuth.test.ts`, `apps/web/src/lib/auth/authBootstrap.test.ts`, Playwright login smoke | Browser logout smoke test | Moderate |
 | API health/runtime | System | `apps/api/src/app.ts`, deploy workflows | `apps/api/src/app.test.ts`, `apps/api/src/lib/readiness.test.ts`, Docker readiness smoke in CI | Deploy smoke still depends on real hosted DB availability | Moderate |
 | CORS/cookie contract | Browser, API | `apps/api/src/lib/sessionAuth.ts` | `apps/api/src/lib/sessionAuth.test.ts` | Same-origin proxy strategy is not covered until chosen | Moderate |
-| Chargen rules | Player | `packages/rules-engine/src/chargen`, `packages/domain/src/character` | `primaryAllocation.test.ts`, `selectionStructure.test.ts`, `statResolution.test.ts`, `importedContentIntegration.test.ts` | UI-level component tests for real user interaction | High |
-| Chargen UI/helpers | Player | `apps/web/app/(app)/chargen/ChargenWizard.tsx`, `apps/web/src/lib/chargen` | `ChargenWizard.test.ts`, `chargenBrowse.test.ts`, Playwright chargen smoke | Rendered React interaction tests for deeper choices | High |
-| Character browser/sheet/edit | Player, GM | `apps/web/src/lib/characters`, `packages/database/src/services/characterService.ts` | `characterBrowser.test.ts`, `characterSheet.test.ts`, `characterEdit.test.ts`, `characterService.test.ts`, Playwright characters-list smoke | Character sheet route smoke for browser rendering | Moderate |
-| Character advancement | Player | `packages/rules-engine/src/advancement`, `apps/web/src/lib/characters` | `advanceCharacter.test.ts`, `loadLocalCharacterAdvancementContext.test.ts` | UI smoke test for advancement workflow | High |
+| Chargen rules | Player | `packages/rules-engine/src/chargen`, `packages/domain/src/character` | `primaryAllocation.test.ts`, `selectionStructure.test.ts`, `statResolution.test.ts`, `importedContentIntegration.test.ts`; covers canonical content initialization, group pricing, required slot choices, and Longbow-as-specialization behavior | One or two UI smoke interactions for user-facing choice flows, avoiding full brittle end-to-end chargen scripts | High |
+| Chargen UI/helpers | Player | `apps/web/app/(app)/chargen/ChargenWizard.tsx`, `apps/web/src/lib/chargen` | `ChargenWizard.test.ts`, `ChargenWizard.component.test.tsx`, `chargenBrowse.test.ts`, Playwright chargen smoke | Rendered React interaction tests for deeper choices if setup remains lightweight | High |
+| Character Sheet/browser/edit | Player, GM | `apps/web/src/lib/characters`, `packages/database/src/services/characterService.ts` | `characterBrowser.test.ts`, `characterSheet.test.ts`, `characterEdit.test.ts`, `characterService.test.ts`, Playwright characters-list smoke; sheet tests cover stat columns, skill XP columns, specialization XP, derived XP, total skill level, and current skill-point gains | Character sheet route smoke for browser rendering | Moderate |
+| Character Progression | Player | `packages/rules-engine/src/advancement`, `apps/web/src/lib/characters` | `advanceCharacter.test.ts`, `loadLocalCharacterAdvancementContext.test.ts`; covers requested/approved checks, requested-only rejection, point deduction, provisional rows, success/failure history, and progression-point gains separate from chargen points | UI smoke test for advancement workflow | High |
 | Equipment/loadout/combat stats | Player, GM | `apps/web/src/features/equipment`, `packages/database/src/services/characterEquipment*`, `packages/content/src/equipment` | Equipment selector/loadout/movement/combat panel tests, importer/content tests, database equipment write integration tests | Service read-model integration breadth | High |
 | Combat calculations | Player, GM | `packages/rules-engine/src/combat`, `apps/web/src/features/equipment` | `workbookCombatMath.test.ts`, `combatVerification.test.ts`, `composeDefenseValues.test.ts`, `combatStateDerivation.test.ts` | More spreadsheet-backed golden rows for varied loadouts | High |
-| Campaign workspace | GM, player | `apps/web/src/lib/campaigns`, `apps/web/app/(app)/campaigns`, `apps/api/src/routes/scenarios/campaignRoutes.ts` | Campaign workspace/detail tests, `scenarios.test.ts`, scenario service integration tests, Playwright seeded campaign smoke | Player-side browser smoke for campaign access | High |
-| Scenario/encounter API | GM, player | `apps/api/src/routes/scenarios/` (campaignRoutes, scenarioRoutes, encounterRoutes, participantRoutes, templateRoutes), `packages/database/src/services/scenarioService.ts` | `apps/api/src/routes/scenarios.test.ts`, `packages/database/src/services/scenarioService.test.ts` | Kontraktstester per domenefil etter splitting | High |
-| Encounter/roleplay screens | GM, player | `apps/web/app/(app)/encounters`, `packages/domain/src/encounter` | `EncounterDetail.test.ts`, `RoleplayEncounterScreens.test.ts`, `roleplay.test.ts` | Browser smoke for active encounter | Moderate |
-| Admin content/rules docs/players | Admin, GM | `apps/web/app/(app)/admin`, `apps/web/src/lib/admin`, `apps/api/src/routes/adminContent.ts` | `admin-ui.test.ts`, `PlayersAdminPage.test.ts`, `MarkdownRenderer.test.ts`, `viewModels.test.ts` | API route characterization for admin content save conflicts | Moderate |
+| Campaign roster/workspace | GM, player | `apps/web/src/lib/campaigns`, `apps/web/app/(app)/campaigns`, `apps/api/src/routes/scenarios/campaignRoutes.ts`, `packages/database/src/services/campaignService.ts` | Campaign workspace/detail tests, `campaignService.test.ts`, `scenarios.test.ts`, scenario service integration tests, Playwright seeded campaign smoke; roster service tests cover per-campaign membership, dedupe, unlink, and source preservation | Player-side browser smoke for campaign access | High |
+| Scenario/encounter API | GM, player | `apps/api/src/routes/scenarios/` (campaignRoutes, scenarioRoutes, encounterRoutes, participantRoutes, templateRoutes), `packages/database/src/services/scenarioService.ts` | `apps/api/src/routes/scenarios.test.ts`, `packages/database/src/services/scenarioService.test.ts` | Narrow scenario/encounter API contract tests as read models are split | High |
+| Encounter/roleplay screens | GM, player | `apps/web/app/(app)/encounters`, `packages/domain/src/encounter` | `EncounterDetail.test.ts`, `RoleplayEncounterScreens.test.ts`, `roleplay.test.ts`; encounter invariants are covered separately by issue #124 | Keep tests focused on invariants such as session normalization, roll rules, opposed comparison, silent data hiding, and read-model contracts; defer detailed layout/browser tests while encounter UI evolves | Moderate |
+| Admin content/rules docs/players | Admin, GM | `apps/web/app/(app)/admin`, `apps/web/src/lib/admin`, `apps/api/src/routes/adminContent.ts`, `apps/web/src/lib/rulesDocs.ts` | `admin-ui.test.ts`, `PlayersAdminPage.test.ts`, `MarkdownRenderer.test.ts`, `viewModels.test.ts`, `rulesDocs.test.ts`; rules docs registry covers Chargen, Character Sheet, Equipment & Encumbrance, Equip Items, and Character Progression calculations | API route characterization for admin content save conflicts | Moderate |
 | Web API client | Browser | `apps/web/src/lib/api/localServiceClient.ts` | `apps/web/src/lib/api/localServiceClient.test.ts` | More methods can be added as domains are split | High |
 
 ## Test Policy For Large Refactors
@@ -95,6 +116,16 @@ Treat these paths as high-value coverage targets:
 - Add characterization tests before moving code when behavior is not obvious.
 - Prefer service/helper tests for logic and a few browser/e2e smoke tests for
   wiring.
+- Put the strongest characterization coverage around stable/protected flows:
+  Chargen, Character Sheet, Character Progression, Admin content/rules docs, and
+  Campaign roster basics.
+- For encounter screens, test stable invariants instead of current visual layout:
+  encounter session normalization, roleplay roll rules, opposed roll comparison,
+  scenario participant vs encounter participant boundaries, hidden/silent data
+  not visible to players, and API/read-model contracts.
+- Avoid detailed Playwright or component tests that lock current encounter table
+  order, section order, or exact button placement until encounter product design
+  settles.
 - Keep spreadsheet-derived tests tied to exact workbook/sheet/cell references.
 - Do not use coverage percentage alone as a quality signal; use this matrix to
   decide whether the touched workflow has the right kind of coverage.

--- a/packages/database/src/services/campaignService.test.ts
+++ b/packages/database/src/services/campaignService.test.ts
@@ -157,4 +157,121 @@ describe("CampaignService campaign roster", () => {
 
     await expect(service.listCampaignRosterEntries("campaign-1")).resolves.toEqual([]);
   });
+
+  it("keeps roster membership scoped to each campaign/source pair", async () => {
+    const { repository, rosterEntries } = createScenarioRepositoryStub();
+    const characters = new Map([
+      ["character-1", createCharacterRecord({ id: "character-1", name: "Ari", ownerId: "user-1" })],
+    ]);
+    const service = new CampaignService(
+      repository,
+      {
+        getCharacterById: async (characterId: string) => characters.get(characterId) ?? null,
+      } as never,
+    );
+
+    const campaignOneEntry = await service.addCampaignRosterEntry({
+      campaignId: "campaign-1",
+      category: "pc",
+      sourceId: "character-1",
+      sourceType: "character",
+    });
+    const campaignOneDuplicate = await service.addCampaignRosterEntry({
+      campaignId: "campaign-1",
+      category: "pc",
+      sourceId: "character-1",
+      sourceType: "character",
+    });
+    const campaignTwoEntry = await service.addCampaignRosterEntry({
+      campaignId: "campaign-2",
+      category: "pc",
+      sourceId: "character-1",
+      sourceType: "character",
+    });
+
+    expect(campaignOneDuplicate.id).toBe(campaignOneEntry.id);
+    expect(campaignTwoEntry.id).not.toBe(campaignOneEntry.id);
+    expect(rosterEntries).toHaveLength(2);
+    await expect(service.listCampaignRosterEntries("campaign-1")).resolves.toEqual([campaignOneEntry]);
+    await expect(service.listCampaignRosterEntries("campaign-2")).resolves.toEqual([campaignTwoEntry]);
+  });
+
+  it("removes only roster links and leaves source characters and templates available", async () => {
+    const { repository, rosterEntries } = createScenarioRepositoryStub();
+    const characters = new Map([
+      ["character-1", createCharacterRecord({ id: "character-1", name: "Ari", ownerId: "user-1" })],
+    ]);
+    const reusableEntities = new Map<string, ReusableEntity>([
+      [
+        "template-1",
+        {
+          createdAt: "2026-04-21T00:00:00.000Z",
+          gmUserId: "gm-1",
+          id: "template-1",
+          kind: "npc",
+          name: "Bandit Template",
+          snapshot: {
+            actorClass: "template",
+          },
+          updatedAt: "2026-04-21T00:00:00.000Z",
+        },
+      ],
+    ]);
+    repository.getReusableEntityById = async (entityId) => reusableEntities.get(entityId) ?? null;
+    const service = new CampaignService(
+      repository,
+      {
+        getCharacterById: async (characterId: string) => characters.get(characterId) ?? null,
+      } as never,
+    );
+
+    const characterEntry = await service.addCampaignRosterEntry({
+      campaignId: "campaign-1",
+      category: "pc",
+      sourceId: "character-1",
+      sourceType: "character",
+    });
+    const templateEntry = await service.addCampaignRosterEntry({
+      campaignId: "campaign-1",
+      category: "template",
+      sourceId: "template-1",
+      sourceType: "template",
+    });
+
+    await service.removeCampaignRosterEntry({
+      campaignId: "campaign-1",
+      rosterEntryId: characterEntry.id,
+    });
+    await service.removeCampaignRosterEntry({
+      campaignId: "campaign-1",
+      rosterEntryId: templateEntry.id,
+    });
+
+    expect(rosterEntries).toHaveLength(0);
+    expect(characters.get("character-1")?.name).toBe("Ari");
+    expect(reusableEntities.get("template-1")?.name).toBe("Bandit Template");
+
+    await expect(
+      service.addCampaignRosterEntry({
+        campaignId: "campaign-1",
+        category: "pc",
+        sourceId: "character-1",
+        sourceType: "character",
+      }),
+    ).resolves.toMatchObject({
+      labelSnapshot: "Ari",
+      sourceId: "character-1",
+    });
+    await expect(
+      service.addCampaignRosterEntry({
+        campaignId: "campaign-1",
+        category: "template",
+        sourceId: "template-1",
+        sourceType: "template",
+      }),
+    ).resolves.toMatchObject({
+      labelSnapshot: "Bandit Template",
+      sourceId: "template-1",
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Adds stable-flow characterization coverage for campaign roster service invariants and updates the testing regression matrix.

## Verification
- pnpm --filter @glantri/database test
- pnpm --filter @glantri/domain test
- pnpm --filter @glantri/rules-engine test
- pnpm --filter @glantri/web test
- pnpm test
- pnpm lint
- pnpm build

Closes #92