### PR TITLE
fix: replace NODE|22-lts with DOCKER image in appservice.bicep (#49)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -62,6 +62,7 @@ module appService 'modules/appservice.bicep' = {
     prefix: prefix
     location: location
     keyVaultUri: keyVault.outputs.uri
+    registryServer: acr.outputs.loginServer
   }
 }
 

--- a/infra/modules/appservice.bicep
+++ b/infra/modules/appservice.bicep
@@ -1,6 +1,7 @@
 param prefix string
 param location string
 param keyVaultUri string
+param registryServer string
 
 resource plan 'Microsoft.Web/serverfarms@2023-12-01' = {
   name: '${prefix}-plan'
@@ -18,7 +19,7 @@ resource apiApp 'Microsoft.Web/sites@2023-12-01' = {
     serverFarmId: plan.id
     httpsOnly: true
     siteConfig: {
-      linuxFxVersion: 'NODE|22-lts'
+      linuxFxVersion: 'DOCKER|${registryServer}/glantri-api:latest'
       appSettings: [
         {
           name: 'NODE_ENV'
@@ -54,7 +55,7 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
     serverFarmId: plan.id
     httpsOnly: true
     siteConfig: {
-      linuxFxVersion: 'NODE|22-lts'
+      linuxFxVersion: 'DOCKER|${registryServer}/glantri-web:latest'
       appSettings: [
         {
           name: 'NODE_ENV'


### PR DESCRIPTION
## Summary

- `linuxFxVersion` was set to `NODE|22-lts` in both app service resources while actual deploys push Docker container images from ACR — Bicep was not authoritative.
- Added `registryServer` parameter to `appservice.bicep`, fed from `acr.outputs.loginServer` in `main.bicep`.
- Both app services now declare `DOCKER|<registry>/glantri-api:latest` and `DOCKER|<registry>/glantri-web:latest` — consistent with what the deploy workflow sets on each push to main.

Closes #49

## Test plan

- [ ] Bicep lints/validates: `az bicep build --file infra/main.bicep`
- [ ] Fresh provisioning deploys app services in Docker mode (no manual override needed)
- [ ] Re-running Bicep after a deploy no longer resets runtime to Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)