### PR TITLE
Fixing the roster removal bug

### DIFF
--- a/apps/api/src/routes/scenarios.test.ts
+++ b/apps/api/src/routes/scenarios.test.ts
@@ -15,9 +15,13 @@ const mocks = vi.hoisted(() => {
   const campaignService = {
     createCampaign: vi.fn(),
     getCampaignById: vi.fn(),
+    listCampaignRosterEntries: vi.fn(),
+    listCampaignsByCharacterRosterAccess: vi.fn(),
     listCampaignsByGameMaster: vi.fn(),
   };
-  const characterService = {};
+  const characterService = {
+    getOwnedCharacter: vi.fn(),
+  };
   const encounterService = {
     getEncounterById: vi.fn(),
     listEncountersByScenario: vi.fn(),
@@ -25,6 +29,7 @@ const mocks = vi.hoisted(() => {
   };
   const scenarioService = {
     createScenario: vi.fn(),
+    addCharacterParticipant: vi.fn(),
     getScenarioById: vi.fn(),
     listScenariosByCampaign: vi.fn(),
     listScenarioParticipants: vi.fn(),
@@ -161,6 +166,164 @@ describe("scenarios route contract", () => {
       name: "Bridge Ambush",
       status: "prepared",
     });
+  });
+
+  it("lists live roster-eligible scenarios for a character without campaign self-join", async () => {
+    const campaign = {
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    };
+    mocks.campaignService.listCampaignsByCharacterRosterAccess.mockResolvedValue([campaign]);
+    mocks.scenarioService.listScenariosByCampaign.mockResolvedValue([
+      {
+        campaignId: "campaign-1",
+        id: "scenario-live",
+        kind: "mixed",
+        name: "Live Scene",
+        status: "live",
+      },
+      {
+        campaignId: "campaign-1",
+        id: "scenario-draft",
+        kind: "mixed",
+        name: "Draft Scene",
+        status: "draft",
+      },
+    ]);
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "GET",
+      url: "/scenarios/joinable?characterId=character-1",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      joinableScenarios: [
+        {
+          campaignId: "campaign-1",
+          campaignName: "Border Trouble",
+          kind: "mixed",
+          scenarioId: "scenario-live",
+          scenarioName: "Live Scene",
+          status: "live",
+        },
+      ],
+    });
+    expect(mocks.campaignService.listCampaignsByCharacterRosterAccess).toHaveBeenCalledWith(
+      "character-1",
+    );
+  });
+
+  it("allows a player-owned roster character to join a live scenario", async () => {
+    const scenario = {
+      campaignId: "campaign-1",
+      id: "scenario-1",
+      kind: "mixed",
+      name: "Live Scene",
+      status: "live",
+    };
+    const campaign = {
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      settings: {
+        allowPlayerSelfJoin: false,
+      },
+      status: "active",
+    };
+    const participant = {
+      characterId: "character-1",
+      controlledByUserId: "player-1",
+      id: "participant-1",
+      scenarioId: "scenario-1",
+    };
+    mocks.scenarioService.getScenarioById.mockResolvedValue(scenario);
+    mocks.campaignService.getCampaignById.mockResolvedValue(campaign);
+    mocks.characterService.getOwnedCharacter.mockResolvedValue({
+      id: "character-1",
+      ownerId: "player-1",
+    });
+    mocks.campaignService.listCampaignRosterEntries.mockResolvedValue([
+      {
+        campaignId: "campaign-1",
+        id: "roster-1",
+        sourceId: "character-1",
+        sourceType: "character",
+      },
+    ]);
+    mocks.scenarioService.addCharacterParticipant.mockResolvedValue(participant);
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "POST",
+      payload: {
+        characterId: "character-1",
+        controlledByUserId: "player-1",
+        joinSource: "player_joined",
+        role: "player_character",
+      },
+      url: "/scenarios/scenario-1/participants/character",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ participant });
+    expect(mocks.scenarioService.addCharacterParticipant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        characterId: "character-1",
+        joinSource: "player_joined",
+        scenarioId: "scenario-1",
+      }),
+    );
+  });
+
+  it("rejects player scenario join when the character is not in the campaign roster", async () => {
+    mocks.scenarioService.getScenarioById.mockResolvedValue({
+      campaignId: "campaign-1",
+      id: "scenario-1",
+      kind: "mixed",
+      name: "Live Scene",
+      status: "live",
+    });
+    mocks.campaignService.getCampaignById.mockResolvedValue({
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      settings: {
+        allowPlayerSelfJoin: false,
+      },
+      status: "active",
+    });
+    mocks.characterService.getOwnedCharacter.mockResolvedValue({
+      id: "character-1",
+      ownerId: "player-1",
+    });
+    mocks.campaignService.listCampaignRosterEntries.mockResolvedValue([]);
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "POST",
+      payload: {
+        characterId: "character-1",
+        joinSource: "player_joined",
+        role: "player_character",
+      },
+      url: "/scenarios/scenario-1/participants/character",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(403);
+    expect(response.json()).toEqual({
+      error: "This character is not currently assigned to a campaign.",
+    });
+    expect(mocks.scenarioService.addCharacterParticipant).not.toHaveBeenCalled();
   });
 
   it("lists encounters for a player with scenario workspace access", async () => {

--- a/apps/api/src/routes/scenarios.test.ts
+++ b/apps/api/src/routes/scenarios.test.ts
@@ -232,7 +232,7 @@ describe("scenarios route contract", () => {
 
     const response = await app.inject({
       method: "DELETE",
-      url: "/campaigns/campaign-1/roster-membership?sourceType=character&sourceId=character-1",
+      url: "/campaigns/campaign-1/roster-membership/character/character-1",
     });
 
     await app.close();
@@ -258,7 +258,7 @@ describe("scenarios route contract", () => {
 
     const response = await app.inject({
       method: "DELETE",
-      url: "/campaigns/campaign-1/roster-membership?sourceType=template&sourceId=template-1",
+      url: "/campaigns/campaign-1/roster-membership/template/template-1",
     });
 
     await app.close();
@@ -283,13 +283,60 @@ describe("scenarios route contract", () => {
 
     const response = await app.inject({
       method: "DELETE",
-      url: "/campaigns/campaign-1/roster-membership?sourceType=character&sourceId=character-1",
+      url: "/campaigns/campaign-1/roster-membership/character/character-1",
     });
 
     await app.close();
 
     expect(response.statusCode).toBe(404);
     expect(response.json()).toEqual({ error: "Campaign not found." });
+    expect(mocks.campaignService.removeCampaignRosterEntryBySource).not.toHaveBeenCalled();
+  });
+
+  it("keeps query-based roster membership removal as a compatibility no-op path", async () => {
+    mocks.campaignService.getCampaignById.mockResolvedValue({
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    });
+    mocks.campaignService.removeCampaignRosterEntryBySource.mockResolvedValue(undefined);
+    const app = await buildScenarioTestApp();
+
+    const firstResponse = await app.inject({
+      method: "DELETE",
+      url: "/campaigns/campaign-1/roster-membership?sourceType=character&sourceId=character-1",
+    });
+    const secondResponse = await app.inject({
+      method: "DELETE",
+      url: "/campaigns/campaign-1/roster-membership?sourceType=character&sourceId=character-1",
+    });
+
+    await app.close();
+
+    expect(firstResponse.statusCode).toBe(200);
+    expect(secondResponse.statusCode).toBe(200);
+    expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a useful validation error for invalid roster source types", async () => {
+    mocks.campaignService.getCampaignById.mockResolvedValue({
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    });
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/campaigns/campaign-1/roster-membership/pc/character-1",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json().error).toContain("Invalid enum value");
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/scenarios.test.ts
+++ b/apps/api/src/routes/scenarios.test.ts
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => {
     listCampaignRosterEntries: vi.fn(),
     listCampaignsByCharacterRosterAccess: vi.fn(),
     listCampaignsByGameMaster: vi.fn(),
+    removeCampaignRosterEntryBySource: vi.fn(),
   };
   const characterService = {
     getOwnedCharacter: vi.fn(),
@@ -217,6 +218,79 @@ describe("scenarios route contract", () => {
     expect(mocks.campaignService.listCampaignsByCharacterRosterAccess).toHaveBeenCalledWith(
       "character-1",
     );
+  });
+
+  it("removes a campaign character roster membership by source identity", async () => {
+    mocks.campaignService.getCampaignById.mockResolvedValue({
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    });
+    mocks.campaignService.removeCampaignRosterEntryBySource.mockResolvedValue(undefined);
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/campaigns/campaign-1/roster-membership?sourceType=character&sourceId=character-1",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true });
+    expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledWith({
+      campaignId: "campaign-1",
+      sourceId: "character-1",
+      sourceType: "character",
+    });
+  });
+
+  it("removes a campaign template roster membership by source identity", async () => {
+    mocks.campaignService.getCampaignById.mockResolvedValue({
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    });
+    mocks.campaignService.removeCampaignRosterEntryBySource.mockResolvedValue(undefined);
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/campaigns/campaign-1/roster-membership?sourceType=template&sourceId=template-1",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true });
+    expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledWith({
+      campaignId: "campaign-1",
+      sourceId: "template-1",
+      sourceType: "template",
+    });
+  });
+
+  it("rejects roster membership removal outside the game master's campaign", async () => {
+    mocks.campaignService.getCampaignById.mockResolvedValue({
+      gmUserId: "other-gm",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    });
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/campaigns/campaign-1/roster-membership?sourceType=character&sourceId=character-1",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json()).toEqual({ error: "Campaign not found." });
+    expect(mocks.campaignService.removeCampaignRosterEntryBySource).not.toHaveBeenCalled();
   });
 
   it("allows a player-owned roster character to join a live scenario", async () => {

--- a/apps/api/src/routes/scenarios.test.ts
+++ b/apps/api/src/routes/scenarios.test.ts
@@ -238,10 +238,37 @@ describe("scenarios route contract", () => {
     await app.close();
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ ok: true, removed: true });
+    expect(response.json()).toEqual({ ok: true, removed: true, route: "source-key" });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledWith({
       campaignId: "campaign-1",
       sourceId: "character-1",
+      sourceType: "character",
+    });
+  });
+
+  it("accepts UUID character source ids on the source-key removal route", async () => {
+    const sourceId = "23831e49-9060-493d-9eaf-65667c210ce5";
+    mocks.campaignService.getCampaignById.mockResolvedValue({
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    });
+    mocks.campaignService.removeCampaignRosterEntryBySource.mockResolvedValue({ removed: true });
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: `/campaigns/campaign-1/roster-membership/character/${sourceId}`,
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true, removed: true, route: "source-key" });
+    expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledWith({
+      campaignId: "campaign-1",
+      sourceId,
       sourceType: "character",
     });
   });
@@ -264,7 +291,7 @@ describe("scenarios route contract", () => {
     await app.close();
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ ok: true, removed: true });
+    expect(response.json()).toEqual({ ok: true, removed: true, route: "source-key" });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledWith({
       campaignId: "campaign-1",
       sourceId: "template-1",
@@ -289,9 +316,10 @@ describe("scenarios route contract", () => {
     await app.close();
 
     expect(response.statusCode).toBe(404);
-    expect(response.json()).toEqual({
+    expect(response.json()).toMatchObject({
       code: "CAMPAIGN_NOT_FOUND",
       error: "Campaign not found.",
+      route: "source-key",
     });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).not.toHaveBeenCalled();
   });
@@ -321,8 +349,8 @@ describe("scenarios route contract", () => {
 
     expect(firstResponse.statusCode).toBe(200);
     expect(secondResponse.statusCode).toBe(200);
-    expect(firstResponse.json()).toEqual({ ok: true, removed: true });
-    expect(secondResponse.json()).toEqual({ ok: true, removed: false });
+    expect(firstResponse.json()).toEqual({ ok: true, removed: true, route: "source-query" });
+    expect(secondResponse.json()).toEqual({ ok: true, removed: false, route: "source-query" });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledTimes(2);
   });
 
@@ -344,11 +372,46 @@ describe("scenarios route contract", () => {
     await app.close();
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ ok: true, removed: false });
+    expect(response.json()).toEqual({ ok: true, removed: false, route: "source-key" });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledWith({
       campaignId: "campaign-1",
       sourceId: "missing-character",
       sourceType: "character",
+    });
+  });
+
+  it("returns source-key diagnostics when roster membership removal fails", async () => {
+    mocks.campaignService.getCampaignById.mockResolvedValue({
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    });
+    mocks.campaignService.removeCampaignRosterEntryBySource.mockRejectedValue(
+      new Error("Synthetic delete failure"),
+    );
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/campaigns/campaign-1/roster-membership/character/character-1",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toMatchObject({
+      code: "CAMPAIGN_ROSTER_REMOVE_FAILED",
+      details: {
+        campaignId: "campaign-1",
+        causeMessage: "Synthetic delete failure",
+        causeName: "Error",
+        route: "source-key",
+        sourceId: "character-1",
+        sourceType: "character",
+      },
+      error: "Synthetic delete failure",
+      route: "source-key",
     });
   });
 
@@ -372,6 +435,7 @@ describe("scenarios route contract", () => {
     expect(response.json()).toMatchObject({
       code: "INVALID_ROSTER_SOURCE_TYPE",
       error: "Invalid roster source type. Expected character, reusableEntity, or template.",
+      route: "source-key",
     });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).not.toHaveBeenCalled();
   });

--- a/apps/api/src/routes/scenarios.test.ts
+++ b/apps/api/src/routes/scenarios.test.ts
@@ -227,7 +227,7 @@ describe("scenarios route contract", () => {
       name: "Border Trouble",
       status: "active",
     });
-    mocks.campaignService.removeCampaignRosterEntryBySource.mockResolvedValue(undefined);
+    mocks.campaignService.removeCampaignRosterEntryBySource.mockResolvedValue({ removed: true });
     const app = await buildScenarioTestApp();
 
     const response = await app.inject({
@@ -238,7 +238,7 @@ describe("scenarios route contract", () => {
     await app.close();
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ ok: true });
+    expect(response.json()).toEqual({ ok: true, removed: true });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledWith({
       campaignId: "campaign-1",
       sourceId: "character-1",
@@ -253,7 +253,7 @@ describe("scenarios route contract", () => {
       name: "Border Trouble",
       status: "active",
     });
-    mocks.campaignService.removeCampaignRosterEntryBySource.mockResolvedValue(undefined);
+    mocks.campaignService.removeCampaignRosterEntryBySource.mockResolvedValue({ removed: true });
     const app = await buildScenarioTestApp();
 
     const response = await app.inject({
@@ -264,7 +264,7 @@ describe("scenarios route contract", () => {
     await app.close();
 
     expect(response.statusCode).toBe(200);
-    expect(response.json()).toEqual({ ok: true });
+    expect(response.json()).toEqual({ ok: true, removed: true });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledWith({
       campaignId: "campaign-1",
       sourceId: "template-1",
@@ -303,7 +303,9 @@ describe("scenarios route contract", () => {
       name: "Border Trouble",
       status: "active",
     });
-    mocks.campaignService.removeCampaignRosterEntryBySource.mockResolvedValue(undefined);
+    mocks.campaignService.removeCampaignRosterEntryBySource
+      .mockResolvedValueOnce({ removed: true })
+      .mockResolvedValueOnce({ removed: false });
     const app = await buildScenarioTestApp();
 
     const firstResponse = await app.inject({
@@ -319,7 +321,35 @@ describe("scenarios route contract", () => {
 
     expect(firstResponse.statusCode).toBe(200);
     expect(secondResponse.statusCode).toBe(200);
+    expect(firstResponse.json()).toEqual({ ok: true, removed: true });
+    expect(secondResponse.json()).toEqual({ ok: true, removed: false });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats missing source-key roster membership removal as successful and idempotent", async () => {
+    mocks.campaignService.getCampaignById.mockResolvedValue({
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    });
+    mocks.campaignService.removeCampaignRosterEntryBySource.mockResolvedValue({ removed: false });
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "DELETE",
+      url: "/campaigns/campaign-1/roster-membership/character/missing-character",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ ok: true, removed: false });
+    expect(mocks.campaignService.removeCampaignRosterEntryBySource).toHaveBeenCalledWith({
+      campaignId: "campaign-1",
+      sourceId: "missing-character",
+      sourceType: "character",
+    });
   });
 
   it("returns a useful validation error for invalid roster source types", async () => {

--- a/apps/api/src/routes/scenarios.test.ts
+++ b/apps/api/src/routes/scenarios.test.ts
@@ -289,7 +289,10 @@ describe("scenarios route contract", () => {
     await app.close();
 
     expect(response.statusCode).toBe(404);
-    expect(response.json()).toEqual({ error: "Campaign not found." });
+    expect(response.json()).toEqual({
+      code: "CAMPAIGN_NOT_FOUND",
+      error: "Campaign not found.",
+    });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).not.toHaveBeenCalled();
   });
 
@@ -336,7 +339,10 @@ describe("scenarios route contract", () => {
     await app.close();
 
     expect(response.statusCode).toBe(400);
-    expect(response.json().error).toContain("Invalid enum value");
+    expect(response.json()).toMatchObject({
+      code: "INVALID_ROSTER_SOURCE_TYPE",
+      error: "Invalid roster source type. Expected character, reusableEntity, or template.",
+    });
     expect(mocks.campaignService.removeCampaignRosterEntryBySource).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/routes/scenarios/campaignRoutes.ts
+++ b/apps/api/src/routes/scenarios/campaignRoutes.ts
@@ -25,6 +25,26 @@ import {
 const campaignService = new CampaignService();
 const scenarioService = new ScenarioService();
 
+async function removeCampaignRosterMembershipBySource(input: {
+  campaignId: string;
+  sourceId: string;
+  sourceType: unknown;
+  userId: string;
+}): Promise<void> {
+  const sourceType = campaignRosterSourceTypeSchema.parse(input.sourceType);
+  const campaign = await campaignService.getCampaignById(input.campaignId);
+
+  if (!campaign || campaign.gmUserId !== input.userId) {
+    throw new Error("Campaign not found.");
+  }
+
+  await campaignService.removeCampaignRosterEntryBySource({
+    campaignId: input.campaignId,
+    sourceId: input.sourceId,
+    sourceType
+  });
+}
+
 export const campaignRoutes: FastifyPluginAsync = async (app) => {
   app.get("/campaigns", async (request, reply) => {
     const user = await requireAdminUser(request, reply);
@@ -333,6 +353,43 @@ export const campaignRoutes: FastifyPluginAsync = async (app) => {
     }
   });
 
+  app.delete("/campaigns/:campaignId/roster-membership/:sourceType/:sourceId", async (request, reply) => {
+    const user = await requireAdminUser(request, reply);
+
+    if (!user) {
+      return;
+    }
+
+    try {
+      const campaignId = parseId(request.params, "campaignId", "Campaign id");
+      const params =
+        request.params && typeof request.params === "object"
+          ? (request.params as Record<string, unknown>)
+          : {};
+      const sourceId = parseRequiredString(params, "sourceId");
+
+      await removeCampaignRosterMembershipBySource({
+        campaignId,
+        sourceId,
+        sourceType: params.sourceType,
+        userId: user.id
+      });
+
+      return { ok: true };
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message === "Campaign not found."
+          ? "Campaign not found."
+          : error instanceof Error
+            ? error.message
+            : "Unable to remove campaign roster membership.";
+
+      return reply.code(message === "Campaign not found." ? 404 : 400).send({
+        error: message
+      });
+    }
+  });
+
   app.get("/campaigns/:campaignId/entities", async (request, reply) => {
     const user = await requireAdminUser(request, reply);
 
@@ -374,25 +431,25 @@ export const campaignRoutes: FastifyPluginAsync = async (app) => {
           ? (request.query as Record<string, unknown>)
           : {};
       const sourceId = parseRequiredString(query, "sourceId");
-      const sourceType = campaignRosterSourceTypeSchema.parse(query.sourceType);
-      const campaign = await campaignService.getCampaignById(campaignId);
 
-      if (!campaign || campaign.gmUserId !== user.id) {
-        return reply.code(404).send({
-          error: "Campaign not found."
-        });
-      }
-
-      await campaignService.removeCampaignRosterEntryBySource({
+      await removeCampaignRosterMembershipBySource({
         campaignId,
         sourceId,
-        sourceType
+        sourceType: query.sourceType,
+        userId: user.id
       });
 
       return { ok: true };
     } catch (error) {
-      return reply.code(400).send({
-        error: error instanceof Error ? error.message : "Unable to remove campaign roster membership."
+      const message =
+        error instanceof Error && error.message === "Campaign not found."
+          ? "Campaign not found."
+          : error instanceof Error
+            ? error.message
+            : "Unable to remove campaign roster membership.";
+
+      return reply.code(message === "Campaign not found." ? 404 : 400).send({
+        error: message
       });
     }
   });

--- a/apps/api/src/routes/scenarios/campaignRoutes.ts
+++ b/apps/api/src/routes/scenarios/campaignRoutes.ts
@@ -89,7 +89,7 @@ async function removeCampaignRosterMembershipBySource(input: {
   sourceId: string;
   sourceType: unknown;
   userId: string;
-}): Promise<void> {
+}): Promise<{ removed: boolean }> {
   const sourceType = parseCampaignRosterSourceType(input.sourceType);
   const campaign = await campaignService.getCampaignById(input.campaignId);
 
@@ -97,7 +97,7 @@ async function removeCampaignRosterMembershipBySource(input: {
     throw new Error("Campaign not found.");
   }
 
-  await campaignService.removeCampaignRosterEntryBySource({
+  return campaignService.removeCampaignRosterEntryBySource({
     campaignId: input.campaignId,
     sourceId: input.sourceId,
     sourceType
@@ -427,14 +427,14 @@ export const campaignRoutes: FastifyPluginAsync = async (app) => {
           : {};
       const sourceId = parseRequiredString(params, "sourceId");
 
-      await removeCampaignRosterMembershipBySource({
+      const result = await removeCampaignRosterMembershipBySource({
         campaignId,
         sourceId,
         sourceType: params.sourceType,
         userId: user.id
       });
 
-      return { ok: true };
+      return { ok: true, removed: result.removed };
     } catch (error) {
       const { payload, status } = buildRosterRouteErrorPayload(error);
 
@@ -484,14 +484,14 @@ export const campaignRoutes: FastifyPluginAsync = async (app) => {
           : {};
       const sourceId = parseRequiredString(query, "sourceId");
 
-      await removeCampaignRosterMembershipBySource({
+      const result = await removeCampaignRosterMembershipBySource({
         campaignId,
         sourceId,
         sourceType: query.sourceType,
         userId: user.id
       });
 
-      return { ok: true };
+      return { ok: true, removed: result.removed };
     } catch (error) {
       const { payload, status } = buildRosterRouteErrorPayload(error);
 

--- a/apps/api/src/routes/scenarios/campaignRoutes.ts
+++ b/apps/api/src/routes/scenarios/campaignRoutes.ts
@@ -51,12 +51,31 @@ function parseCampaignRosterSourceType(value: unknown) {
   return parsed.data;
 }
 
-function buildRosterRouteErrorPayload(error: unknown) {
+function buildRosterRouteErrorPayload(
+  error: unknown,
+  context?: {
+    campaignId?: unknown;
+    route?: string;
+    sourceId?: unknown;
+    sourceType?: unknown;
+  }
+) {
+  const diagnosticDetails = {
+    campaignId: context?.campaignId,
+    causeMessage: error instanceof Error ? error.message : String(error),
+    causeName: error instanceof Error ? error.name : typeof error,
+    route: context?.route,
+    sourceId: context?.sourceId,
+    sourceType: context?.sourceType,
+  };
+
   if (error instanceof Error && error.message === "Campaign not found.") {
     return {
       payload: {
         code: "CAMPAIGN_NOT_FOUND",
-        error: "Campaign not found."
+        details: diagnosticDetails,
+        error: "Campaign not found.",
+        route: context?.route,
       },
       status: 404
     };
@@ -68,8 +87,12 @@ function buildRosterRouteErrorPayload(error: unknown) {
     return {
       payload: {
         code: routeError.code ?? "CAMPAIGN_ROSTER_REMOVE_FAILED",
-        details: routeError.details,
-        error: routeError.message
+        details: {
+          ...diagnosticDetails,
+          validation: routeError.details,
+        },
+        error: routeError.message,
+        route: context?.route,
       },
       status: 400
     };
@@ -78,7 +101,9 @@ function buildRosterRouteErrorPayload(error: unknown) {
   return {
     payload: {
       code: "CAMPAIGN_ROSTER_REMOVE_FAILED",
-      error: "Unable to remove campaign roster membership."
+      details: diagnosticDetails,
+      error: "Unable to remove campaign roster membership.",
+      route: context?.route,
     },
     status: 400
   };
@@ -419,12 +444,19 @@ export const campaignRoutes: FastifyPluginAsync = async (app) => {
       return;
     }
 
+    const params =
+      request.params && typeof request.params === "object"
+        ? (request.params as Record<string, unknown>)
+        : {};
+    const context = {
+      campaignId: params.campaignId,
+      route: "source-key",
+      sourceId: params.sourceId,
+      sourceType: params.sourceType,
+    };
+
     try {
       const campaignId = parseId(request.params, "campaignId", "Campaign id");
-      const params =
-        request.params && typeof request.params === "object"
-          ? (request.params as Record<string, unknown>)
-          : {};
       const sourceId = parseRequiredString(params, "sourceId");
 
       const result = await removeCampaignRosterMembershipBySource({
@@ -434,9 +466,19 @@ export const campaignRoutes: FastifyPluginAsync = async (app) => {
         userId: user.id
       });
 
-      return { ok: true, removed: result.removed };
+      return { ok: true, removed: result.removed, route: "source-key" };
     } catch (error) {
-      const { payload, status } = buildRosterRouteErrorPayload(error);
+      request.log.error(
+        {
+          campaignId: context.campaignId,
+          err: error,
+          route: context.route,
+          sourceId: context.sourceId,
+          sourceType: context.sourceType,
+        },
+        "remove roster membership failed"
+      );
+      const { payload, status } = buildRosterRouteErrorPayload(error, context);
 
       return reply.code(status).send(payload);
     }
@@ -491,9 +533,21 @@ export const campaignRoutes: FastifyPluginAsync = async (app) => {
         userId: user.id
       });
 
-      return { ok: true, removed: result.removed };
+      return { ok: true, removed: result.removed, route: "source-query" };
     } catch (error) {
-      const { payload, status } = buildRosterRouteErrorPayload(error);
+      const query =
+        request.query && typeof request.query === "object"
+          ? (request.query as Record<string, unknown>)
+          : {};
+      const { payload, status } = buildRosterRouteErrorPayload(error, {
+        campaignId:
+          request.params && typeof request.params === "object"
+            ? (request.params as Record<string, unknown>).campaignId
+            : undefined,
+        route: "source-query",
+        sourceId: query.sourceId,
+        sourceType: query.sourceType,
+      });
 
       return reply.code(status).send(payload);
     }

--- a/apps/api/src/routes/scenarios/campaignRoutes.ts
+++ b/apps/api/src/routes/scenarios/campaignRoutes.ts
@@ -360,6 +360,43 @@ export const campaignRoutes: FastifyPluginAsync = async (app) => {
     }
   });
 
+  app.delete("/campaigns/:campaignId/roster-membership", async (request, reply) => {
+    const user = await requireAdminUser(request, reply);
+
+    if (!user) {
+      return;
+    }
+
+    try {
+      const campaignId = parseId(request.params, "campaignId", "Campaign id");
+      const query =
+        request.query && typeof request.query === "object"
+          ? (request.query as Record<string, unknown>)
+          : {};
+      const sourceId = parseRequiredString(query, "sourceId");
+      const sourceType = campaignRosterSourceTypeSchema.parse(query.sourceType);
+      const campaign = await campaignService.getCampaignById(campaignId);
+
+      if (!campaign || campaign.gmUserId !== user.id) {
+        return reply.code(404).send({
+          error: "Campaign not found."
+        });
+      }
+
+      await campaignService.removeCampaignRosterEntryBySource({
+        campaignId,
+        sourceId,
+        sourceType
+      });
+
+      return { ok: true };
+    } catch (error) {
+      return reply.code(400).send({
+        error: error instanceof Error ? error.message : "Unable to remove campaign roster membership."
+      });
+    }
+  });
+
   app.post("/campaigns/:campaignId/entities", async (request, reply) => {
     const user = await requireAdminUser(request, reply);
 

--- a/apps/api/src/routes/scenarios/campaignRoutes.ts
+++ b/apps/api/src/routes/scenarios/campaignRoutes.ts
@@ -25,13 +25,72 @@ import {
 const campaignService = new CampaignService();
 const scenarioService = new ScenarioService();
 
+interface RouteError extends Error {
+  code?: string;
+  details?: unknown;
+}
+
+function createRosterRouteError(message: string, code: string, details?: unknown): RouteError {
+  const error = new Error(message) as RouteError;
+  error.code = code;
+  error.details = details;
+  return error;
+}
+
+function parseCampaignRosterSourceType(value: unknown) {
+  const parsed = campaignRosterSourceTypeSchema.safeParse(value);
+
+  if (!parsed.success) {
+    throw createRosterRouteError(
+      "Invalid roster source type. Expected character, reusableEntity, or template.",
+      "INVALID_ROSTER_SOURCE_TYPE",
+      parsed.error.issues
+    );
+  }
+
+  return parsed.data;
+}
+
+function buildRosterRouteErrorPayload(error: unknown) {
+  if (error instanceof Error && error.message === "Campaign not found.") {
+    return {
+      payload: {
+        code: "CAMPAIGN_NOT_FOUND",
+        error: "Campaign not found."
+      },
+      status: 404
+    };
+  }
+
+  if (error instanceof Error) {
+    const routeError = error as RouteError;
+
+    return {
+      payload: {
+        code: routeError.code ?? "CAMPAIGN_ROSTER_REMOVE_FAILED",
+        details: routeError.details,
+        error: routeError.message
+      },
+      status: 400
+    };
+  }
+
+  return {
+    payload: {
+      code: "CAMPAIGN_ROSTER_REMOVE_FAILED",
+      error: "Unable to remove campaign roster membership."
+    },
+    status: 400
+  };
+}
+
 async function removeCampaignRosterMembershipBySource(input: {
   campaignId: string;
   sourceId: string;
   sourceType: unknown;
   userId: string;
 }): Promise<void> {
-  const sourceType = campaignRosterSourceTypeSchema.parse(input.sourceType);
+  const sourceType = parseCampaignRosterSourceType(input.sourceType);
   const campaign = await campaignService.getCampaignById(input.campaignId);
 
   if (!campaign || campaign.gmUserId !== input.userId) {
@@ -377,16 +436,9 @@ export const campaignRoutes: FastifyPluginAsync = async (app) => {
 
       return { ok: true };
     } catch (error) {
-      const message =
-        error instanceof Error && error.message === "Campaign not found."
-          ? "Campaign not found."
-          : error instanceof Error
-            ? error.message
-            : "Unable to remove campaign roster membership.";
+      const { payload, status } = buildRosterRouteErrorPayload(error);
 
-      return reply.code(message === "Campaign not found." ? 404 : 400).send({
-        error: message
-      });
+      return reply.code(status).send(payload);
     }
   });
 
@@ -441,16 +493,9 @@ export const campaignRoutes: FastifyPluginAsync = async (app) => {
 
       return { ok: true };
     } catch (error) {
-      const message =
-        error instanceof Error && error.message === "Campaign not found."
-          ? "Campaign not found."
-          : error instanceof Error
-            ? error.message
-            : "Unable to remove campaign roster membership.";
+      const { payload, status } = buildRosterRouteErrorPayload(error);
 
-      return reply.code(message === "Campaign not found." ? 404 : 400).send({
-        error: message
-      });
+      return reply.code(status).send(payload);
     }
   });
 

--- a/apps/api/src/routes/scenarios/participantRoutes.ts
+++ b/apps/api/src/routes/scenarios/participantRoutes.ts
@@ -88,12 +88,6 @@ export const participantRoutes: FastifyPluginAsync = async (app) => {
         });
       }
 
-      if (!isGameMaster && !campaign.settings.allowPlayerSelfJoin) {
-        return reply.code(403).send({
-          error: "Player self-join is not enabled for this campaign."
-        });
-      }
-
       if (!canEditCharacterInApi(user)) {
         const character = await characterService.getOwnedCharacter(user.id, characterId);
 
@@ -104,16 +98,39 @@ export const participantRoutes: FastifyPluginAsync = async (app) => {
         }
       }
 
+      if (!isGameMaster) {
+        if (scenario.status !== "live") {
+          return reply.code(403).send({
+            error: "No live scenario is currently available for this character."
+          });
+        }
+
+        const campaignRoster = await campaignService.listCampaignRosterEntries(campaign.id);
+        const characterIsInCampaignRoster = campaignRoster.some(
+          (entry) => entry.sourceType === "character" && entry.sourceId === characterId
+        );
+
+        if (!characterIsInCampaignRoster) {
+          return reply.code(403).send({
+            error: "This character is not currently assigned to a campaign."
+          });
+        }
+      }
+
       const participant = await scenarioService.addCharacterParticipant({
         characterId,
-        controlledByUserId: parseOptionalNullableString(body, "controlledByUserId") ?? user.id,
+        controlledByUserId: isGameMaster
+          ? parseOptionalNullableString(body, "controlledByUserId") ?? user.id
+          : user.id,
         displayOrder: parseOptionalInteger(body, "displayOrder"),
         factionId: parseOptionalNullableString(body, "factionId"),
         joinSource:
           body.joinSource == null
             ? "gm_added"
             : scenarioParticipantJoinSourceSchema.parse(body.joinSource),
-        role: body.role == null ? undefined : scenarioParticipantRoleSchema.parse(body.role),
+        role: isGameMaster
+          ? body.role == null ? undefined : scenarioParticipantRoleSchema.parse(body.role)
+          : "player_character",
         roleTag: parseOptionalNullableString(body, "roleTag"),
         scenarioId,
         tacticalGroupId: parseOptionalNullableString(body, "tacticalGroupId")

--- a/apps/api/src/routes/scenarios/scenarioRoutes.ts
+++ b/apps/api/src/routes/scenarios/scenarioRoutes.ts
@@ -29,12 +29,17 @@ export const scenarioRoutes: FastifyPluginAsync = async (app) => {
     }
 
     try {
+      const query = request.query && typeof request.query === "object"
+        ? (request.query as Record<string, unknown>)
+        : {};
+      const characterId = parseOptionalString(query, "characterId");
       const isGameMaster = user.roles.includes("game_master") || user.roles.includes("admin");
-      const campaigns = isGameMaster
-        ? user.roles.includes("admin")
-          ? await campaignService.listCampaignsAllowingPlayerSelfJoin()
-          : await campaignService.listCampaignsByGameMaster(user.id)
-        : await campaignService.listCampaignsAllowingPlayerSelfJoin();
+
+      const campaigns = characterId
+        ? await campaignService.listCampaignsByCharacterRosterAccess(characterId)
+        : isGameMaster
+          ? await campaignService.listCampaignsByGameMaster(user.id)
+          : [];
 
       const scenarioGroups = await Promise.all(
         campaigns.map(async (campaign) => ({
@@ -45,7 +50,7 @@ export const scenarioRoutes: FastifyPluginAsync = async (app) => {
 
       const joinableScenarios = scenarioGroups.flatMap(({ campaign, scenarios }) =>
         scenarios
-          .filter((scenario) => scenario.status !== "archived" && scenario.status !== "completed")
+          .filter((scenario) => scenario.status === "live")
           .map((scenario) => ({
             campaignId: campaign.id,
             campaignName: campaign.name,

--- a/apps/web/app/(app)/campaigns/CampaignsPageContent.test.ts
+++ b/apps/web/app/(app)/campaigns/CampaignsPageContent.test.ts
@@ -17,7 +17,9 @@ describe("CampaignsPageContent player campaign listing", () => {
     expect(source).toContain("Choose an available campaign to continue your story.");
     expect(source).toContain("No active scenario is currently available.");
     expect(source).toContain("canManageCampaigns ? (");
-    expect(source).toContain("Player self-join:");
+    expect(source).not.toContain("Allow player self-join");
+    expect(source).not.toContain("Player self-join:");
+    expect(source).not.toContain("setAllowPlayerSelfJoin");
     expect(source).not.toContain("Accessible scenarios:");
   });
 });

--- a/apps/web/app/(app)/campaigns/CampaignsPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/CampaignsPageContent.tsx
@@ -19,7 +19,6 @@ export default function CampaignsPageContent() {
   const [loading, setLoading] = useState(true);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [allowPlayerSelfJoin, setAllowPlayerSelfJoin] = useState(false);
   const canManageCampaigns = canManageCampaignWorkspace(currentUser);
 
   async function refreshCampaigns() {
@@ -48,7 +47,7 @@ export default function CampaignsPageContent() {
         description,
         name,
         settings: {
-          allowPlayerSelfJoin,
+          allowPlayerSelfJoin: false,
           defaultVisibility: "hidden"
         },
         status: "draft"
@@ -57,7 +56,6 @@ export default function CampaignsPageContent() {
       setFeedback(`Created campaign ${campaign.name}.`);
       setName("");
       setDescription("");
-      setAllowPlayerSelfJoin(false);
       await refreshCampaigns();
     } catch (caughtError) {
       setError(caughtError instanceof Error ? caughtError.message : "Unable to create campaign.");
@@ -97,14 +95,6 @@ export default function CampaignsPageContent() {
             rows={3}
             value={description}
           />
-          <label style={{ alignItems: "center", display: "flex", gap: "0.5rem" }}>
-            <input
-              checked={allowPlayerSelfJoin}
-              onChange={(event) => setAllowPlayerSelfJoin(event.target.checked)}
-              type="checkbox"
-            />
-            Allow player self-join
-          </label>
           <div>
             <button onClick={() => void handleCreateCampaign()} type="button">
               Create campaign
@@ -136,9 +126,6 @@ export default function CampaignsPageContent() {
               {canManageCampaigns ? (
                 <>
                   <div>Status: {campaign.status}</div>
-                  <div>
-                    Player self-join: {campaign.settings.allowPlayerSelfJoin ? "Enabled" : "Disabled"}
-                  </div>
                 </>
               ) : scenarios.length > 0 ? (
                 <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.component.test.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.component.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Campaign, CampaignRosterEntry, Scenario } from "@glantri/domain";
+import type { ServerCharacterRecord } from "@/lib/api/localServiceClient";
+
+const mocks = vi.hoisted(() => ({
+  addCampaignRosterEntryOnServer: vi.fn(),
+  createCampaignAssetOnServer: vi.fn(),
+  createScenarioOnServer: vi.fn(),
+  loadCampaignAssets: vi.fn(),
+  loadCampaignById: vi.fn(),
+  loadCampaignEntities: vi.fn(),
+  loadCampaigns: vi.fn(),
+  loadCampaignRoster: vi.fn(),
+  loadCampaignScenarioRelationships: vi.fn(),
+  loadCampaignScenarios: vi.fn(),
+  loadServerCharacters: vi.fn(),
+  loadTemplates: vi.fn(),
+  removeCampaignRosterEntryOnServer: vi.fn(),
+  updateCampaignAssetVisibilityOnServer: vi.fn(),
+}));
+
+vi.mock("@/lib/api/localServiceClient", () => ({
+  addCampaignRosterEntryOnServer: mocks.addCampaignRosterEntryOnServer,
+  createCampaignAssetOnServer: mocks.createCampaignAssetOnServer,
+  createScenarioOnServer: mocks.createScenarioOnServer,
+  loadCampaignAssets: mocks.loadCampaignAssets,
+  loadCampaignById: mocks.loadCampaignById,
+  loadCampaignEntities: mocks.loadCampaignEntities,
+  loadCampaigns: mocks.loadCampaigns,
+  loadCampaignRoster: mocks.loadCampaignRoster,
+  loadCampaignScenarioRelationships: mocks.loadCampaignScenarioRelationships,
+  loadCampaignScenarios: mocks.loadCampaignScenarios,
+  loadServerCharacters: mocks.loadServerCharacters,
+  loadTemplates: mocks.loadTemplates,
+  removeCampaignRosterEntryOnServer: mocks.removeCampaignRosterEntryOnServer,
+  updateCampaignAssetVisibilityOnServer: mocks.updateCampaignAssetVisibilityOnServer,
+}));
+
+async function importCampaignDetailPageContent() {
+  const mod = await import("./CampaignDetailPageContent");
+  return mod.default;
+}
+
+const campaign: Campaign = {
+  createdAt: "2026-05-01T00:00:00.000Z",
+  description: "Campaign description",
+  gmUserId: "gm-1",
+  id: "campaign-1",
+  name: "Border Trouble",
+  settings: {
+    allowPlayerSelfJoin: false,
+    defaultVisibility: "hidden",
+  },
+  slug: "border-trouble",
+  status: "active",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+};
+
+const rosterEntry: CampaignRosterEntry = {
+  campaignId: "campaign-1",
+  category: "pc",
+  createdAt: "2026-05-01T00:00:00.000Z",
+  id: "roster-1",
+  labelSnapshot: "Ari",
+  sourceId: "character-1",
+  sourceType: "character",
+  updatedAt: "2026-05-01T00:00:00.000Z",
+};
+
+const character = {
+  build: {
+    name: "Ari",
+    professionId: "fighter",
+    progression: {
+      skillGroups: [],
+    },
+    societyId: "thyatis",
+  },
+  createdAt: "2026-05-01T00:00:00.000Z",
+  id: "character-1",
+  level: 1,
+  name: "Ari",
+  owner: {
+    displayName: "Player One",
+    email: "player@example.test",
+    id: "player-1",
+  },
+  updatedAt: "2026-05-01T00:00:00.000Z",
+} as unknown as ServerCharacterRecord;
+
+describe("CampaignDetailPageContent roster membership interaction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadCampaignById.mockResolvedValue(campaign);
+    mocks.loadCampaignScenarios.mockResolvedValue([] satisfies Scenario[]);
+    mocks.loadCampaignEntities.mockResolvedValue([]);
+    mocks.loadCampaignAssets.mockResolvedValue([]);
+    mocks.loadTemplates.mockResolvedValue([]);
+    mocks.loadCampaignScenarioRelationships.mockResolvedValue([]);
+    mocks.loadCampaigns.mockResolvedValue([campaign]);
+    mocks.loadServerCharacters.mockResolvedValue([character]);
+    mocks.removeCampaignRosterEntryOnServer.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("unchecking a member calls roster removal with source identity, not roster entry id", async () => {
+    let roster = [rosterEntry];
+    mocks.loadCampaignRoster.mockImplementation(async () => roster);
+    mocks.removeCampaignRosterEntryOnServer.mockImplementation(async () => {
+      roster = [];
+    });
+    const CampaignDetailPageContent = await importCampaignDetailPageContent();
+    const user = userEvent.setup();
+
+    render(<CampaignDetailPageContent campaignId="campaign-1" />);
+
+    const memberCheckbox = await screen.findByRole("checkbox", {
+      name: "Toggle Ari campaign roster membership",
+    });
+    expect(memberCheckbox).toBeChecked();
+
+    await user.click(memberCheckbox);
+
+    await waitFor(() => {
+      expect(mocks.removeCampaignRosterEntryOnServer).toHaveBeenCalledWith({
+        campaignId: "campaign-1",
+        sourceId: "character-1",
+        sourceType: "character",
+      });
+    });
+    expect(mocks.removeCampaignRosterEntryOnServer).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        rosterEntryId: "roster-1",
+      }),
+    );
+  });
+});

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.component.test.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.component.test.tsx
@@ -140,4 +140,31 @@ describe("CampaignDetailPageContent roster membership interaction", () => {
       }),
     );
   });
+
+  it("prefers the stored roster entry source key when removing an existing membership", async () => {
+    const { getRosterRemovalSource } = await import("./CampaignDetailPageContent");
+
+    expect(
+      getRosterRemovalSource({
+        rosterEntry: {
+          sourceId: "stored-character-id",
+          sourceType: "character",
+        },
+        sourceId: "candidate-character-id",
+        sourceType: "character",
+      }),
+    ).toEqual({
+      sourceId: "stored-character-id",
+      sourceType: "character",
+    });
+    expect(
+      getRosterRemovalSource({
+        sourceId: "candidate-character-id",
+        sourceType: "character",
+      }),
+    ).toEqual({
+      sourceId: "candidate-character-id",
+      sourceType: "character",
+    });
+  });
 });

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.test.ts
@@ -46,6 +46,8 @@ describe("CampaignDetailPageContent roster UI", () => {
     expect(source).toContain("Civilization</th>");
     expect(source).toContain("Profession</th>");
     expect(source).toContain("Owner</th>");
+    expect(source).toContain("Action</th>");
+    expect(source).toContain("Remove");
     expect(source).not.toContain("Skill groups</th>");
     expect(source).not.toContain("Source</th>");
     expect(source).not.toContain("Character · Owner:");
@@ -73,9 +75,14 @@ describe("CampaignDetailPageContent roster UI", () => {
     );
   });
 
-  it("does not show combat status on the campaign-level scenario list", () => {
+  it("does not expose scenario kind or combat status on the campaign-level scenario UI", () => {
     const source = readCampaignDetailSource();
 
+    expect(source).toContain('kind: "mixed"');
+    expect(source).not.toContain("setScenarioKind");
+    expect(source).not.toContain('<option value="combat">Combat</option>');
+    expect(source).not.toContain(">Kind</th>");
+    expect(source).not.toContain("scenario.kind}</td>");
     expect(source).not.toContain(">Combat</th>");
     expect(source).not.toContain("scenario.liveState?.combatStatus");
     expect(source).toContain(">Scenario</th>");

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.test.ts
@@ -60,4 +60,27 @@ describe("CampaignDetailPageContent roster UI", () => {
     expect(source).toContain("civilizationNamesBySocietyId");
     expect(source).toContain('return "—";');
   });
+
+  it("removes roster membership locally by entry and source so filters do not stay stale", () => {
+    const source = readCampaignDetailSource();
+
+    expect(source).toContain("function removeRosterEntryFromList");
+    expect(source).toContain("entry.id === removedEntry.id");
+    expect(source).toContain("entry.campaignId === removedEntry.campaignId");
+    expect(source).toContain("setRoster((current) => removeRosterEntryFromList(current, rosterEntry))");
+    expect(source).toContain(
+      "setAllRosterEntries((current) => removeRosterEntryFromList(current, rosterEntry))"
+    );
+  });
+
+  it("does not show combat status on the campaign-level scenario list", () => {
+    const source = readCampaignDetailSource();
+
+    expect(source).not.toContain(">Combat</th>");
+    expect(source).not.toContain("scenario.liveState?.combatStatus");
+    expect(source).toContain(">Scenario</th>");
+    expect(source).toContain(">Status</th>");
+    expect(source).toContain(">Follows</th>");
+    expect(source).toContain(">Action</th>");
+  });
 });

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.test.ts
@@ -46,8 +46,7 @@ describe("CampaignDetailPageContent roster UI", () => {
     expect(source).toContain("Civilization</th>");
     expect(source).toContain("Profession</th>");
     expect(source).toContain("Owner</th>");
-    expect(source).toContain("Action</th>");
-    expect(source).toContain("Remove");
+    expect(source).not.toContain(">Remove<");
     expect(source).not.toContain("Skill groups</th>");
     expect(source).not.toContain("Source</th>");
     expect(source).not.toContain("Character · Owner:");
@@ -63,16 +62,15 @@ describe("CampaignDetailPageContent roster UI", () => {
     expect(source).toContain('return "—";');
   });
 
-  it("removes roster membership locally by entry and source so filters do not stay stale", () => {
+  it("removes roster membership locally by source so filters do not stay stale", () => {
     const source = readCampaignDetailSource();
 
-    expect(source).toContain("function removeRosterEntryFromList");
-    expect(source).toContain("entry.id === removedEntry.id");
-    expect(source).toContain("entry.campaignId === removedEntry.campaignId");
-    expect(source).toContain("setRoster((current) => removeRosterEntryFromList(current, rosterEntry))");
-    expect(source).toContain(
-      "setAllRosterEntries((current) => removeRosterEntryFromList(current, rosterEntry))"
-    );
+    expect(source).toContain("function removeRosterSourceFromList");
+    expect(source).toContain("entry.campaignId === removedSource.campaignId");
+    expect(source).toContain("sourceId: candidate.sourceId");
+    expect(source).toContain("sourceType: candidate.sourceType");
+    expect(source).toContain("setRoster((current) =>");
+    expect(source).toContain("setAllRosterEntries((current) =>");
   });
 
   it("does not expose scenario kind or combat status on the campaign-level scenario UI", () => {

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.tsx
@@ -82,19 +82,15 @@ function buildRosterSourceKey(sourceType: CampaignRosterEntry["sourceType"], sou
   return `${sourceType}:${sourceId}`;
 }
 
-function removeRosterEntryFromList(
+function removeRosterSourceFromList(
   entries: CampaignRosterEntry[],
-  removedEntry: CampaignRosterEntry
+  removedSource: Pick<CampaignRosterEntry, "campaignId" | "sourceId" | "sourceType">
 ): CampaignRosterEntry[] {
-  const removedSourceKey = buildRosterSourceKey(removedEntry.sourceType, removedEntry.sourceId);
+  const removedSourceKey = buildRosterSourceKey(removedSource.sourceType, removedSource.sourceId);
 
   return entries.filter((entry) => {
-    if (entry.id === removedEntry.id) {
-      return false;
-    }
-
     return !(
-      entry.campaignId === removedEntry.campaignId &&
+      entry.campaignId === removedSource.campaignId &&
       buildRosterSourceKey(entry.sourceType, entry.sourceId) === removedSourceKey
     );
   });
@@ -487,12 +483,25 @@ export default function CampaignDetailPageContent({
 
         await removeCampaignRosterEntryOnServer({
           campaignId,
-          rosterEntryId: rosterEntry.id
+          sourceId: candidate.sourceId,
+          sourceType: candidate.sourceType
         });
 
         setFeedback(`Removed ${candidate.name} from the campaign roster.`);
-        setRoster((current) => removeRosterEntryFromList(current, rosterEntry));
-        setAllRosterEntries((current) => removeRosterEntryFromList(current, rosterEntry));
+        setRoster((current) =>
+          removeRosterSourceFromList(current, {
+            campaignId,
+            sourceId: candidate.sourceId,
+            sourceType: candidate.sourceType
+          })
+        );
+        setAllRosterEntries((current) =>
+          removeRosterSourceFromList(current, {
+            campaignId,
+            sourceId: candidate.sourceId,
+            sourceType: candidate.sourceType
+          })
+        );
       }
       await refreshPage();
     } catch (caughtError) {
@@ -678,8 +687,7 @@ export default function CampaignDetailPageContent({
                   <th style={{ background: "#fff", padding: "0.5rem 0.75rem", position: "sticky", top: 0 }}>Type</th>
                   <th style={{ background: "#fff", padding: "0.5rem 0.75rem", position: "sticky", top: 0 }}>Civilization</th>
                   <th style={{ background: "#fff", padding: "0.5rem 0.75rem", position: "sticky", top: 0 }}>Profession</th>
-                  <th style={{ background: "#fff", padding: "0.5rem 0.75rem", position: "sticky", top: 0 }}>Owner</th>
-                  <th style={{ background: "#fff", padding: "0.5rem 0", position: "sticky", top: 0 }}>Action</th>
+                  <th style={{ background: "#fff", padding: "0.5rem 0", position: "sticky", top: 0 }}>Owner</th>
                 </tr>
               </thead>
               <tbody>
@@ -704,19 +712,7 @@ export default function CampaignDetailPageContent({
                     <td style={{ padding: "0.6rem 0.75rem" }}>{candidate.typeLabel}</td>
                     <td style={{ padding: "0.6rem 0.75rem" }}>{candidate.civilizationLabel}</td>
                     <td style={{ padding: "0.6rem 0.75rem" }}>{candidate.professionLabel}</td>
-                    <td style={{ padding: "0.6rem 0.75rem" }}>{candidate.ownerLabel}</td>
-                    <td style={{ padding: "0.6rem 0" }}>
-                      {candidate.member ? (
-                        <button
-                          onClick={() => void handleRosterMembershipToggle(candidate, false)}
-                          type="button"
-                        >
-                          Remove
-                        </button>
-                      ) : (
-                        "—"
-                      )}
-                    </td>
+                    <td style={{ padding: "0.6rem 0" }}>{candidate.ownerLabel}</td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.tsx
@@ -199,7 +199,6 @@ export default function CampaignDetailPageContent({
 
   const [scenarioName, setScenarioName] = useState("");
   const [scenarioDescription, setScenarioDescription] = useState("");
-  const [scenarioKind, setScenarioKind] = useState<Scenario["kind"]>("mixed");
   const [continuesFromScenarioId, setContinuesFromScenarioId] = useState("");
 
   const [assetTitle, setAssetTitle] = useState("");
@@ -440,7 +439,7 @@ export default function CampaignDetailPageContent({
         campaignId,
         continuesFromScenarioId: continuesFromScenarioId || undefined,
         description: scenarioDescription,
-        kind: scenarioKind,
+        kind: "mixed",
         name: scenarioName,
         status: "draft"
       });
@@ -679,7 +678,8 @@ export default function CampaignDetailPageContent({
                   <th style={{ background: "#fff", padding: "0.5rem 0.75rem", position: "sticky", top: 0 }}>Type</th>
                   <th style={{ background: "#fff", padding: "0.5rem 0.75rem", position: "sticky", top: 0 }}>Civilization</th>
                   <th style={{ background: "#fff", padding: "0.5rem 0.75rem", position: "sticky", top: 0 }}>Profession</th>
-                  <th style={{ background: "#fff", padding: "0.5rem 0", position: "sticky", top: 0 }}>Owner</th>
+                  <th style={{ background: "#fff", padding: "0.5rem 0.75rem", position: "sticky", top: 0 }}>Owner</th>
+                  <th style={{ background: "#fff", padding: "0.5rem 0", position: "sticky", top: 0 }}>Action</th>
                 </tr>
               </thead>
               <tbody>
@@ -704,7 +704,19 @@ export default function CampaignDetailPageContent({
                     <td style={{ padding: "0.6rem 0.75rem" }}>{candidate.typeLabel}</td>
                     <td style={{ padding: "0.6rem 0.75rem" }}>{candidate.civilizationLabel}</td>
                     <td style={{ padding: "0.6rem 0.75rem" }}>{candidate.professionLabel}</td>
-                    <td style={{ padding: "0.6rem 0" }}>{candidate.ownerLabel}</td>
+                    <td style={{ padding: "0.6rem 0.75rem" }}>{candidate.ownerLabel}</td>
+                    <td style={{ padding: "0.6rem 0" }}>
+                      {candidate.member ? (
+                        <button
+                          onClick={() => void handleRosterMembershipToggle(candidate, false)}
+                          type="button"
+                        >
+                          Remove
+                        </button>
+                      ) : (
+                        "—"
+                      )}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -728,15 +740,6 @@ export default function CampaignDetailPageContent({
           rows={3}
           value={scenarioDescription}
         />
-        <select
-          onChange={(event) => setScenarioKind(event.target.value as Scenario["kind"])}
-          value={scenarioKind}
-        >
-          <option value="combat">Combat</option>
-          <option value="social">Social</option>
-          <option value="travel">Travel</option>
-          <option value="mixed">Mixed</option>
-        </select>
         <select
           onChange={(event) => setContinuesFromScenarioId(event.target.value)}
           value={continuesFromScenarioId}
@@ -769,7 +772,6 @@ export default function CampaignDetailPageContent({
               <thead>
                 <tr style={{ borderBottom: "1px solid #d9ddd8", textAlign: "left" }}>
                   <th style={{ padding: "0.5rem 0.75rem 0.5rem 0" }}>Scenario</th>
-                  <th style={{ padding: "0.5rem 0.75rem" }}>Kind</th>
                   <th style={{ padding: "0.5rem 0.75rem" }}>Status</th>
                   <th style={{ padding: "0.5rem 0.75rem" }}>Follows</th>
                   <th style={{ padding: "0.5rem 0" }}>Action</th>
@@ -786,7 +788,6 @@ export default function CampaignDetailPageContent({
                         {scenario.description || "No description yet."}
                       </div>
                     </td>
-                    <td style={{ padding: "0.6rem 0.75rem" }}>{scenario.kind}</td>
                     <td style={{ padding: "0.6rem 0.75rem" }}>{scenario.status}</td>
                     <td style={{ padding: "0.6rem 0.75rem" }}>
                       {getContinuationLabel(scenario.id)}

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.tsx
@@ -96,6 +96,17 @@ function removeRosterSourceFromList(
   });
 }
 
+export function getRosterRemovalSource(input: {
+  rosterEntry?: Pick<CampaignRosterEntry, "sourceId" | "sourceType">;
+  sourceId: string;
+  sourceType: CampaignRosterEntry["sourceType"];
+}): Pick<CampaignRosterEntry, "sourceId" | "sourceType"> {
+  return {
+    sourceId: input.rosterEntry?.sourceId ?? input.sourceId,
+    sourceType: input.rosterEntry?.sourceType ?? input.sourceType
+  };
+}
+
 function formatEntityKind(kind: ReusableEntity["kind"]): string {
   if (kind === "npc") {
     return "NPC";
@@ -481,25 +492,31 @@ export default function CampaignDetailPageContent({
           return;
         }
 
-        await removeCampaignRosterEntryOnServer({
-          campaignId,
+        const removalSource = getRosterRemovalSource({
+          rosterEntry,
           sourceId: candidate.sourceId,
           sourceType: candidate.sourceType
+        });
+
+        await removeCampaignRosterEntryOnServer({
+          campaignId,
+          sourceId: removalSource.sourceId,
+          sourceType: removalSource.sourceType
         });
 
         setFeedback(`Removed ${candidate.name} from the campaign roster.`);
         setRoster((current) =>
           removeRosterSourceFromList(current, {
             campaignId,
-            sourceId: candidate.sourceId,
-            sourceType: candidate.sourceType
+            sourceId: removalSource.sourceId,
+            sourceType: removalSource.sourceType
           })
         );
         setAllRosterEntries((current) =>
           removeRosterSourceFromList(current, {
             campaignId,
-            sourceId: candidate.sourceId,
-            sourceType: candidate.sourceType
+            sourceId: removalSource.sourceId,
+            sourceType: removalSource.sourceType
           })
         );
       }

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignDetailPageContent.tsx
@@ -82,6 +82,24 @@ function buildRosterSourceKey(sourceType: CampaignRosterEntry["sourceType"], sou
   return `${sourceType}:${sourceId}`;
 }
 
+function removeRosterEntryFromList(
+  entries: CampaignRosterEntry[],
+  removedEntry: CampaignRosterEntry
+): CampaignRosterEntry[] {
+  const removedSourceKey = buildRosterSourceKey(removedEntry.sourceType, removedEntry.sourceId);
+
+  return entries.filter((entry) => {
+    if (entry.id === removedEntry.id) {
+      return false;
+    }
+
+    return !(
+      entry.campaignId === removedEntry.campaignId &&
+      buildRosterSourceKey(entry.sourceType, entry.sourceId) === removedSourceKey
+    );
+  });
+}
+
 function formatEntityKind(kind: ReusableEntity["kind"]): string {
   if (kind === "npc") {
     return "NPC";
@@ -454,6 +472,9 @@ export default function CampaignDetailPageContent({
         setRoster((current) =>
           current.some((rosterEntry) => rosterEntry.id === entry.id) ? current : [...current, entry]
         );
+        setAllRosterEntries((current) =>
+          current.some((rosterEntry) => rosterEntry.id === entry.id) ? current : [...current, entry]
+        );
       } else {
         const rosterEntry =
           candidate.rosterEntry ??
@@ -471,7 +492,8 @@ export default function CampaignDetailPageContent({
         });
 
         setFeedback(`Removed ${candidate.name} from the campaign roster.`);
-        setRoster((current) => current.filter((entry) => entry.id !== rosterEntry.id));
+        setRoster((current) => removeRosterEntryFromList(current, rosterEntry));
+        setAllRosterEntries((current) => removeRosterEntryFromList(current, rosterEntry));
       }
       await refreshPage();
     } catch (caughtError) {
@@ -749,7 +771,6 @@ export default function CampaignDetailPageContent({
                   <th style={{ padding: "0.5rem 0.75rem 0.5rem 0" }}>Scenario</th>
                   <th style={{ padding: "0.5rem 0.75rem" }}>Kind</th>
                   <th style={{ padding: "0.5rem 0.75rem" }}>Status</th>
-                  <th style={{ padding: "0.5rem 0.75rem" }}>Combat</th>
                   <th style={{ padding: "0.5rem 0.75rem" }}>Follows</th>
                   <th style={{ padding: "0.5rem 0" }}>Action</th>
                 </tr>
@@ -767,9 +788,6 @@ export default function CampaignDetailPageContent({
                     </td>
                     <td style={{ padding: "0.6rem 0.75rem" }}>{scenario.kind}</td>
                     <td style={{ padding: "0.6rem 0.75rem" }}>{scenario.status}</td>
-                    <td style={{ padding: "0.6rem 0.75rem" }}>
-                      {scenario.liveState?.combatStatus ?? "not_started"}
-                    </td>
                     <td style={{ padding: "0.6rem 0.75rem" }}>
                       {getContinuationLabel(scenario.id)}
                     </td>

--- a/apps/web/app/(app)/characters/CharactersBrowser.test.ts
+++ b/apps/web/app/(app)/characters/CharactersBrowser.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sourcePath = join(dirname(fileURLToPath(import.meta.url)), "CharactersBrowser.tsx");
+
+function readSource(): string {
+  return readFileSync(sourcePath, "utf8");
+}
+
+describe("CharactersBrowser scenario join UI", () => {
+  it("loads joinable scenarios for the selected character instead of campaign self-join", () => {
+    const source = readSource();
+
+    expect(source).toContain("loadJoinableScenarios(characterId)");
+    expect(source).toContain("No live scenario is currently available for this character.");
+    expect(source).toContain('tab: "scenario"');
+    expect(source).not.toContain("No active scenarios are currently available from the campaign list.");
+    expect(source).not.toContain("Player self-join");
+  });
+
+  it("keeps scenario kind/status out of the join chooser labels", () => {
+    const source = readSource();
+
+    expect(source).toContain("{scenario.campaignName} - {scenario.scenarioName}");
+    expect(source).not.toContain("{scenario.kind}");
+    expect(source).not.toContain("{scenario.status}");
+  });
+});

--- a/apps/web/app/(app)/characters/CharactersBrowser.tsx
+++ b/apps/web/app/(app)/characters/CharactersBrowser.tsx
@@ -175,17 +175,23 @@ export default function CharactersBrowser() {
     }
   }
 
-  async function ensureJoinableScenarios(): Promise<JoinableScenarioOption[]> {
-    if (joinableScenarios) {
-      return joinableScenarios;
-    }
-
-    const options = (await loadJoinableScenarios()).sort((left, right) =>
+  async function loadJoinableScenariosForCharacter(characterId: string): Promise<JoinableScenarioOption[]> {
+    const options = (await loadJoinableScenarios(characterId)).sort((left, right) =>
       left.campaignName.localeCompare(right.campaignName)
     );
 
     setJoinableScenarios(options);
     return options;
+  }
+
+  function openPlayerScenario(scenario: JoinableScenarioOption) {
+    router.push(
+      buildCampaignWorkspaceHref({
+        campaignId: scenario.campaignId,
+        scenarioId: scenario.scenarioId,
+        tab: "scenario",
+      })
+    );
   }
 
   async function handleToggleJoinChooser(characterId: string) {
@@ -219,7 +225,13 @@ export default function CharactersBrowser() {
     setJoinLoading(true);
 
     try {
-      const options = await ensureJoinableScenarios();
+      const options = await loadJoinableScenariosForCharacter(characterId);
+
+      if (options.length === 1) {
+        await handleJoinScenario(characterId, options[0].scenarioId, options[0]);
+        return;
+      }
+
       setJoiningScenarioId(options[0]?.scenarioId);
     } catch (error) {
       setJoinError(error instanceof Error ? error.message : "Unable to load scenarios.");
@@ -228,15 +240,18 @@ export default function CharactersBrowser() {
     }
   }
 
-  async function handleJoinScenario(characterId: string) {
-    if (!joiningScenarioId) {
+  async function handleJoinScenario(
+    characterId: string,
+    scenarioId = joiningScenarioId,
+    scenarioOption?: JoinableScenarioOption
+  ) {
+    if (!scenarioId) {
       setJoinError("Choose a scenario first.");
       return;
     }
 
-    const selectedScenario = joinableScenarios?.find(
-      (scenario) => scenario.scenarioId === joiningScenarioId
-    );
+    const selectedScenario =
+      scenarioOption ?? joinableScenarios?.find((scenario) => scenario.scenarioId === scenarioId);
 
     if (!selectedScenario) {
       setJoinError("Selected scenario could not be found.");
@@ -261,20 +276,24 @@ export default function CharactersBrowser() {
           (currentUser.roles.includes("game_master") || currentUser.roles.includes("admin"))
       );
 
-      router.push(
-        canOpenGameMasterScenarioView
-          ? buildCampaignWorkspaceHref({
-              campaignId: selectedScenario.campaignId,
-              scenarioId: selectedScenario.scenarioId,
-              tab: "scenario",
-            })
-          : buildCampaignWorkspaceHref({
-              campaignId: selectedScenario.campaignId,
-              scenarioId: selectedScenario.scenarioId,
-              tab: "player-encounter",
-            })
-      );
+      if (canOpenGameMasterScenarioView) {
+        router.push(
+          buildCampaignWorkspaceHref({
+            campaignId: selectedScenario.campaignId,
+            scenarioId: selectedScenario.scenarioId,
+            tab: "scenario",
+          })
+        );
+        return;
+      }
+
+      openPlayerScenario(selectedScenario);
     } catch (error) {
+      if (error instanceof Error && error.message.includes("already participating")) {
+        openPlayerScenario(selectedScenario);
+        return;
+      }
+
       setJoinError(error instanceof Error ? error.message : "Unable to join scenario.");
     }
   }
@@ -501,8 +520,7 @@ export default function CharactersBrowser() {
                               >
                                 {joinableScenarios.map((scenario) => (
                                   <option key={scenario.scenarioId} value={scenario.scenarioId}>
-                                    {scenario.campaignName} - {scenario.scenarioName} ({scenario.kind},{" "}
-                                    {scenario.status})
+                                    {scenario.campaignName} - {scenario.scenarioName}
                                   </option>
                                 ))}
                               </select>
@@ -529,7 +547,7 @@ export default function CharactersBrowser() {
                               </div>
                             </>
                           ) : (
-                            <div>No active scenarios are currently available from the campaign list.</div>
+                            <div>No live scenario is currently available for this character.</div>
                           )}
 
                           {joinError ? <div>{joinError}</div> : null}

--- a/apps/web/src/lib/api/apiClient.ts
+++ b/apps/web/src/lib/api/apiClient.ts
@@ -41,13 +41,16 @@ export async function sendJson<TResponse>(
   path: string,
   init?: Omit<RequestInit, "credentials">
 ): Promise<TResponse> {
+  const headers = new Headers(init?.headers);
+
+  if (init?.body != null && !headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+
   const response = await fetch(`${API_BASE_URL}${path}`, {
     ...init,
     credentials: "include",
-    headers: {
-      "content-type": "application/json",
-      ...(init?.headers ?? {})
-    }
+    headers
   });
 
   return parseResponse<TResponse>(response);

--- a/apps/web/src/lib/api/campaignClient.ts
+++ b/apps/web/src/lib/api/campaignClient.ts
@@ -211,7 +211,7 @@ export async function removeCampaignRosterEntryOnServer(input: {
   sourceId: string;
   sourceType: CampaignRosterSourceType;
 }): Promise<void> {
-  await sendJson<{ ok: true }>(
+  await sendJson<{ ok: true; removed?: boolean }>(
     `/campaigns/${input.campaignId}/roster-membership/${encodeURIComponent(input.sourceType)}/${encodeURIComponent(input.sourceId)}`,
     {
       method: "DELETE"

--- a/apps/web/src/lib/api/campaignClient.ts
+++ b/apps/web/src/lib/api/campaignClient.ts
@@ -211,13 +211,8 @@ export async function removeCampaignRosterEntryOnServer(input: {
   sourceId: string;
   sourceType: CampaignRosterSourceType;
 }): Promise<void> {
-  const params = new URLSearchParams({
-    sourceId: input.sourceId,
-    sourceType: input.sourceType,
-  });
-
   await sendJson<{ ok: true }>(
-    `/campaigns/${input.campaignId}/roster-membership?${params.toString()}`,
+    `/campaigns/${input.campaignId}/roster-membership/${encodeURIComponent(input.sourceType)}/${encodeURIComponent(input.sourceId)}`,
     {
       method: "DELETE"
     }

--- a/apps/web/src/lib/api/campaignClient.ts
+++ b/apps/web/src/lib/api/campaignClient.ts
@@ -208,10 +208,16 @@ export async function addCampaignRosterEntryOnServer(input: {
 
 export async function removeCampaignRosterEntryOnServer(input: {
   campaignId: string;
-  rosterEntryId: string;
+  sourceId: string;
+  sourceType: CampaignRosterSourceType;
 }): Promise<void> {
+  const params = new URLSearchParams({
+    sourceId: input.sourceId,
+    sourceType: input.sourceType,
+  });
+
   await sendJson<{ ok: true }>(
-    `/campaigns/${input.campaignId}/roster/${input.rosterEntryId}`,
+    `/campaigns/${input.campaignId}/roster-membership?${params.toString()}`,
     {
       method: "DELETE"
     }

--- a/apps/web/src/lib/api/localServiceClient.test.ts
+++ b/apps/web/src/lib/api/localServiceClient.test.ts
@@ -162,6 +162,42 @@ describe("localServiceClient wire contract", () => {
     });
   });
 
+  it("deletes campaign roster membership by stable source identity", async () => {
+    const fetchMock = stubFetch({ ok: true });
+    const client = await loadClient();
+
+    await expect(
+      client.removeCampaignRosterEntryOnServer({
+        campaignId: "campaign-1",
+        sourceId: "character-1",
+        sourceType: "character",
+      }),
+    ).resolves.toBeUndefined();
+
+    expectFetchCall(fetchMock, {
+      method: "DELETE",
+      url: "https://api.example.test/campaigns/campaign-1/roster-membership/character/character-1",
+    });
+  });
+
+  it("preserves template source type when deleting campaign roster membership", async () => {
+    const fetchMock = stubFetch({ ok: true });
+    const client = await loadClient();
+
+    await expect(
+      client.removeCampaignRosterEntryOnServer({
+        campaignId: "campaign-1",
+        sourceId: "template-1",
+        sourceType: "template",
+      }),
+    ).resolves.toBeUndefined();
+
+    expectFetchCall(fetchMock, {
+      method: "DELETE",
+      url: "https://api.example.test/campaigns/campaign-1/roster-membership/template/template-1",
+    });
+  });
+
   it("puts scenario updates under the scenario domain", async () => {
     const scenario = {
       campaignId: "campaign-1",

--- a/apps/web/src/lib/api/localServiceClient.test.ts
+++ b/apps/web/src/lib/api/localServiceClient.test.ts
@@ -30,6 +30,7 @@ function expectFetchCall(
   fetchMock: FetchMock,
   expected: {
     body?: unknown;
+    headers?: Record<string, string>;
     method?: string;
     url: string;
   },
@@ -44,10 +45,20 @@ function expectFetchCall(
   }
 
   if (expected.body !== undefined) {
-    expect(init?.headers).toMatchObject({
-      "content-type": "application/json",
-    });
+    expect(init?.headers).toBeInstanceOf(Headers);
+    expect((init?.headers as Headers).get("content-type")).toBe("application/json");
     expect(init?.body).toBe(JSON.stringify(expected.body));
+  } else {
+    expect(init?.body).toBeUndefined();
+    expect((init?.headers as Headers | undefined)?.has("content-type") ?? false).toBe(false);
+  }
+
+  if (expected.headers) {
+    expect(init?.headers).toBeInstanceOf(Headers);
+
+    for (const [name, value] of Object.entries(expected.headers)) {
+      expect((init?.headers as Headers).get(name)).toBe(value);
+    }
   }
 }
 
@@ -103,6 +114,31 @@ describe("localServiceClient wire contract", () => {
       },
       method: "POST",
       url: "https://api.example.test/auth/login",
+    });
+  });
+
+  it("preserves caller-provided headers while posting JSON bodies", async () => {
+    const fetchMock = stubFetch({ ok: true });
+    vi.stubEnv("NEXT_PUBLIC_API_BASE_URL", "https://api.example.test");
+    const { sendJson } = await import("./apiClient");
+
+    await expect(
+      sendJson("/custom", {
+        body: JSON.stringify({ ok: true }),
+        headers: {
+          "x-request-id": "request-1",
+        },
+        method: "POST",
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expectFetchCall(fetchMock, {
+      body: { ok: true },
+      headers: {
+        "x-request-id": "request-1",
+      },
+      method: "POST",
+      url: "https://api.example.test/custom",
     });
   });
 
@@ -178,6 +214,8 @@ describe("localServiceClient wire contract", () => {
       method: "DELETE",
       url: "https://api.example.test/campaigns/campaign-1/roster-membership/character/character-1",
     });
+    expect(fetchMock.mock.calls[0][1]?.headers).toBeInstanceOf(Headers);
+    expect((fetchMock.mock.calls[0][1]?.headers as Headers).has("content-type")).toBe(false);
   });
 
   it("preserves template source type when deleting campaign roster membership", async () => {

--- a/apps/web/src/lib/api/scenarioClient.ts
+++ b/apps/web/src/lib/api/scenarioClient.ts
@@ -57,9 +57,10 @@ export interface ScenarioParticipantFromEntityInput {
   tacticalGroupId?: string | null;
 }
 
-export async function loadJoinableScenarios(): Promise<JoinableScenarioRecord[]> {
+export async function loadJoinableScenarios(characterId?: string): Promise<JoinableScenarioRecord[]> {
+  const query = characterId ? `?characterId=${encodeURIComponent(characterId)}` : "";
   const payload = await sendJson<{ joinableScenarios: JoinableScenarioRecord[] }>(
-    "/scenarios/joinable",
+    `/scenarios/joinable${query}`,
     {
       method: "GET"
     }

--- a/docs/product/campaign-scenario-encounter-workflows.md
+++ b/docs/product/campaign-scenario-encounter-workflows.md
@@ -33,6 +33,8 @@ Player responsibilities:
 
 Important rule: campaign roster means available to the campaign, not currently present in a scene. A roster member is not automatically in a scenario or encounter.
 
+Campaigns are not self-join spaces. The GM controls campaign roster membership. A character may join or open a live scenario only when that character is already in the campaign roster and the scenario is currently live.
+
 Player Campaign pages should not show:
 
 - GM-only notes.
@@ -65,6 +67,7 @@ Current design rules:
 
 - Scenario participants are concrete actors in a scenario.
 - Scenario participants are not the same as campaign roster entries.
+- Scenario kind is an internal/model-level classification for now, not a workflow control that should be emphasized in Campaign or Player pages.
 - Template sources are not participants until the GM creates concrete actors from them.
 - Player pages should not expose whether hidden or GM-only participants exist.
 

--- a/packages/database/src/repositories/scenarioRepository.ts
+++ b/packages/database/src/repositories/scenarioRepository.ts
@@ -375,6 +375,11 @@ export interface ScenarioRepository {
     sourceType: CampaignRosterSourceType;
   }): Promise<CampaignRosterEntry>;
   deleteCampaignRosterEntry(entryId: string): Promise<void>;
+  deleteCampaignRosterEntryBySource(input: {
+    campaignId: string;
+    sourceId: string;
+    sourceType: CampaignRosterSourceType;
+  }): Promise<void>;
   getCampaignRosterEntryById(entryId: string): Promise<CampaignRosterEntry | null>;
   listCampaignRosterEntries(campaignId: string): Promise<CampaignRosterEntry[]>;
   createScenarioRelationship(input: {
@@ -739,6 +744,15 @@ export function createPrismaScenarioRepository(client?: PrismaClient): ScenarioR
     async deleteCampaignRosterEntry(entryId) {
       await prisma.campaignRosterEntry.delete({
         where: { id: entryId }
+      });
+    },
+    async deleteCampaignRosterEntryBySource(input) {
+      await prisma.campaignRosterEntry.deleteMany({
+        where: {
+          campaignId: input.campaignId,
+          sourceId: input.sourceId,
+          sourceType: input.sourceType
+        }
       });
     },
     async getCampaignRosterEntryById(entryId) {

--- a/packages/database/src/repositories/scenarioRepository.ts
+++ b/packages/database/src/repositories/scenarioRepository.ts
@@ -273,6 +273,7 @@ export interface ScenarioRepository {
   getCampaignById(campaignId: string): Promise<Campaign | null>;
   listCampaignsByGameMaster(gmUserId: string): Promise<Campaign[]>;
   listCampaignsAllowingPlayerSelfJoin(): Promise<Campaign[]>;
+  listCampaignsByCharacterRosterAccess(characterId: string): Promise<Campaign[]>;
   listCampaignsByPlayerAccess(userId: string): Promise<Campaign[]>;
   createScenario(input: {
     campaignId: string;
@@ -438,6 +439,21 @@ export function createPrismaScenarioRepository(client?: PrismaClient): ScenarioR
             equals: true
           }
         }
+      });
+
+      return records.map(mapCampaign);
+    },
+    async listCampaignsByCharacterRosterAccess(characterId) {
+      const records = await prisma.campaign.findMany({
+        orderBy: { updatedAt: "desc" },
+        where: {
+          rosterEntries: {
+            some: {
+              sourceId: characterId,
+              sourceType: "character",
+            },
+          },
+        },
       });
 
       return records.map(mapCampaign);

--- a/packages/database/src/repositories/scenarioRepository.ts
+++ b/packages/database/src/repositories/scenarioRepository.ts
@@ -379,7 +379,7 @@ export interface ScenarioRepository {
     campaignId: string;
     sourceId: string;
     sourceType: CampaignRosterSourceType;
-  }): Promise<void>;
+  }): Promise<number>;
   getCampaignRosterEntryById(entryId: string): Promise<CampaignRosterEntry | null>;
   listCampaignRosterEntries(campaignId: string): Promise<CampaignRosterEntry[]>;
   createScenarioRelationship(input: {
@@ -747,13 +747,15 @@ export function createPrismaScenarioRepository(client?: PrismaClient): ScenarioR
       });
     },
     async deleteCampaignRosterEntryBySource(input) {
-      await prisma.campaignRosterEntry.deleteMany({
+      const result = await prisma.campaignRosterEntry.deleteMany({
         where: {
           campaignId: input.campaignId,
           sourceId: input.sourceId,
           sourceType: input.sourceType
         }
       });
+
+      return result.count;
     },
     async getCampaignRosterEntryById(entryId) {
       const record = await prisma.campaignRosterEntry.findUnique({

--- a/packages/database/src/services/campaignService.test.ts
+++ b/packages/database/src/services/campaignService.test.ts
@@ -224,6 +224,73 @@ describe("CampaignService campaign roster", () => {
     await expect(service.listCampaignRosterEntries("campaign-2")).resolves.toEqual([campaignTwoEntry]);
   });
 
+  it("removes roster membership by campaign source identity", async () => {
+    const { repository, rosterEntries } = createScenarioRepositoryStub();
+    const characters = new Map([
+      ["character-1", createCharacterRecord({ id: "character-1", name: "Ari", ownerId: "user-1" })],
+    ]);
+    const reusableEntities = new Map<string, ReusableEntity>([
+      [
+        "template-1",
+        {
+          createdAt: "2026-04-21T00:00:00.000Z",
+          gmUserId: "gm-1",
+          id: "template-1",
+          kind: "npc",
+          name: "Bandit Template",
+          snapshot: {
+            actorClass: "template",
+          },
+          updatedAt: "2026-04-21T00:00:00.000Z",
+        },
+      ],
+    ]);
+    repository.getReusableEntityById = async (entityId) => reusableEntities.get(entityId) ?? null;
+    const service = new CampaignService(
+      repository,
+      {
+        getCharacterById: async (characterId: string) => characters.get(characterId) ?? null,
+      } as never,
+    );
+
+    await service.addCampaignRosterEntry({
+      campaignId: "campaign-1",
+      category: "pc",
+      sourceId: "character-1",
+      sourceType: "character",
+    });
+    await service.addCampaignRosterEntry({
+      campaignId: "campaign-1",
+      category: "template",
+      sourceId: "template-1",
+      sourceType: "template",
+    });
+
+    await service.removeCampaignRosterEntryBySource({
+      campaignId: "campaign-1",
+      sourceId: "character-1",
+      sourceType: "character",
+    });
+
+    expect(rosterEntries).toHaveLength(1);
+    expect(rosterEntries[0]?.sourceType).toBe("template");
+
+    await service.removeCampaignRosterEntryBySource({
+      campaignId: "campaign-1",
+      sourceId: "template-1",
+      sourceType: "template",
+    });
+    await service.removeCampaignRosterEntryBySource({
+      campaignId: "campaign-1",
+      sourceId: "template-1",
+      sourceType: "template",
+    });
+
+    expect(rosterEntries).toHaveLength(0);
+    expect(characters.get("character-1")?.name).toBe("Ari");
+    expect(reusableEntities.get("template-1")?.name).toBe("Bandit Template");
+  });
+
   it("removes only roster links and leaves source characters and templates available", async () => {
     const { repository, rosterEntries } = createScenarioRepositoryStub();
     const characters = new Map([

--- a/packages/database/src/services/campaignService.test.ts
+++ b/packages/database/src/services/campaignService.test.ts
@@ -186,6 +186,18 @@ describe("CampaignService campaign roster", () => {
     await expect(service.listCampaignRosterEntries("campaign-1")).resolves.toEqual([]);
   });
 
+  it("treats already-removed roster entry ids as an idempotent no-op", async () => {
+    const { repository, rosterEntries } = createScenarioRepositoryStub();
+    const service = new CampaignService(repository);
+
+    await service.removeCampaignRosterEntry({
+      campaignId: "campaign-1",
+      rosterEntryId: "missing-roster-entry",
+    });
+
+    expect(rosterEntries).toHaveLength(0);
+  });
+
   it("keeps roster membership scoped to each campaign/source pair", async () => {
     const { repository, rosterEntries } = createScenarioRepositoryStub();
     const characters = new Map([

--- a/packages/database/src/services/campaignService.test.ts
+++ b/packages/database/src/services/campaignService.test.ts
@@ -278,29 +278,50 @@ describe("CampaignService campaign roster", () => {
       sourceType: "template",
     });
 
-    await service.removeCampaignRosterEntryBySource({
-      campaignId: "campaign-1",
-      sourceId: "character-1",
-      sourceType: "character",
-    });
+    await expect(
+      service.removeCampaignRosterEntryBySource({
+        campaignId: "campaign-1",
+        sourceId: "character-1",
+        sourceType: "character",
+      }),
+    ).resolves.toEqual({ removed: true });
 
     expect(rosterEntries).toHaveLength(1);
     expect(rosterEntries[0]?.sourceType).toBe("template");
 
-    await service.removeCampaignRosterEntryBySource({
-      campaignId: "campaign-1",
-      sourceId: "template-1",
-      sourceType: "template",
-    });
-    await service.removeCampaignRosterEntryBySource({
-      campaignId: "campaign-1",
-      sourceId: "template-1",
-      sourceType: "template",
-    });
+    await expect(
+      service.removeCampaignRosterEntryBySource({
+        campaignId: "campaign-1",
+        sourceId: "template-1",
+        sourceType: "template",
+      }),
+    ).resolves.toEqual({ removed: true });
+    await expect(
+      service.removeCampaignRosterEntryBySource({
+        campaignId: "campaign-1",
+        sourceId: "template-1",
+        sourceType: "template",
+      }),
+    ).resolves.toEqual({ removed: false });
 
     expect(rosterEntries).toHaveLength(0);
     expect(characters.get("character-1")?.name).toBe("Ari");
     expect(reusableEntities.get("template-1")?.name).toBe("Bandit Template");
+  });
+
+  it("returns an idempotent no-op when removing a missing roster source", async () => {
+    const { repository, rosterEntries } = createScenarioRepositoryStub();
+    const service = new CampaignService(repository);
+
+    await expect(
+      service.removeCampaignRosterEntryBySource({
+        campaignId: "campaign-1",
+        sourceId: "missing-character",
+        sourceType: "character",
+      }),
+    ).resolves.toEqual({ removed: false });
+
+    expect(rosterEntries).toHaveLength(0);
   });
 
   it("removes only roster links and leaves source characters and templates available", async () => {

--- a/packages/database/src/services/campaignService.test.ts
+++ b/packages/database/src/services/campaignService.test.ts
@@ -34,6 +34,34 @@ describe("CampaignService access listing", () => {
 
     await expect(service.listCampaignsByPlayerAccess("player-1")).resolves.toEqual(expectedCampaigns);
   });
+
+  it("returns campaigns where a character is in the roster", async () => {
+    const { repository } = createScenarioRepositoryStub();
+    const expectedCampaigns: Campaign[] = [
+      {
+        createdAt: "2026-04-21T00:00:00.000Z",
+        description: "Roster campaign",
+        gmUserId: "gm-1",
+        id: "campaign-1",
+        name: "Campaign One",
+        settings: {
+          allowPlayerSelfJoin: false,
+          defaultVisibility: "hidden",
+        },
+        slug: "campaign-one",
+        status: "active",
+        updatedAt: "2026-04-21T00:00:00.000Z",
+      },
+    ];
+    repository.listCampaignsByCharacterRosterAccess = async (characterId) =>
+      characterId === "character-1" ? expectedCampaigns : [];
+
+    const service = new CampaignService(repository);
+
+    await expect(service.listCampaignsByCharacterRosterAccess("character-1")).resolves.toEqual(
+      expectedCampaigns,
+    );
+  });
 });
 
 describe("CampaignService campaign roster", () => {

--- a/packages/database/src/services/campaignService.ts
+++ b/packages/database/src/services/campaignService.ts
@@ -114,8 +114,12 @@ export class CampaignService {
     campaignId: string;
     sourceId: string;
     sourceType: CampaignRosterSourceType;
-  }): Promise<void> {
-    await this.repository.deleteCampaignRosterEntryBySource(input);
+  }): Promise<{ removed: boolean }> {
+    const removedCount = await this.repository.deleteCampaignRosterEntryBySource(input);
+
+    return {
+      removed: removedCount > 0,
+    };
   }
 
   async createReusableEntity(input: {

--- a/packages/database/src/services/campaignService.ts
+++ b/packages/database/src/services/campaignService.ts
@@ -99,7 +99,11 @@ export class CampaignService {
   }): Promise<void> {
     const entry = await this.repository.getCampaignRosterEntryById(input.rosterEntryId);
 
-    if (!entry || entry.campaignId !== input.campaignId) {
+    if (!entry) {
+      return;
+    }
+
+    if (entry.campaignId !== input.campaignId) {
       throw new Error("Campaign roster entry not found.");
     }
 

--- a/packages/database/src/services/campaignService.ts
+++ b/packages/database/src/services/campaignService.ts
@@ -106,6 +106,14 @@ export class CampaignService {
     await this.repository.deleteCampaignRosterEntry(input.rosterEntryId);
   }
 
+  async removeCampaignRosterEntryBySource(input: {
+    campaignId: string;
+    sourceId: string;
+    sourceType: CampaignRosterSourceType;
+  }): Promise<void> {
+    await this.repository.deleteCampaignRosterEntryBySource(input);
+  }
+
   async createReusableEntity(input: {
     description?: string;
     gmUserId: string;

--- a/packages/database/src/services/campaignService.ts
+++ b/packages/database/src/services/campaignService.ts
@@ -56,6 +56,10 @@ export class CampaignService {
     return this.repository.listCampaignsAllowingPlayerSelfJoin();
   }
 
+  async listCampaignsByCharacterRosterAccess(characterId: string): Promise<Campaign[]> {
+    return this.repository.listCampaignsByCharacterRosterAccess(characterId);
+  }
+
   async listCampaignsByPlayerAccess(userId: string): Promise<Campaign[]> {
     return this.repository.listCampaignsByPlayerAccess(userId);
   }

--- a/packages/database/src/services/scenarioService.testHelpers.ts
+++ b/packages/database/src/services/scenarioService.testHelpers.ts
@@ -265,7 +265,10 @@ export function createScenarioRepositoryStub() {
 
       if (index >= 0) {
         rosterEntries.splice(index, 1);
+        return 1;
       }
+
+      return 0;
     },
     getCampaignRosterEntryById: async (entryId) =>
       rosterEntries.find((entry) => entry.id === entryId) ?? null,

--- a/packages/database/src/services/scenarioService.testHelpers.ts
+++ b/packages/database/src/services/scenarioService.testHelpers.ts
@@ -99,6 +99,15 @@ export function createScenarioRepositoryStub() {
     getCampaignById: async () => null,
     listCampaignsByGameMaster: async () => [],
     listCampaignsAllowingPlayerSelfJoin: async () => [],
+    listCampaignsByCharacterRosterAccess: async (characterId) => {
+      const campaignIds = new Set(
+        rosterEntries
+          .filter((entry) => entry.sourceType === "character" && entry.sourceId === characterId)
+          .map((entry) => entry.campaignId),
+      );
+
+      return campaigns.filter((campaign) => campaignIds.has(campaign.id));
+    },
     listCampaignsByPlayerAccess: async () => campaigns,
     createScenario: async (input) => {
       const now = "2026-04-21T00:00:00.000Z";

--- a/packages/database/src/services/scenarioService.testHelpers.ts
+++ b/packages/database/src/services/scenarioService.testHelpers.ts
@@ -255,6 +255,18 @@ export function createScenarioRepositoryStub() {
         rosterEntries.splice(index, 1);
       }
     },
+    deleteCampaignRosterEntryBySource: async (input) => {
+      const index = rosterEntries.findIndex(
+        (entry) =>
+          entry.campaignId === input.campaignId &&
+          entry.sourceId === input.sourceId &&
+          entry.sourceType === input.sourceType,
+      );
+
+      if (index >= 0) {
+        rosterEntries.splice(index, 1);
+      }
+    },
     getCampaignRosterEntryById: async (entryId) =>
       rosterEntries.find((entry) => entry.id === entryId) ?? null,
     listCampaignRosterEntries: async (campaignId) =>


### PR DESCRIPTION
In the PR body, include a note that the roster removal bug was caused by Content-Type: application/json being sent on bodyless DELETE requests, which Fastify rejected before the route handler.