### PR TITLE
fix: samle sikkerhetsfikser for roller og scenarioer

### DIFF
--- a/apps/api/src/lib/sessionAuth.ts
+++ b/apps/api/src/lib/sessionAuth.ts
@@ -1,4 +1,4 @@
-import { canAccessAdmin, type AuthUser } from "@glantri/auth";
+import { canAccessAdmin, isAdmin, type AuthUser } from "@glantri/auth";
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 
 import { AuthService } from "@glantri/database";
@@ -132,6 +132,27 @@ export async function requireAdminUser(
   if (!canAccessAdmin(user.roles)) {
     await reply.code(403).send({
       error: "Admin or GM role required."
+    });
+    return null;
+  }
+
+  return user;
+}
+
+export async function requireStrictAdminUser(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  authService = new AuthService()
+): Promise<AuthUser | null> {
+  const user = await requireAuthenticatedUser(request, reply, authService);
+
+  if (!user) {
+    return null;
+  }
+
+  if (!isAdmin(user.roles)) {
+    await reply.code(403).send({
+      error: "Admin role required."
     });
     return null;
   }

--- a/apps/api/src/routes/adminContent.ts
+++ b/apps/api/src/routes/adminContent.ts
@@ -13,7 +13,7 @@ import type {
 import type { CanonicalContent } from "@glantri/content";
 
 import { CanonicalContentService } from "../lib/adminContentService";
-import { requireAdminUser, requireAuthenticatedUser } from "../lib/sessionAuth";
+import { requireAuthenticatedUser, requireStrictAdminUser } from "../lib/sessionAuth";
 
 const canonicalContentService = new CanonicalContentService();
 
@@ -57,7 +57,7 @@ export const adminContentRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.put("/content", async (request, reply) => {
-    const user = await requireAdminUser(request, reply);
+    const user = await requireStrictAdminUser(request, reply);
 
     if (!user) {
       return;

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -12,8 +12,8 @@ import {
   buildSessionCookie,
   getAuthenticatedUser,
   getSessionTokenFromRequest,
-  requireAdminUser,
-  requireAuthenticatedUser
+  requireAuthenticatedUser,
+  requireStrictAdminUser
 } from "../lib/sessionAuth";
 
 const authService = new AuthService();
@@ -102,7 +102,7 @@ export const authRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.post("/users/:id/role", async (request, reply) => {
-    const user = await requireAdminUser(request, reply, authService);
+    const user = await requireStrictAdminUser(request, reply, authService);
 
     if (!user) {
       return;

--- a/apps/api/src/routes/scenarios/participantRoutes.ts
+++ b/apps/api/src/routes/scenarios/participantRoutes.ts
@@ -10,6 +10,7 @@ import {
 } from "@glantri/domain";
 
 import { requireAdminUser, requireAuthenticatedUser } from "../../lib/sessionAuth";
+import { resolveScenarioWorkspaceAccess } from "./access";
 import { canEditCharacterInApi } from "../../lib/characterEditAccess";
 import {
   parseBodyObject,
@@ -20,7 +21,6 @@ import {
   parseOptionalString,
   parseRequiredString
 } from "./parsing";
-import { resolveScenarioWorkspaceAccess } from "./access";
 
 const characterService = new CharacterService();
 const campaignService = new CampaignService();
@@ -197,12 +197,13 @@ export const participantRoutes: FastifyPluginAsync = async (app) => {
 
     try {
       const scenarioId = parseId(request.params, "scenarioId", "Scenario id");
-      const scenario = await scenarioService.getScenarioById(scenarioId);
+      const access = await resolveScenarioWorkspaceAccess(
+        { campaignService, scenarioService },
+        { scenarioId, userId: user.id, userRoles: user.roles }
+      );
 
-      if (!scenario) {
-        return reply.code(404).send({
-          error: "Scenario not found."
-        });
+      if (!access || access.mode !== "gm") {
+        return reply.code(404).send({ error: "Scenario not found." });
       }
 
       const body = parseBodyObject(request.body, "Entity participant payload");
@@ -258,6 +259,26 @@ export const participantRoutes: FastifyPluginAsync = async (app) => {
     try {
       const scenarioId = parseId(request.params, "scenarioId", "Scenario id");
       const participantId = parseId(request.params, "participantId", "Participant id");
+      const access = await resolveScenarioWorkspaceAccess(
+        { campaignService, scenarioService },
+        { scenarioId, userId: user.id, userRoles: user.roles }
+      );
+
+      if (!access) {
+        return reply.code(404).send({ error: "Scenario not found." });
+      }
+
+      if (access.mode === "player") {
+        const participant = await scenarioService.getScenarioParticipantById(
+          participantId,
+          scenarioId
+        );
+
+        if (!participant || participant.controlledByUserId !== user.id) {
+          return reply.code(403).send({ error: "Access denied." });
+        }
+      }
+
       const body = parseBodyObject(request.body, "Participant state payload");
       const participant = await encounterService.updateScenarioParticipantState({
         participantId,
@@ -285,12 +306,13 @@ export const participantRoutes: FastifyPluginAsync = async (app) => {
       try {
         const scenarioId = parseId(request.params, "scenarioId", "Scenario id");
         const participantId = parseId(request.params, "participantId", "Participant id");
-        const scenario = await scenarioService.getScenarioById(scenarioId);
+        const access = await resolveScenarioWorkspaceAccess(
+          { campaignService, scenarioService },
+          { scenarioId, userId: user.id, userRoles: user.roles }
+        );
 
-        if (!scenario) {
-          return reply.code(404).send({
-            error: "Scenario not found."
-          });
+        if (!access || access.mode !== "gm") {
+          return reply.code(404).send({ error: "Scenario not found." });
         }
 
         const body = parseBodyObject(request.body, "Participant metadata payload");

--- a/apps/api/src/routes/scenarios/scenarioRoutes.ts
+++ b/apps/api/src/routes/scenarios/scenarioRoutes.ts
@@ -9,6 +9,7 @@ import {
 } from "@glantri/domain";
 
 import { requireAdminUser, requireAuthenticatedUser } from "../../lib/sessionAuth";
+import { resolveScenarioWorkspaceAccess } from "./access";
 import {
   parseBodyObject,
   parseId,
@@ -78,13 +79,16 @@ export const scenarioRoutes: FastifyPluginAsync = async (app) => {
 
     try {
       const scenarioId = parseId(request.params, "scenarioId", "Scenario id");
-      const scenario = await scenarioService.getScenarioById(scenarioId);
+      const access = await resolveScenarioWorkspaceAccess(
+        { campaignService, scenarioService },
+        { scenarioId, userId: user.id, userRoles: user.roles }
+      );
 
-      if (!scenario) {
-        return reply.code(404).send({
-          error: "Scenario not found."
-        });
+      if (!access) {
+        return reply.code(404).send({ error: "Scenario not found." });
       }
+
+      const scenario = await scenarioService.getScenarioById(scenarioId);
 
       return { scenario };
     } catch (error) {
@@ -103,18 +107,20 @@ export const scenarioRoutes: FastifyPluginAsync = async (app) => {
 
     try {
       const scenarioId = parseId(request.params, "scenarioId", "Scenario id");
-      const scenario = await scenarioService.getScenarioById(scenarioId);
+      const access = await resolveScenarioWorkspaceAccess(
+        { campaignService, scenarioService },
+        { scenarioId, userId: user.id, userRoles: user.roles }
+      );
 
-      if (!scenario) {
-        return reply.code(404).send({
-          error: "Scenario not found."
-        });
+      if (!access) {
+        return reply.code(404).send({ error: "Scenario not found." });
       }
 
+      const scenario = await scenarioService.getScenarioById(scenarioId);
       const participants = await scenarioService.listScenarioParticipants(scenarioId);
       const projection = buildScenarioPlayerProjection({
         participants,
-        scenario,
+        scenario: scenario!,
         userId: user.id
       });
 
@@ -217,12 +223,13 @@ export const scenarioRoutes: FastifyPluginAsync = async (app) => {
 
     try {
       const scenarioId = parseId(request.params, "scenarioId", "Scenario id");
-      const scenario = await scenarioService.getScenarioById(scenarioId);
+      const access = await resolveScenarioWorkspaceAccess(
+        { campaignService, scenarioService },
+        { scenarioId, userId: user.id, userRoles: user.roles }
+      );
 
-      if (!scenario) {
-        return reply.code(404).send({
-          error: "Scenario not found."
-        });
+      if (!access || access.mode !== "gm") {
+        return reply.code(404).send({ error: "Scenario not found." });
       }
 
       const eventLogs = await scenarioService.listScenarioEventLogs(scenarioId);

--- a/packages/auth/src/session.test.ts
+++ b/packages/auth/src/session.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from "vitest";
 
-import { formatAuthRoleLabel, getPrimaryRole } from "./session";
+import { formatAuthRoleLabel, getPrimaryRole, isAdmin } from "./session";
+
+describe("isAdmin", () => {
+  it("returns true only for admin role", () => {
+    expect(isAdmin(["admin"])).toBe(true);
+  });
+
+  it("returns false for game_master", () => {
+    expect(isAdmin(["game_master"])).toBe(false);
+  });
+
+  it("returns false for player", () => {
+    expect(isAdmin(["player"])).toBe(false);
+  });
+
+  it("returns true when admin is present alongside other roles", () => {
+    expect(isAdmin(["game_master", "admin"])).toBe(true);
+  });
+});
 
 describe("auth session role helpers", () => {
   it("resolves legacy-style mixed player plus GM role arrays to GM as the primary role", () => {

--- a/packages/auth/src/session.ts
+++ b/packages/auth/src/session.ts
@@ -12,6 +12,10 @@ export function canAccessAdmin(userRoles: AuthRole[]): boolean {
   return hasAnyRole(userRoles, ["admin", "game_master"]);
 }
 
+export function isAdmin(userRoles: AuthRole[]): boolean {
+  return hasRole(userRoles, "admin");
+}
+
 export function getPrimaryRole(userRoles: AuthRole[]): AuthRole {
   if (hasRole(userRoles, "admin")) {
     return "admin";

--- a/packages/database/src/repositories/authRepository.ts
+++ b/packages/database/src/repositories/authRepository.ts
@@ -95,24 +95,28 @@ export function createPrismaAuthRepository(client?: PrismaClient): AuthRepositor
             return null;
           }
 
+          const targetUser = await tx.user.findUnique({
+            select: { id: true },
+            where: { id: userId }
+          });
+
+          if (!targetUser) {
+            return null;
+          }
+
           const gmRole = await tx.role.upsert({
             create: { name: "game_master" },
             update: {},
             where: { name: "game_master" }
           });
 
-          const user = await tx.user
-            .update({
-              data: {
-                roles: {
-                  create: [{ roleId: gmRole.id }],
-                  deleteMany: {}
-                }
-              },
-              include: { roles: { include: { role: true } } },
-              where: { id: userId }
-            })
-            .catch(() => null);
+          await tx.userRole.deleteMany({ where: { userId } });
+          await tx.userRole.create({ data: { roleId: gmRole.id, userId } });
+
+          const user = await tx.user.findUnique({
+            include: { roles: { include: { role: true } } },
+            where: { id: userId }
+          });
 
           if (!user) {
             return null;

--- a/packages/database/src/repositories/authRepository.ts
+++ b/packages/database/src/repositories/authRepository.ts
@@ -1,5 +1,5 @@
 import type { AuthRole, AuthSession, AuthUser } from "@glantri/auth";
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 
 import { prisma as defaultPrisma } from "../client";
 
@@ -17,6 +17,7 @@ export interface CreateSessionInput {
 
 export interface AuthRepository {
   anyPrivilegedUserExists(): Promise<boolean>;
+  atomicBootstrapGameMaster(userId: string): Promise<AuthUser | null>;
   createSession(input: CreateSessionInput): Promise<AuthSession>;
   createUser(input: CreateUserInput): Promise<AuthUser>;
   deleteSessionByTokenHash(tokenHash: string): Promise<void>;
@@ -72,6 +73,61 @@ export function createPrismaAuthRepository(client?: PrismaClient): AuthRepositor
       });
 
       return privilegedUserCount > 0;
+    },
+    async atomicBootstrapGameMaster(userId) {
+      try {
+        return await prisma.$transaction(async (tx) => {
+          const count = await tx.user.count({
+            where: {
+              roles: {
+                some: {
+                  role: {
+                    name: {
+                      in: getStoredPrivilegedRoleNames()
+                    }
+                  }
+                }
+              }
+            }
+          });
+
+          if (count > 0) {
+            return null;
+          }
+
+          const gmRole = await tx.role.upsert({
+            create: { name: "game_master" },
+            update: {},
+            where: { name: "game_master" }
+          });
+
+          const user = await tx.user
+            .update({
+              data: {
+                roles: {
+                  create: [{ roleId: gmRole.id }],
+                  deleteMany: {}
+                }
+              },
+              include: { roles: { include: { role: true } } },
+              where: { id: userId }
+            })
+            .catch(() => null);
+
+          if (!user) {
+            return null;
+          }
+
+          return {
+            displayName: user.displayName ?? undefined,
+            email: user.email,
+            id: user.id,
+            roles: mapRoles(user.roles)
+          };
+        }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+      } catch {
+        return null;
+      }
     },
     async createSession(input) {
       const session = await prisma.session.create({

--- a/packages/database/src/repositories/scenarioRepository.ts
+++ b/packages/database/src/repositories/scenarioRepository.ts
@@ -331,6 +331,10 @@ export interface ScenarioRepository {
     tacticalGroupId?: string | null;
     visibilityOverrides?: ScenarioParticipant["visibilityOverrides"];
   }): Promise<ScenarioParticipant>;
+  getScenarioParticipantById(
+    participantId: string,
+    scenarioId: string
+  ): Promise<ScenarioParticipant | null>;
   listScenarioParticipants(scenarioId: string): Promise<ScenarioParticipant[]>;
   updateScenarioLiveState(
     scenarioId: string,
@@ -625,6 +629,13 @@ export function createPrismaScenarioRepository(client?: PrismaClient): ScenarioR
       });
 
       return mapScenarioParticipant(record);
+    },
+    async getScenarioParticipantById(participantId, scenarioId) {
+      const record = await prisma.scenarioParticipant.findFirst({
+        where: { id: participantId, scenarioId }
+      });
+
+      return record ? mapScenarioParticipant(record) : null;
     },
     async listScenarioParticipants(scenarioId) {
       const records = await prisma.scenarioParticipant.findMany({

--- a/packages/database/src/services/authService.integration.test.ts
+++ b/packages/database/src/services/authService.integration.test.ts
@@ -107,5 +107,52 @@ if (!process.env.DATABASE_URL_TEST) {
 
       expect(result).toBeNull();
     });
+
+    describe("bootstrapGameMasterForUser", () => {
+      it("promotes user to GM when no privileged users exist", async () => {
+        const repository = createPrismaAuthRepository(prisma!);
+        const service = new AuthService(repository);
+
+        const { id } = await createTestUser(prisma!, { email: "bootstrap@example.com" });
+
+        expect(await service.canBootstrapGameMaster()).toBe(true);
+
+        const result = await service.bootstrapGameMasterForUser(id);
+
+        expect(result).not.toBeNull();
+        expect(result!.roles).toContain("game_master");
+        expect(await service.canBootstrapGameMaster()).toBe(false);
+      });
+
+      it("returns null and makes no change when a privileged user already exists", async () => {
+        const repository = createPrismaAuthRepository(prisma!);
+        const service = new AuthService(repository);
+
+        const existing = await createTestUser(prisma!, {
+          email: "existing-gm@example.com",
+          roles: ["game_master"]
+        });
+        const newcomer = await createTestUser(prisma!, { email: "newcomer@example.com" });
+
+        const result = await service.bootstrapGameMasterForUser(newcomer.id);
+
+        expect(result).toBeNull();
+
+        const newcomerUser = await repository.findUserById(newcomer.id);
+        expect(newcomerUser!.roles).not.toContain("game_master");
+
+        const existingUser = await repository.findUserById(existing.id);
+        expect(existingUser!.roles).toContain("game_master");
+      });
+
+      it("returns null for a non-existent user id", async () => {
+        const repository = createPrismaAuthRepository(prisma!);
+        const service = new AuthService(repository);
+
+        const result = await service.bootstrapGameMasterForUser("non-existent-id");
+
+        expect(result).toBeNull();
+      });
+    });
   });
 }

--- a/packages/database/src/services/authService.test.ts
+++ b/packages/database/src/services/authService.test.ts
@@ -5,7 +5,7 @@ import { AuthService } from "./authService";
 
 function createRepositoryStub(options?: {
   anyPrivilegedUserExists?: boolean;
-  replacedUser?: {
+  bootstrapResult?: {
     displayName?: string;
     email: string;
     id: string;
@@ -13,11 +13,18 @@ function createRepositoryStub(options?: {
   } | null;
 }) {
   const calls = {
-    replaceUserRoles: [] as Array<{ roles: Array<"admin" | "game_master" | "player">; userId: string }>,
+    atomicBootstrapGameMaster: [] as string[],
   };
 
   const repository: AuthRepository = {
     anyPrivilegedUserExists: async () => options?.anyPrivilegedUserExists ?? false,
+    atomicBootstrapGameMaster: async (userId) => {
+      calls.atomicBootstrapGameMaster.push(userId);
+      if (options && "bootstrapResult" in options) {
+        return options.bootstrapResult ?? null;
+      }
+      return { id: userId, email: "gm@example.com", roles: ["game_master"] };
+    },
     createSession: async () => {
       throw new Error("not implemented");
     },
@@ -42,13 +49,8 @@ function createRepositoryStub(options?: {
     listUsers: async () => {
       throw new Error("not implemented");
     },
-    replaceUserRoles: async (userId, roles) => {
-      calls.replaceUserRoles.push({ roles, userId });
-      return options?.replacedUser ?? {
-        id: userId,
-        email: "gm@example.com",
-        roles: ["game_master"],
-      };
+    replaceUserRoles: async () => {
+      throw new Error("not implemented");
     },
   };
 
@@ -66,24 +68,21 @@ describe("AuthService bootstrap GM", () => {
     await expect(bootstrapClosed.canBootstrapGameMaster()).resolves.toBe(false);
   });
 
-  it("promotes the current user to game_master during bootstrap", async () => {
+  it("delegates bootstrap to the repository and returns the promoted user", async () => {
     const { calls, repository } = createRepositoryStub();
     const service = new AuthService(repository);
 
     const user = await service.bootstrapGameMasterForUser("user-1");
 
-    expect(calls.replaceUserRoles).toEqual([{ roles: ["game_master"], userId: "user-1" }]);
-    expect(user).toMatchObject({
-      id: "user-1",
-      roles: ["game_master"],
-    });
+    expect(calls.atomicBootstrapGameMaster).toEqual(["user-1"]);
+    expect(user).toMatchObject({ id: "user-1", roles: ["game_master"] });
   });
 
-  it("blocks bootstrap once a privileged user already exists", async () => {
-    const { calls, repository } = createRepositoryStub({ anyPrivilegedUserExists: true });
+  it("returns null when the repository reports bootstrap is no longer available", async () => {
+    const { calls, repository } = createRepositoryStub({ bootstrapResult: null });
     const service = new AuthService(repository);
 
     await expect(service.bootstrapGameMasterForUser("user-1")).resolves.toBeNull();
-    expect(calls.replaceUserRoles).toEqual([]);
+    expect(calls.atomicBootstrapGameMaster).toEqual(["user-1"]);
   });
 });

--- a/packages/database/src/services/authService.ts
+++ b/packages/database/src/services/authService.ts
@@ -51,13 +51,7 @@ export class AuthService {
   }
 
   async bootstrapGameMasterForUser(userId: string): Promise<AuthUser | null> {
-    const bootstrapAvailable = await this.canBootstrapGameMaster();
-
-    if (!bootstrapAvailable) {
-      return null;
-    }
-
-    return this.repository.replaceUserRoles(userId, ["game_master"]);
+    return this.repository.atomicBootstrapGameMaster(userId);
   }
 
   async createSessionForUser(userId: string): Promise<{ session: AuthSession; token: string }> {

--- a/packages/database/src/services/scenarioService.testHelpers.ts
+++ b/packages/database/src/services/scenarioService.testHelpers.ts
@@ -164,6 +164,8 @@ export function createScenarioRepositoryStub() {
       participants.push(participant);
       return participant;
     },
+    getScenarioParticipantById: async (participantId, scenarioId) =>
+      participants.find((p) => p.id === participantId && p.scenarioId === scenarioId) ?? null,
     listScenarioParticipants: async (scenarioId) =>
       participants.filter((participant) => participant.scenarioId === scenarioId),
     updateScenarioLiveState: async () => scenario,

--- a/packages/database/src/services/scenarioService.ts
+++ b/packages/database/src/services/scenarioService.ts
@@ -240,6 +240,13 @@ export class ScenarioService {
     return participant;
   }
 
+  async getScenarioParticipantById(
+    participantId: string,
+    scenarioId: string
+  ): Promise<ScenarioParticipant | null> {
+    return this.repository.getScenarioParticipantById(participantId, scenarioId);
+  }
+
   async listScenarioParticipants(scenarioId: string): Promise<ScenarioParticipant[]> {
     return this.repository.listScenarioParticipants(scenarioId);
   }


### PR DESCRIPTION
## Summary

Samler sikkerhetsfikser fra de tre åpne PR-ene i én felles branch:

- Supersedes #145: GM-rolle kan ikke eskalere til admin.
- Supersedes #146: atomic bootstrap-GM for å hindre race condition.
- Supersedes #147: scenario- og participant-ruter får manglende autorisasjonssjekker.

## Notes

- Branchen er bygd fra fersk `origin/main`.
- Kun de unike fix-commitene er tatt med; gammel merge-commit fra #147 er utelatt.
- Konflikten i `participantRoutes.ts` ble løst ved å beholde både eksisterende player-visible filtering fra `main` og de nye scenario workspace access-sjekkene.

## Verification

- `git diff --check origin/main...HEAD`
- GitHub Actions kjører på PR-en.