### PR TITLE
Adds the first Player General Encounter screen and improves the Campaign → Scenario → Encounter workflow 

### DIFF
--- a/apps/web/app/(app)/encounters/[id]/RoleplayEncounterScreens.test.ts
+++ b/apps/web/app/(app)/encounters/[id]/RoleplayEncounterScreens.test.ts
@@ -176,6 +176,7 @@ describe("RoleplayEncounterScreens", () => {
     expect(source).toContain("unknownSkillPenalty");
     expect(source).toContain("otherModTouched");
     expect(source).toContain("Skill not known (-3 default). GM may adjust or forbid.");
+    expect(source).toContain("No stats available for this actor.");
     expect(typesSource).toContain("profile?: ParticipantSkillRollProfile");
     expect(typesSource).toContain("warning?: string");
   });

--- a/apps/web/app/(app)/encounters/[id]/RoleplayEncounterScreens.test.ts
+++ b/apps/web/app/(app)/encounters/[id]/RoleplayEncounterScreens.test.ts
@@ -176,7 +176,7 @@ describe("RoleplayEncounterScreens", () => {
     expect(source).toContain("unknownSkillPenalty");
     expect(source).toContain("otherModTouched");
     expect(source).toContain("Skill not known (-3 default). GM may adjust or forbid.");
-    expect(source).toContain("No stats available for this actor.");
+    expect(source).toContain("profile.warning");
     expect(typesSource).toContain("profile?: ParticipantSkillRollProfile");
     expect(typesSource).toContain("warning?: string");
   });

--- a/apps/web/app/(app)/encounters/[id]/RoleplayEncounterScreens.tsx
+++ b/apps/web/app/(app)/encounters/[id]/RoleplayEncounterScreens.tsx
@@ -223,11 +223,12 @@ function readSystemSkillOptions(input: {
         label: skill.name,
         profile,
         value: profile.rollBaseValue,
-        warning: profile.known
-          ? undefined
-          : profile.sourceQuality === "missing"
-            ? "No stats available for this actor."
-            : "Skill not known (-3 default). GM may adjust or forbid.",
+        warning: profile.warning
+          ? profile.warning ===
+              "Skill not known: using linked stat average with -3 default modifier. GM may adjust or forbid."
+            ? "Skill not known (-3 default). GM may adjust or forbid."
+            : profile.warning
+          : undefined,
       };
     })
     .sort((left, right) => left.label.localeCompare(right.label));

--- a/apps/web/app/(app)/encounters/[id]/RoleplayEncounterScreens.tsx
+++ b/apps/web/app/(app)/encounters/[id]/RoleplayEncounterScreens.tsx
@@ -223,7 +223,11 @@ function readSystemSkillOptions(input: {
         label: skill.name,
         profile,
         value: profile.rollBaseValue,
-        warning: profile.known ? undefined : "Skill not known (-3 default). GM may adjust or forbid.",
+        warning: profile.known
+          ? undefined
+          : profile.sourceQuality === "missing"
+            ? "No stats available for this actor."
+            : "Skill not known (-3 default). GM may adjust or forbid.",
       };
     })
     .sort((left, right) => left.label.localeCompare(right.label));

--- a/apps/web/src/lib/campaigns/campaignActors.test.ts
+++ b/apps/web/src/lib/campaigns/campaignActors.test.ts
@@ -110,6 +110,24 @@ describe("campaignActors", () => {
       snapshot: {
         actorClass: "template",
         equipmentProfile: "Mail shirt and spear",
+        humanoidNpcArchetype: {
+          skills: [{ skillId: "perception", skillName: "Perception", targetLevel: 13 }],
+          stats: {
+            final: {
+              cha: 10,
+              com: 10,
+              con: 10,
+              dex: 10,
+              health: 10,
+              int: 14,
+              lck: 10,
+              pow: 12,
+              siz: 10,
+              str: 10,
+              will: 10
+            }
+          }
+        },
         profession: "guard",
         roleLabel: "Town watch",
         socialClass: "Common",
@@ -143,6 +161,9 @@ describe("campaignActors", () => {
       name: "North Gate Guard",
       snapshot: {
         actorClass: "template",
+        humanoidNpcArchetype: {
+          skills: [{ skillId: "perception", skillName: "Perception", targetLevel: 13 }]
+        },
         profession: "guard",
         templateId: "template-guard"
       }

--- a/apps/web/src/lib/campaigns/campaignActors.ts
+++ b/apps/web/src/lib/campaigns/campaignActors.ts
@@ -112,13 +112,15 @@ export function buildScenarioActorInputFromTemplate(input: {
   snapshot: Record<string, unknown>;
 } {
   const metadata = getCampaignActorMetadata(input.template);
+  const sourceSnapshot = isObject(input.template.snapshot) ? input.template.snapshot : {};
 
   return {
     description: input.template.description,
     kind: input.template.kind,
     name: input.name?.trim() || input.template.name,
     snapshot: {
-      actorClass: "template",
+      ...sourceSnapshot,
+      actorClass: metadata.actorClass === "generated_npc" ? "generated_npc" : "template",
       equipmentProfile: metadata.equipmentProfile,
       profession: metadata.profession,
       roleLabel: metadata.roleLabel,

--- a/packages/database/src/services/scenarioService.test.ts
+++ b/packages/database/src/services/scenarioService.test.ts
@@ -100,6 +100,62 @@ describe("ScenarioService controller assignment", () => {
     expect(participants).toHaveLength(2);
   });
 
+  it("preserves temporary actor build, sheet, and equipment snapshots from entity input", async () => {
+    const { repository } = createScenarioRepositoryStub();
+    const sourceBuild = createCharacterRecord({
+      id: "template-build-1",
+      name: "City Guard",
+    }).build;
+    const sheetSummary = {
+      draftView: {
+        skills: [{ skillId: "perception", totalSkill: 18 }],
+      },
+    };
+    const equipmentState = {
+      activeLoadoutByCharacterId: {
+        "template-build-1": {
+          activePrimaryWeaponItemId: "spear-1",
+          readyShieldItemId: "shield-1",
+        },
+      },
+      itemsById: {
+        "rope-1": { characterId: "template-build-1" },
+        "shield-1": { characterId: "template-build-1" },
+        "spear-1": { characterId: "template-build-1", isEquipped: true },
+      },
+    };
+    const service = new ScenarioService(repository);
+
+    const participant = await service.addEntityParticipant({
+      entityInput: {
+        gmUserId: "gm-1",
+        kind: "npc",
+        name: "City Guard",
+        snapshot: {
+          actorClass: "template",
+          build: sourceBuild,
+          equipmentState,
+          sheetSummary,
+        },
+      },
+      isTemporary: true,
+      role: "npc",
+      scenarioId: "scenario-1",
+    });
+
+    expect(participant.snapshot).toMatchObject({
+      build: sourceBuild,
+      displayName: "City Guard",
+      equipmentState,
+      sheetSummary,
+    });
+    expect(participant.state.equipment).toMatchObject({
+      carriedItemIds: ["rope-1", "shield-1", "spear-1"],
+      equippedItemIds: ["spear-1"],
+      readyItemIds: ["shield-1", "spear-1"],
+    });
+  });
+
   it("enforces the active-control rule when participant metadata is reassigned", async () => {
     const { repository } = createScenarioRepositoryStub();
     const characters = new Map([

--- a/packages/domain/src/campaign/scenario.ts
+++ b/packages/domain/src/campaign/scenario.ts
@@ -533,6 +533,38 @@ export function createParticipantSnapshotFromCharacter(input: {
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function looksLikeCharacterBuild(value: unknown): value is CharacterBuild {
+  return isRecord(value) && isRecord(value.profile) && isRecord(value.progression);
+}
+
+function readEntitySnapshotBuild(snapshot: unknown): unknown {
+  if (!isRecord(snapshot)) {
+    return snapshot;
+  }
+
+  if (looksLikeCharacterBuild(snapshot.build)) {
+    return snapshot.build;
+  }
+
+  if (looksLikeCharacterBuild(snapshot)) {
+    return snapshot;
+  }
+
+  return snapshot;
+}
+
+function readEntitySnapshotField(snapshot: unknown, field: "equipmentState" | "sheetSummary"): unknown {
+  if (!isRecord(snapshot)) {
+    return undefined;
+  }
+
+  return snapshot[field];
+}
+
 export function createParticipantSnapshotFromEntity(input: {
   entity: {
     description?: string | null;
@@ -548,10 +580,13 @@ export function createParticipantSnapshotFromEntity(input: {
   state: ScenarioParticipantState;
 } {
   const maxHp = Math.max(1, input.maxHp ?? 10);
+  const build = readEntitySnapshotBuild(input.entity.snapshot);
+  const equipmentState = readEntitySnapshotField(input.entity.snapshot, "equipmentState");
+  const sheetSummary = readEntitySnapshotField(input.entity.snapshot, "sheetSummary");
 
   return {
     snapshot: scenarioParticipantSnapshotSchema.parse({
-      build: input.entity.snapshot ?? undefined,
+      build: build ?? undefined,
       displayName: input.entity.name,
       entity: {
         description: input.entity.description ?? undefined,
@@ -559,6 +594,8 @@ export function createParticipantSnapshotFromEntity(input: {
         name: input.entity.name,
         notes: input.entity.notes ?? undefined
       },
+      equipmentState,
+      sheetSummary,
       sourceUpdatedAt: input.sourceUpdatedAt
     }),
     state: scenarioParticipantStateSchema.parse({
@@ -566,7 +603,7 @@ export function createParticipantSnapshotFromEntity(input: {
         engaged: false
       },
       conditions: [],
-      equipment: {},
+      equipment: inferEquipmentArrays(equipmentState),
       health: {
         bleeding: 0,
         currentHp: clampHealth(maxHp, maxHp),

--- a/packages/rules-engine/src/encounters/resolveParticipantSkillRollProfile.test.ts
+++ b/packages/rules-engine/src/encounters/resolveParticipantSkillRollProfile.test.ts
@@ -387,7 +387,7 @@ describe("resolveParticipantSkillRollProfile", () => {
     expect(profile.warning).toContain("Skill not known");
   });
 
-  it("uses generated temporary actor target levels for known skills", () => {
+  it("adds generated temporary actor skill ranks to linked stat average for known skills", () => {
     const profile = resolveParticipantSkillRollProfile({
       build: {
         actorClass: "generated_npc",
@@ -416,11 +416,78 @@ describe("resolveParticipantSkillRollProfile", () => {
     expect(profile).toMatchObject({
       avgStats: 15,
       known: true,
-      rollBaseValue: 18,
+      rollBaseValue: 33,
       sourceQuality: "snapshot",
-      totalSkillLevel: 18,
+      skillXP: 18,
+      totalSkillLevel: 33,
+      totalXP: 18,
       unknownSkillPenalty: 0,
       warning: undefined,
+    });
+  });
+
+  it("uses explicit generated temporary actor final skill totals when the source stores totals", () => {
+    const profile = resolveParticipantSkillRollProfile({
+      build: {
+        actorClass: "generated_npc",
+        generatedHumanoidNpc: {
+          skills: [{ skillId: "perception", skillName: "Perception", totalSkill: 18 }],
+          stats: {
+            final: {
+              cha: 10,
+              com: 10,
+              con: 10,
+              dex: 11,
+              health: 10,
+              int: 14,
+              lck: 10,
+              pow: 16,
+              siz: 10,
+              str: 10,
+              will: 10,
+            },
+          },
+        },
+      },
+      skill: perceptionSkill,
+    });
+
+    expect(profile).toMatchObject({
+      avgStats: 15,
+      known: true,
+      rollBaseValue: 18,
+      skillXP: 3,
+      totalSkillLevel: 18,
+      totalXP: 3,
+      warning: undefined,
+    });
+  });
+
+  it("normalizes generated temporary actor stat keys before calculating linked stat averages", () => {
+    const profile = resolveParticipantSkillRollProfile({
+      build: {
+        actorClass: "generated_npc",
+        generatedHumanoidNpc: {
+          skills: [{ skillId: "perception", skillName: "Perception", targetLevel: 8 }],
+          stats: {
+            final: {
+              DEX: 11,
+              INT: 14,
+              POW: 16,
+              STR: 12,
+            },
+          },
+        },
+      },
+      skill: perceptionSkill,
+    });
+
+    expect(profile).toMatchObject({
+      avgStats: 15,
+      known: true,
+      rollBaseValue: 23,
+      skillXP: 8,
+      totalSkillLevel: 23,
     });
   });
 
@@ -455,6 +522,30 @@ describe("resolveParticipantSkillRollProfile", () => {
       rollBaseValue: 14,
       sourceQuality: "snapshot",
       unknownSkillPenalty: -3,
+    });
+  });
+
+  it("warns when a generated temporary actor has skill ranks but no stats", () => {
+    const profile = resolveParticipantSkillRollProfile({
+      build: {
+        actorClass: "generated_npc",
+        generatedHumanoidNpc: {
+          skills: [{ skillId: "perception", skillName: "Perception", targetLevel: 8 }],
+        },
+      },
+      skill: perceptionSkill,
+    });
+
+    expect(profile).toMatchObject({
+      avgStats: 0,
+      known: true,
+      rollBaseValue: 8,
+      sourceQuality: "snapshot",
+      skillXP: 8,
+      totalSkillLevel: 8,
+      totalXP: 8,
+      unknownSkillPenalty: 0,
+      warning: "Stats unavailable; using stored skill value only.",
     });
   });
 

--- a/packages/rules-engine/src/encounters/resolveParticipantSkillRollProfile.test.ts
+++ b/packages/rules-engine/src/encounters/resolveParticipantSkillRollProfile.test.ts
@@ -352,6 +352,112 @@ describe("resolveParticipantSkillRollProfile", () => {
     expect(opponentProfile.rollBaseValue).toBe(23);
   });
 
+  it("uses generated temporary actor stats for unknown skills", () => {
+    const profile = resolveParticipantSkillRollProfile({
+      build: {
+        actorClass: "generated_npc",
+        generatedHumanoidNpc: {
+          stats: {
+            final: {
+              cha: 10,
+              com: 10,
+              con: 10,
+              dex: 11,
+              health: 10,
+              int: 14,
+              lck: 10,
+              pow: 16,
+              siz: 10,
+              str: 10,
+              will: 10,
+            },
+          },
+        },
+      },
+      skill: perceptionSkill,
+    });
+
+    expect(profile).toMatchObject({
+      avgStats: 15,
+      known: false,
+      rollBaseValue: 15,
+      sourceQuality: "snapshot",
+      unknownSkillPenalty: -3,
+    });
+    expect(profile.warning).toContain("Skill not known");
+  });
+
+  it("uses generated temporary actor target levels for known skills", () => {
+    const profile = resolveParticipantSkillRollProfile({
+      build: {
+        actorClass: "generated_npc",
+        generatedHumanoidNpc: {
+          skills: [{ skillId: "perception", skillName: "Perception", targetLevel: 18 }],
+          stats: {
+            final: {
+              cha: 10,
+              com: 10,
+              con: 10,
+              dex: 11,
+              health: 10,
+              int: 14,
+              lck: 10,
+              pow: 16,
+              siz: 10,
+              str: 10,
+              will: 10,
+            },
+          },
+        },
+      },
+      skill: perceptionSkill,
+    });
+
+    expect(profile).toMatchObject({
+      avgStats: 15,
+      known: true,
+      rollBaseValue: 18,
+      sourceQuality: "snapshot",
+      totalSkillLevel: 18,
+      unknownSkillPenalty: 0,
+      warning: undefined,
+    });
+  });
+
+  it("uses humanoid archetype snapshot stats for temporary actors created directly from templates", () => {
+    const profile = resolveParticipantSkillRollProfile({
+      build: {
+        actorClass: "template",
+        humanoidNpcArchetype: {
+          stats: {
+            final: {
+              cha: 10,
+              com: 10,
+              con: 10,
+              dex: 11,
+              health: 10,
+              int: 13,
+              lck: 10,
+              pow: 15,
+              siz: 10,
+              str: 10,
+              will: 10,
+            },
+          },
+        },
+      },
+      skill: perceptionSkill,
+    });
+
+    expect(profile).toMatchObject({
+      avgStats: 14,
+      known: false,
+      rollBaseValue: 14,
+      sourceQuality: "snapshot",
+      unknownSkillPenalty: -3,
+    });
+  });
+
   it("returns a safe missing-source fallback for temporary actors without stats", () => {
     const profile = resolveParticipantSkillRollProfile({
       sheetSummary: {},
@@ -365,6 +471,6 @@ describe("resolveParticipantSkillRollProfile", () => {
       sourceQuality: "missing",
       unknownSkillPenalty: -3,
     });
-    expect(profile.warning).toContain("Linked stats could not be resolved");
+    expect(profile.warning).toBe("No stats available for this actor.");
   });
 });

--- a/packages/rules-engine/src/encounters/resolveParticipantSkillRollProfile.ts
+++ b/packages/rules-engine/src/encounters/resolveParticipantSkillRollProfile.ts
@@ -53,6 +53,32 @@ export interface ResolveParticipantSkillRollProfileInput {
 const UNKNOWN_SKILL_WARNING =
   "Skill not known: using linked stat average with -3 default modifier. GM may adjust or forbid.";
 const NO_STATS_WARNING = "No stats available for this actor.";
+const PARTIAL_STATS_WARNING = "Stats unavailable; using stored skill value only.";
+
+const STAT_KEY_ALIASES: Record<string, string> = {
+  charisma: "cha",
+  cha: "cha",
+  com: "com",
+  comeliness: "com",
+  con: "con",
+  constitution: "con",
+  dex: "dex",
+  dexterity: "dex",
+  health: "health",
+  hp: "health",
+  int: "int",
+  intelligence: "int",
+  lck: "lck",
+  luck: "lck",
+  pow: "pow",
+  power: "pow",
+  siz: "siz",
+  size: "siz",
+  str: "str",
+  strength: "str",
+  will: "will",
+  willpower: "will",
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -73,7 +99,8 @@ function readStatsFromRecord(value: unknown): Record<string, number> | undefined
 
   const entries = Object.entries(value).flatMap(([key, entry]) => {
     const numeric = readNumber(entry);
-    return numeric == null ? [] : ([[key, numeric]] as const);
+    const normalizedKey = STAT_KEY_ALIASES[key.trim().toLowerCase()] ?? key.trim().toLowerCase();
+    return numeric == null ? [] : ([[normalizedKey, numeric]] as const);
   });
 
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
@@ -188,6 +215,23 @@ function readSnapshotSkillView(input: {
   return undefined;
 }
 
+function readSnapshotFinalSkill(skillView: Record<string, unknown> | undefined): number | undefined {
+  return readNumber(skillView?.totalSkill) ?? readNumber(skillView?.totalSkillLevel);
+}
+
+function readSnapshotSkillContribution(skillView: Record<string, unknown> | undefined): number | undefined {
+  // Generated/template NPC `targetLevel` values come from seniority bands and represent
+  // skill contribution/ranks. Explicit totalSkill fields, when present, are final totals.
+  return (
+    readNumber(skillView?.effectiveSkillNumber) ??
+    readNumber(skillView?.skillXP) ??
+    readNumber(skillView?.skillXp) ??
+    readNumber(skillView?.ranks) ??
+    readNumber(skillView?.targetLevel) ??
+    readNumber(skillView?.level)
+  );
+}
+
 function hasDraftViewSkills(sheetSummary: unknown): boolean {
   return (
     isRecord(sheetSummary) &&
@@ -266,26 +310,36 @@ export function resolveParticipantSkillRollProfile(
     readNumber(skillView?.linkedStatAverage) ??
     getLinkedStatAverage({ linkedStats: input.skill.linkedStats, stats }) ??
     0;
-  const snapshotTotalSkill =
-    readNumber(snapshotSkillView?.totalSkill) ??
-    readNumber(snapshotSkillView?.totalSkillLevel) ??
-    readNumber(snapshotSkillView?.targetLevel) ??
-    readNumber(snapshotSkillView?.level);
+  const snapshotFinalSkill = readSnapshotFinalSkill(snapshotSkillView);
+  const snapshotSkillContribution = readSnapshotSkillContribution(snapshotSkillView);
+  const hasStats = Boolean(stats);
   const groupXP = readBestGroupXp({ sheetSummary, skill: input.skill }) ?? readNumber(skillView?.groupLevel) ?? 0;
   const skillXP =
     readNumber(skillView?.specificSkillLevel) ??
-    (snapshotTotalSkill == null ? 0 : Math.max(0, snapshotTotalSkill - avgStats));
+    (snapshotFinalSkill == null
+      ? snapshotSkillContribution ?? 0
+      : Math.max(0, snapshotFinalSkill - avgStats));
   const derivedXP = readNumber(skillView?.relationshipGrantedSkillLevel) ?? 0;
   const totalXP =
     readNumber(skillView?.effectiveSkillNumber) ??
-    (snapshotTotalSkill == null ? groupXP + skillXP + derivedXP : Math.max(0, snapshotTotalSkill - avgStats));
-  const totalSkillLevel = readNumber(skillView?.totalSkill) ?? snapshotTotalSkill ?? avgStats + totalXP;
-  const known = (Boolean(skillView) && totalXP > 0) || (snapshotTotalSkill != null && snapshotTotalSkill > 0);
+    (snapshotFinalSkill == null ? groupXP + skillXP + derivedXP : Math.max(0, snapshotFinalSkill - avgStats));
+  const totalSkillLevel = readNumber(skillView?.totalSkill) ?? snapshotFinalSkill ?? avgStats + totalXP;
+  const known =
+    (Boolean(skillView) && totalXP > 0) ||
+    (snapshotFinalSkill != null && snapshotFinalSkill > 0) ||
+    (snapshotSkillContribution != null && snapshotSkillContribution > 0);
   const sourceQuality: ParticipantSkillRollProfile["sourceQuality"] = skillView
     ? "full"
     : stats || snapshotSkillView
       ? "snapshot"
       : "missing";
+  const warning = known
+    ? !hasStats && snapshotFinalSkill == null && snapshotSkillContribution != null
+      ? PARTIAL_STATS_WARNING
+      : undefined
+    : sourceQuality === "missing"
+      ? NO_STATS_WARNING
+      : UNKNOWN_SKILL_WARNING;
 
   return {
     avgStats,
@@ -303,10 +357,6 @@ export function resolveParticipantSkillRollProfile(
     totalSkillLevel: known ? totalSkillLevel : avgStats,
     totalXP: known ? totalXP : 0,
     unknownSkillPenalty: known ? 0 : -3,
-    warning: known
-      ? undefined
-      : sourceQuality === "missing"
-        ? NO_STATS_WARNING
-        : UNKNOWN_SKILL_WARNING,
+    warning,
   };
 }

--- a/packages/rules-engine/src/encounters/resolveParticipantSkillRollProfile.ts
+++ b/packages/rules-engine/src/encounters/resolveParticipantSkillRollProfile.ts
@@ -52,6 +52,7 @@ export interface ResolveParticipantSkillRollProfileInput {
 
 const UNKNOWN_SKILL_WARNING =
   "Skill not known: using linked stat average with -3 default modifier. GM may adjust or forbid.";
+const NO_STATS_WARNING = "No stats available for this actor.";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -98,6 +99,26 @@ function readSheetStats(sheetSummary: unknown): Record<string, number> | undefin
   );
 }
 
+function readStatsBlock(value: unknown): Record<string, number> | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  return readStatsFromRecord(value.final) ?? readStatsFromRecord(value.base) ?? readStatsFromRecord(value);
+}
+
+function readSnapshotStats(snapshot: unknown): Record<string, number> | undefined {
+  if (!isRecord(snapshot)) {
+    return undefined;
+  }
+
+  return (
+    (isRecord(snapshot.generatedHumanoidNpc) ? readStatsBlock(snapshot.generatedHumanoidNpc.stats) : undefined) ??
+    (isRecord(snapshot.humanoidNpcArchetype) ? readStatsBlock(snapshot.humanoidNpcArchetype.stats) : undefined) ??
+    readStatsBlock(snapshot.stats)
+  );
+}
+
 function getLinkedStatAverage(input: {
   linkedStats: readonly string[];
   stats?: Record<string, number>;
@@ -133,6 +154,38 @@ function findSkillView(input: {
     (skill): skill is Record<string, unknown> =>
       isRecord(skill) && readString(skill.skillId) === input.skillId
   );
+}
+
+function readSnapshotSkillView(input: {
+  snapshot?: unknown;
+  skillId: string;
+}): Record<string, unknown> | undefined {
+  if (!isRecord(input.snapshot)) {
+    return undefined;
+  }
+
+  const skillLists = [
+    isRecord(input.snapshot.generatedHumanoidNpc) ? input.snapshot.generatedHumanoidNpc.skills : undefined,
+    isRecord(input.snapshot.humanoidNpcArchetype) ? input.snapshot.humanoidNpcArchetype.skills : undefined,
+    input.snapshot.skills,
+  ];
+
+  for (const skills of skillLists) {
+    if (!Array.isArray(skills)) {
+      continue;
+    }
+
+    const skill = skills.find(
+      (entry): entry is Record<string, unknown> =>
+        isRecord(entry) && readString(entry.skillId) === input.skillId
+    );
+
+    if (skill) {
+      return skill;
+    }
+  }
+
+  return undefined;
 }
 
 function hasDraftViewSkills(sheetSummary: unknown): boolean {
@@ -204,20 +257,33 @@ export function resolveParticipantSkillRollProfile(
     sheetSummary,
     skillId: input.skill.id,
   });
-  const stats = readProfileStats(input.build) ?? readSheetStats(sheetSummary);
+  const snapshotSkillView = readSnapshotSkillView({
+    snapshot: input.build,
+    skillId: input.skill.id,
+  });
+  const stats = readProfileStats(input.build) ?? readSheetStats(sheetSummary) ?? readSnapshotStats(input.build);
   const avgStats =
     readNumber(skillView?.linkedStatAverage) ??
     getLinkedStatAverage({ linkedStats: input.skill.linkedStats, stats }) ??
     0;
+  const snapshotTotalSkill =
+    readNumber(snapshotSkillView?.totalSkill) ??
+    readNumber(snapshotSkillView?.totalSkillLevel) ??
+    readNumber(snapshotSkillView?.targetLevel) ??
+    readNumber(snapshotSkillView?.level);
   const groupXP = readBestGroupXp({ sheetSummary, skill: input.skill }) ?? readNumber(skillView?.groupLevel) ?? 0;
-  const skillXP = readNumber(skillView?.specificSkillLevel) ?? 0;
+  const skillXP =
+    readNumber(skillView?.specificSkillLevel) ??
+    (snapshotTotalSkill == null ? 0 : Math.max(0, snapshotTotalSkill - avgStats));
   const derivedXP = readNumber(skillView?.relationshipGrantedSkillLevel) ?? 0;
-  const totalXP = readNumber(skillView?.effectiveSkillNumber) ?? groupXP + skillXP + derivedXP;
-  const totalSkillLevel = readNumber(skillView?.totalSkill) ?? avgStats + totalXP;
-  const known = Boolean(skillView) && totalXP > 0;
+  const totalXP =
+    readNumber(skillView?.effectiveSkillNumber) ??
+    (snapshotTotalSkill == null ? groupXP + skillXP + derivedXP : Math.max(0, snapshotTotalSkill - avgStats));
+  const totalSkillLevel = readNumber(skillView?.totalSkill) ?? snapshotTotalSkill ?? avgStats + totalXP;
+  const known = (Boolean(skillView) && totalXP > 0) || (snapshotTotalSkill != null && snapshotTotalSkill > 0);
   const sourceQuality: ParticipantSkillRollProfile["sourceQuality"] = skillView
     ? "full"
-    : stats
+    : stats || snapshotSkillView
       ? "snapshot"
       : "missing";
 
@@ -240,7 +306,7 @@ export function resolveParticipantSkillRollProfile(
     warning: known
       ? undefined
       : sourceQuality === "missing"
-        ? `${UNKNOWN_SKILL_WARNING} Linked stats could not be resolved.`
+        ? NO_STATS_WARNING
         : UNKNOWN_SKILL_WARNING,
   };
 }


### PR DESCRIPTION
## Summary

Adds the first Player General Encounter screen and improves the Campaign → Scenario → Encounter workflow for both GM and Player use.

This branch adds player-safe encounter access, player roll assignment/submission, roleplay roll calculation improvements, campaign/scenario workflow cleanup, and fixes several interaction bugs found during manual testing.

## Main changes

### Campaign / Scenario workflow

- Cleaned up the player-facing Campaign and Scenario pages so they show only story-facing/actionable information.
- Removed player-facing internal/admin concepts such as fallback participant counts, scenario kind, combat status, phase/round, and future placeholder text.
- Removed campaign self-join UI/concept.
- Fixed Character page “Join scenario” flow so it uses campaign roster + live scenario access instead of campaign self-join.
- Removed Scenario Kind and Combat columns/selectors from the campaign scenario list/create flow.
- Added `docs/product/campaign-scenario-encounter-workflows.md` as a product guide for what belongs on Campaign, Scenario, and Encounter pages.

### Campaign roster

- Fixed campaign roster membership removal.
- The roster now uses the `Member` checkbox as the single add/remove control.
- Added source-key removal route:
  - `DELETE /campaigns/:campaignId/roster-membership/:sourceType/:sourceId`
- Made roster membership removal idempotent.
- Fixed the client request bug where bodyless `DELETE` requests sent `content-type: application/json`, causing Fastify to reject them before the route handler.
- Removing a roster member does not delete the underlying character/template/entity.

### Player General Encounter screen

- Added a player-safe encounter screen showing:
  - encounter heading and description
  - Situation
  - PCs and NPCs visible to the player
  - player skill roll grid
  - ranked roll results
  - character log
- Player views do not expose GM-only action log, visibility controls, hidden participants, silent rolls, internal ids, or fallback implementation details.
- Added player-safe encounter read model and filtering.

### Encounter access and membership

- Added default encounter participant fallback:
  - if an encounter has no explicit participants, active concrete scenario participants are treated as effective participants.
  - once the GM explicitly edits encounter membership, explicit membership is used and fallback is disabled.
- Added `participantMembershipMode` in encounter session JSON to distinguish default fallback from explicit membership.
- Player access now updates on refresh/focus/polling and stops showing stale encounter views when access is rescinded.

### Roleplay roll flow

- Added player-safe assigned roll submission endpoint:
  - `POST /encounters/:encounterId/player-roll`
- Player assigned non-silent rolls can now be rolled by the player without using GM-only update routes.
- GM sees player-submitted assigned roll results.
- Opposed assigned rolls now preserve roll-set identity, pending roll id, and side (`actor` / `opponent`) so comparisons resolve correctly.
- Opposed rolls are excluded from ranked results.
- Non-opposed roll stacks now keep a shared stack id so GM/player ranked results include all visible current-stack results once, sorted correctly.
- GM Clear resets the shared ranked roll stack for all players.
- Player Clear clears only the local player display.

### Skill roll calculation

- Known skills now use Character Sheet total skill level.
- Unknown skills use linked stat average and default raw `Other mod = -3`.
- Added warning for unknown skills:
  - `Skill not known (-3 default).`
- Added roleplay modifier pipeline:
  - raw modifiers are summed and applied through the existing workbook percentage modifier table.
  - `Other mod` is now a raw modifier, not a direct flat subtraction.
  - Gen / OB-Skill / DB remain placeholder flags until character-state/map-derived modifier sources are implemented.
- Support rolls now roll/display separately when support skill is selected; support result is currently display/log metadata and does not modify the main result.

### Generated/template actors

- Preserved generated/template actor snapshot data when creating scenario-local temporary actors.
- Generated NPC/template stats and skill data are now available to the skill roll resolver.
- `generatedHumanoidNpc.skills[].targetLevel` and `humanoidNpcArchetype.skills[].targetLevel` are treated as skill contribution/ranks, not final totals.
- Generated/template actor roll base now uses:
  - linked stat average + targetLevel
- Added fallback warning when an actor has skill data but no usable stats:
  - `Stats unavailable; using stored skill value only.`
- Added clear missing-stat warning:
  - `No stats available for this actor.`

### UI / component cleanup

- Re-extracted roleplay encounter UI into local components after merging main:
  - `RoleplayRollBlock`
  - `RoleplayCalculationPanel`
  - `RoleplaySections`
  - shared roll types/styles
- Reduced brittleness of source-level tests after extraction.
- Preserved player-general encounter behavior while improving readability.

## Notes / limitations

- Free/local player rolls remain local-only for now.
- Assigned non-silent GM rolls can be submitted by players through the player-safe endpoint.
- Support roll results are recorded/displayed, but do not yet modify the main skill roll.
- Gen / OB-Skill / DB flags remain placeholders until character-state, equipment, and situation-map modifier sources are implemented.
- No database migration is included.

## Verification

Passed locally:

- `pnpm --filter @glantri/domain test`
- `pnpm --filter @glantri/rules-engine test`
- `pnpm --filter @glantri/api test`
- `pnpm --filter @glantri/database test`
- `pnpm --filter @glantri/web test`
- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `pnpm build`

## Manual checks performed

- GM can add/remove campaign roster members with the Member checkbox.
- Campaign roster removal no longer throws `Bad Request`.
- Player can navigate Campaign → Scenario → Player Encounter.
- Player access updates when GM changes explicit encounter membership.
- GM can assign non-opposed rolls to multiple participants.
- Player-submitted assigned rolls appear in GM ranked results.
- Player ranked results dedupe correctly and clear with GM Clear / Player Clear behavior.
- Opposed assigned rolls resolve correctly and do not appear in ranked results.
- Generated/template actors now produce plausible skill values from stats + targetLevel.