### PR TITLE
fix: @secure() på Bicep databaseUrl og appInsightsConnectionString (#135)

### DIFF
--- a/infra/modules/kvSecrets.bicep
+++ b/infra/modules/kvSecrets.bicep
@@ -1,6 +1,11 @@
 param kvName string
+
+@secure()
 param databaseUrl string
+
 param webOrigin string
+
+@secure()
 param appInsightsConnectionString string
 
 resource kv 'Microsoft.KeyVault/vaults@2023-07-01' existing = {


### PR DESCRIPTION
## Sammendrag

- Merker `databaseUrl` med `@secure()` i `kvSecrets.bicep` — database-URL-en inneholder admin-passordet og ble lagret i klartekst i ARM deployment-historikken
- Merker også `appInsightsConnectionString` med `@secure()` siden instrumentation key ikke bør eksponeres i deployment-historikk

## Hvorfor

ARM/Bicep nested deployments lagrer parameterverdier som ikke er merket `@secure()` i deployment-historikken for ressursgruppen. Enhver Azure-principal med `Microsoft.Resources/deployments/read` kunne lese ut fullstendig database-URL inkludert admin-passord.

## Etter merge

Ro`ter DB-admin-passordet manuelt i Azure Portal etter merge, siden deployment-historikken med det eksponerte passordet ikke slettes automatisk.

## Testplan

- [x] Ingen kodeendringer — kun Bicep-annotering
- [ ] Verifiser at neste deploy ikke feiler på parameter-validering

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)