### PR TITLE
refactor: felles admin-tabellkomponenter for katalogsider (#108)

### DIFF
--- a/apps/web/app/(app)/admin/admin-ui.tsx
+++ b/apps/web/app/(app)/admin/admin-ui.tsx
@@ -541,6 +541,94 @@ export function AdminTextarea(props: TextareaHTMLAttributes<HTMLTextAreaElement>
   return <textarea {...props} style={{ ...inputStyle, minHeight: 132, ...(props.style ?? {}) }} />;
 }
 
+export function formatAdminEnumLabel(value: string): string {
+  return value
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function AdminCatalogTable(props: {
+  columns: string[];
+  emptyLabel: string;
+  rows: string[][];
+  stickyHeader?: boolean;
+}) {
+  return props.rows.length > 0 ? (
+    <div style={{ maxHeight: props.stickyHeader ? "70vh" : undefined, overflow: "auto" }}>
+      <table style={{ borderCollapse: "collapse", minWidth: "100%", width: "100%" }}>
+        <thead>
+          <tr style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.14)", textAlign: "left" }}>
+            {props.columns.map((column) => (
+              <th
+                key={column}
+                style={{
+                  background: "rgba(250, 245, 234, 0.98)",
+                  padding: "0.55rem 0.75rem 0.55rem 0",
+                  position: props.stickyHeader ? "sticky" : undefined,
+                  top: props.stickyHeader ? 0 : undefined,
+                  verticalAlign: "bottom",
+                  zIndex: props.stickyHeader ? 1 : undefined
+                }}
+              >
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {props.rows.map((row, rowIndex) => (
+            <tr key={`catalog-row-${rowIndex}`} style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.08)" }}>
+              {row.map((value, cellIndex) => (
+                <td
+                  key={`catalog-row-${rowIndex}-${cellIndex}`}
+                  style={{ padding: "0.65rem 0.75rem 0.65rem 0", verticalAlign: "top" }}
+                >
+                  {value}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ) : (
+    <div>{props.emptyLabel}</div>
+  );
+}
+
+export function AdminFilterBar(props: { children: ReactNode }) {
+  return (
+    <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
+      {props.children}
+    </div>
+  );
+}
+
+export function AdminFilterSelect<T extends string>(props: {
+  label: string;
+  onChange: (value: T) => void;
+  options: T[];
+  formatOption?: (value: T) => string;
+  value: T;
+}) {
+  return (
+    <label style={{ display: "grid", gap: "0.25rem", minWidth: 160 }}>
+      <span style={{ color: "#5f543a", fontSize: "0.9rem", fontWeight: 600 }}>{props.label}</span>
+      <AdminSelect
+        onChange={(event) => props.onChange(event.target.value as T)}
+        value={props.value}
+      >
+        {props.options.map((option) => (
+          <option key={option} value={option}>
+            {props.formatOption ? props.formatOption(option) : option}
+          </option>
+        ))}
+      </AdminSelect>
+    </label>
+  );
+}
+
 export function AdminCheckboxList(props: {
   options: Array<{ label: string; selected: boolean; value: string }>;
   onToggle: (value: string) => void;

--- a/apps/web/app/(app)/admin/gear/GearAdminPage.tsx
+++ b/apps/web/app/(app)/admin/gear/GearAdminPage.tsx
@@ -4,7 +4,14 @@ import { useMemo, useState } from "react";
 import { equipmentTemplates } from "@glantri/content/equipment";
 import type { GearTemplate, MaterialType, QualityType } from "@glantri/domain";
 
-import { AdminPageIntro, AdminPanel } from "../admin-ui";
+import {
+  AdminCatalogTable,
+  AdminFilterBar,
+  AdminFilterSelect,
+  AdminPageIntro,
+  AdminPanel,
+  formatAdminEnumLabel,
+} from "../admin-ui";
 import {
   buildTemplateCatalogTable,
   getAdminTemplateCatalogRows,
@@ -12,58 +19,6 @@ import {
 
 const materialOptions: MaterialType[] = ["steel", "bronze", "wood", "leather", "cloth"];
 const qualityOptions: QualityType[] = ["standard", "extraordinary"];
-
-function formatLabel(value: string): string {
-  return value
-    .split("_")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function TableShell(input: {
-  columns: string[];
-  emptyLabel: string;
-  rows: string[][];
-}) {
-  return input.rows.length > 0 ? (
-    <div style={{ maxHeight: "70vh", overflow: "auto" }}>
-      <table style={{ borderCollapse: "collapse", minWidth: "100%", width: "100%" }}>
-        <thead>
-          <tr style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.14)", textAlign: "left" }}>
-            {input.columns.map((column) => (
-              <th
-                key={column}
-                style={{
-                  background: "rgba(250, 245, 234, 0.98)",
-                  padding: "0.55rem 0.75rem 0.55rem 0",
-                  position: "sticky",
-                  top: 0,
-                  verticalAlign: "bottom",
-                  zIndex: 1,
-                }}
-              >
-                {column}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {input.rows.map((row, index) => (
-            <tr key={`gear-row-${index}`} style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.08)" }}>
-              {row.map((value, cellIndex) => (
-                <td key={`gear-row-${index}-${cellIndex}`} style={{ padding: "0.65rem 0.75rem 0.65rem 0", verticalAlign: "top" }}>
-                  {value}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  ) : (
-    <div>{input.emptyLabel}</div>
-  );
-}
 
 export default function GearAdminPage() {
   const [material, setMaterial] = useState<MaterialType>("steel");
@@ -96,50 +51,22 @@ export default function GearAdminPage() {
         title="Gear"
         summary="Read-only catalog view of system gear templates."
         actions={
-          <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
-            <label style={{ display: "grid", gap: "0.25rem", minWidth: 160 }}>
-              <span style={{ color: "#5f543a", fontSize: "0.9rem", fontWeight: 600 }}>Material</span>
-              <select
-                onChange={(event) => setMaterial(event.target.value as MaterialType)}
-                style={{
-                  background: "rgba(255, 252, 245, 0.95)",
-                  border: "1px solid rgba(85, 73, 48, 0.18)",
-                  borderRadius: 14,
-                  color: "#2e2619",
-                  font: "inherit",
-                  padding: "0.65rem 0.8rem",
-                }}
-                value={material}
-              >
-                {materialOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {formatLabel(option)}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label style={{ display: "grid", gap: "0.25rem", minWidth: 160 }}>
-              <span style={{ color: "#5f543a", fontSize: "0.9rem", fontWeight: 600 }}>Quality</span>
-              <select
-                onChange={(event) => setQuality(event.target.value as QualityType)}
-                style={{
-                  background: "rgba(255, 252, 245, 0.95)",
-                  border: "1px solid rgba(85, 73, 48, 0.18)",
-                  borderRadius: 14,
-                  color: "#2e2619",
-                  font: "inherit",
-                  padding: "0.65rem 0.8rem",
-                }}
-                value={quality}
-              >
-                {qualityOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {formatLabel(option)}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
+          <AdminFilterBar>
+            <AdminFilterSelect
+              label="Material"
+              options={materialOptions}
+              value={material}
+              onChange={setMaterial}
+              formatOption={formatAdminEnumLabel}
+            />
+            <AdminFilterSelect
+              label="Quality"
+              options={qualityOptions}
+              value={quality}
+              onChange={setQuality}
+              formatOption={formatAdminEnumLabel}
+            />
+          </AdminFilterBar>
         }
       />
 
@@ -147,10 +74,11 @@ export default function GearAdminPage() {
         title="System Gear Catalog"
         subtitle="Gear templates use the shared simple catalog table structure with encumbrance, value, and notes."
       >
-        <TableShell
+        <AdminCatalogTable
           columns={table.columns.map((column) => String(column))}
           emptyLabel="No gear templates found."
           rows={table.rows}
+          stickyHeader
         />
       </AdminPanel>
     </section>

--- a/apps/web/app/(app)/admin/melee-weapons/MeleeWeaponsAdminPage.tsx
+++ b/apps/web/app/(app)/admin/melee-weapons/MeleeWeaponsAdminPage.tsx
@@ -5,8 +5,12 @@ import { equipmentTemplates } from "@glantri/content/equipment";
 import type { MaterialType, QualityType, WeaponTemplate } from "@glantri/domain";
 
 import {
+  AdminCatalogTable,
+  AdminFilterBar,
+  AdminFilterSelect,
   AdminPageIntro,
   AdminPanel,
+  formatAdminEnumLabel,
 } from "../admin-ui";
 import {
   buildMeleeWeaponCatalogTable,
@@ -16,66 +20,6 @@ import {
 
 const materialOptions: MaterialType[] = ["steel", "bronze"];
 const qualityOptions: QualityType[] = ["standard", "extraordinary"];
-
-function formatLabel(value: string): string {
-  return value
-    .split("_")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function TableShell(input: {
-  columns: string[];
-  emptyLabel: string;
-  rows: string[][];
-}) {
-  return input.rows.length > 0 ? (
-    <div
-      style={{
-        maxHeight: "70vh",
-        overflow: "auto",
-      }}
-    >
-      <table style={{ borderCollapse: "collapse", minWidth: "100%", width: "100%" }}>
-        <thead>
-          <tr style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.14)", textAlign: "left" }}>
-            {input.columns.map((column) => (
-              <th
-                key={column}
-                style={{
-                  background: "rgba(250, 245, 234, 0.98)",
-                  padding: "0.55rem 0.75rem 0.55rem 0",
-                  position: "sticky",
-                  top: 0,
-                  verticalAlign: "bottom",
-                  zIndex: 1,
-                }}
-              >
-                {column}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {input.rows.map((row, index) => (
-            <tr key={`melee-weapons-row-${index}`} style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.08)" }}>
-              {row.map((value, cellIndex) => (
-                <td
-                  key={`melee-weapons-row-${index}-${cellIndex}`}
-                  style={{ padding: "0.65rem 0.75rem 0.65rem 0", verticalAlign: "top" }}
-                >
-                  {value}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  ) : (
-    <div>{input.emptyLabel}</div>
-  );
-}
 
 export default function MeleeWeaponsAdminPage() {
   const [material, setMaterial] = useState<MaterialType>("steel");
@@ -108,51 +52,22 @@ export default function MeleeWeaponsAdminPage() {
         title="Melee weapons"
         summary="Read-only catalog view of system melee and thrown-capable weapon templates."
         actions={
-          <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
-            <label style={{ display: "grid", gap: "0.25rem", minWidth: 160 }}>
-              <span style={{ color: "#5f543a", fontSize: "0.9rem", fontWeight: 600 }}>Material</span>
-              <select
-                onChange={(event) => setMaterial(event.target.value as MaterialType)}
-                style={{
-                  background: "rgba(255, 252, 245, 0.95)",
-                  border: "1px solid rgba(85, 73, 48, 0.18)",
-                  borderRadius: 14,
-                  color: "#2e2619",
-                  font: "inherit",
-                  padding: "0.65rem 0.8rem",
-                }}
-                value={material}
-              >
-                {materialOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {formatLabel(option)}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label style={{ display: "grid", gap: "0.25rem", minWidth: 160 }}>
-              <span style={{ color: "#5f543a", fontSize: "0.9rem", fontWeight: 600 }}>Quality</span>
-              <select
-                onChange={(event) => setQuality(event.target.value as QualityType)}
-                style={{
-                  background: "rgba(255, 252, 245, 0.95)",
-                  border: "1px solid rgba(85, 73, 48, 0.18)",
-                  borderRadius: 14,
-                  color: "#2e2619",
-                  font: "inherit",
-                  padding: "0.65rem 0.8rem",
-                }}
-                value={quality}
-              >
-                {qualityOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {formatLabel(option)}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
+          <AdminFilterBar>
+            <AdminFilterSelect
+              label="Material"
+              options={materialOptions}
+              value={material}
+              onChange={setMaterial}
+              formatOption={formatAdminEnumLabel}
+            />
+            <AdminFilterSelect
+              label="Quality"
+              options={qualityOptions}
+              value={quality}
+              onChange={setQuality}
+              formatOption={formatAdminEnumLabel}
+            />
+          </AdminFilterBar>
         }
       />
 
@@ -160,10 +75,11 @@ export default function MeleeWeaponsAdminPage() {
         title="System Melee Weapon Catalog"
         subtitle="Melee and thrown-capable weapons use the same shared table structure as the current character-facing overview."
       >
-        <TableShell
+        <AdminCatalogTable
           emptyLabel="No melee weapon templates found."
           columns={table.columns.map((column) => String(column))}
           rows={table.rows}
+          stickyHeader
         />
       </AdminPanel>
     </section>

--- a/apps/web/app/(app)/admin/missile-weapons/MissileWeaponsAdminPage.tsx
+++ b/apps/web/app/(app)/admin/missile-weapons/MissileWeaponsAdminPage.tsx
@@ -5,8 +5,12 @@ import { equipmentTemplates } from "@glantri/content/equipment";
 import type { MaterialType, QualityType, WeaponTemplate } from "@glantri/domain";
 
 import {
+  AdminCatalogTable,
+  AdminFilterBar,
+  AdminFilterSelect,
   AdminPageIntro,
   AdminPanel,
+  formatAdminEnumLabel,
 } from "../admin-ui";
 import {
   buildMissileWeaponCatalogTable,
@@ -16,66 +20,6 @@ import {
 
 const materialOptions: MaterialType[] = ["steel", "bronze"];
 const qualityOptions: QualityType[] = ["standard", "extraordinary"];
-
-function formatLabel(value: string): string {
-  return value
-    .split("_")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function TableShell(input: {
-  columns: string[];
-  emptyLabel: string;
-  rows: string[][];
-}) {
-  return input.rows.length > 0 ? (
-    <div
-      style={{
-        maxHeight: "70vh",
-        overflow: "auto",
-      }}
-    >
-      <table style={{ borderCollapse: "collapse", minWidth: "100%", width: "100%" }}>
-        <thead>
-          <tr style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.14)", textAlign: "left" }}>
-            {input.columns.map((column) => (
-              <th
-                key={column}
-                style={{
-                  background: "rgba(250, 245, 234, 0.98)",
-                  padding: "0.55rem 0.75rem 0.55rem 0",
-                  position: "sticky",
-                  top: 0,
-                  verticalAlign: "bottom",
-                  zIndex: 1,
-                }}
-              >
-                {column}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {input.rows.map((row, index) => (
-            <tr key={`missile-weapons-row-${index}`} style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.08)" }}>
-              {row.map((value, cellIndex) => (
-                <td
-                  key={`missile-weapons-row-${index}-${cellIndex}`}
-                  style={{ padding: "0.65rem 0.75rem 0.65rem 0", verticalAlign: "top" }}
-                >
-                  {value}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  ) : (
-    <div>{input.emptyLabel}</div>
-  );
-}
 
 export default function MissileWeaponsAdminPage() {
   const [material, setMaterial] = useState<MaterialType>("steel");
@@ -108,51 +52,22 @@ export default function MissileWeaponsAdminPage() {
         title="Missile weapons"
         summary="Read-only catalog view of system missile weapon templates."
         actions={
-          <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
-            <label style={{ display: "grid", gap: "0.25rem", minWidth: 160 }}>
-              <span style={{ color: "#5f543a", fontSize: "0.9rem", fontWeight: 600 }}>Material</span>
-              <select
-                onChange={(event) => setMaterial(event.target.value as MaterialType)}
-                style={{
-                  background: "rgba(255, 252, 245, 0.95)",
-                  border: "1px solid rgba(85, 73, 48, 0.18)",
-                  borderRadius: 14,
-                  color: "#2e2619",
-                  font: "inherit",
-                  padding: "0.65rem 0.8rem",
-                }}
-                value={material}
-              >
-                {materialOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {formatLabel(option)}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label style={{ display: "grid", gap: "0.25rem", minWidth: 160 }}>
-              <span style={{ color: "#5f543a", fontSize: "0.9rem", fontWeight: 600 }}>Quality</span>
-              <select
-                onChange={(event) => setQuality(event.target.value as QualityType)}
-                style={{
-                  background: "rgba(255, 252, 245, 0.95)",
-                  border: "1px solid rgba(85, 73, 48, 0.18)",
-                  borderRadius: 14,
-                  color: "#2e2619",
-                  font: "inherit",
-                  padding: "0.65rem 0.8rem",
-                }}
-                value={quality}
-              >
-                {qualityOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {formatLabel(option)}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
+          <AdminFilterBar>
+            <AdminFilterSelect
+              label="Material"
+              options={materialOptions}
+              value={material}
+              onChange={setMaterial}
+              formatOption={formatAdminEnumLabel}
+            />
+            <AdminFilterSelect
+              label="Quality"
+              options={qualityOptions}
+              value={quality}
+              onChange={setQuality}
+              formatOption={formatAdminEnumLabel}
+            />
+          </AdminFilterBar>
         }
       />
 
@@ -160,10 +75,11 @@ export default function MissileWeaponsAdminPage() {
         title="System Missile Weapon Catalog"
         subtitle="Missile weapons use their own shared table structure so bow and pistol rows no longer borrow melee-only attack columns."
       >
-        <TableShell
+        <AdminCatalogTable
           emptyLabel="No missile weapon templates found."
           columns={table.columns.map((column) => String(column))}
           rows={table.rows}
+          stickyHeader
         />
       </AdminPanel>
     </section>

--- a/apps/web/app/(app)/admin/shields/ShieldsAdminPage.tsx
+++ b/apps/web/app/(app)/admin/shields/ShieldsAdminPage.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { equipmentTemplates } from "@glantri/content/equipment";
 import type { ShieldTemplate } from "@glantri/domain";
 
-import { AdminPageIntro, AdminPanel } from "../admin-ui";
+import { AdminCatalogTable, AdminPageIntro, AdminPanel } from "../admin-ui";
 import { formatWeaponModeDmb } from "@/features/equipment/meleeWeaponDisplay";
 
 function formatOptionalDisplayValue(value: number | string | null | undefined): string {
@@ -28,51 +28,6 @@ function formatRangeLabel(value: number | string | null | undefined): string {
 
   const text = typeof value === "number" ? String(value) : value.trim();
   return text.length > 0 ? text : "—";
-}
-
-function TableShell(input: {
-  columns: string[];
-  emptyLabel: string;
-  rows: string[][];
-}) {
-  return input.rows.length > 0 ? (
-    <div style={{ overflow: "auto" }}>
-      <table style={{ borderCollapse: "collapse", minWidth: "100%", width: "100%" }}>
-        <thead>
-          <tr style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.14)", textAlign: "left" }}>
-            {input.columns.map((column) => (
-              <th
-                key={column}
-                style={{
-                  background: "rgba(250, 245, 234, 0.98)",
-                  padding: "0.55rem 0.75rem 0.55rem 0",
-                  verticalAlign: "bottom"
-                }}
-              >
-                {column}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {input.rows.map((row, rowIndex) => (
-            <tr key={`shields-row-${rowIndex}`} style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.08)" }}>
-              {row.map((value, cellIndex) => (
-                <td
-                  key={`shields-row-${rowIndex}-${cellIndex}`}
-                  style={{ padding: "0.65rem 0.75rem 0.65rem 0", verticalAlign: "top" }}
-                >
-                  {value}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  ) : (
-    <div>{input.emptyLabel}</div>
-  );
 }
 
 export default function ShieldsAdminPage() {
@@ -131,7 +86,7 @@ export default function ShieldsAdminPage() {
         title="System Shield Catalog"
         subtitle="Workbook-backed shield templates merge offensive values from Weapon1 with defensive values from Shields, preserving import warnings where the sources diverge."
       >
-        <TableShell
+        <AdminCatalogTable
           emptyLabel="No shield templates found."
           columns={[
             "Name",

--- a/apps/web/app/(app)/admin/valuables/ValuablesAdminPage.tsx
+++ b/apps/web/app/(app)/admin/valuables/ValuablesAdminPage.tsx
@@ -4,7 +4,14 @@ import { useMemo, useState } from "react";
 import { equipmentTemplates } from "@glantri/content/equipment";
 import type { MaterialType, QualityType, ValuableTemplate } from "@glantri/domain";
 
-import { AdminPageIntro, AdminPanel } from "../admin-ui";
+import {
+  AdminCatalogTable,
+  AdminFilterBar,
+  AdminFilterSelect,
+  AdminPageIntro,
+  AdminPanel,
+  formatAdminEnumLabel,
+} from "../admin-ui";
 import {
   buildTemplateCatalogTable,
   getAdminTemplateCatalogRows,
@@ -12,58 +19,6 @@ import {
 
 const materialOptions: MaterialType[] = ["steel", "bronze", "silver", "gold", "other"];
 const qualityOptions: QualityType[] = ["standard", "extraordinary"];
-
-function formatLabel(value: string): string {
-  return value
-    .split("_")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-function TableShell(input: {
-  columns: string[];
-  emptyLabel: string;
-  rows: string[][];
-}) {
-  return input.rows.length > 0 ? (
-    <div style={{ maxHeight: "70vh", overflow: "auto" }}>
-      <table style={{ borderCollapse: "collapse", minWidth: "100%", width: "100%" }}>
-        <thead>
-          <tr style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.14)", textAlign: "left" }}>
-            {input.columns.map((column) => (
-              <th
-                key={column}
-                style={{
-                  background: "rgba(250, 245, 234, 0.98)",
-                  padding: "0.55rem 0.75rem 0.55rem 0",
-                  position: "sticky",
-                  top: 0,
-                  verticalAlign: "bottom",
-                  zIndex: 1,
-                }}
-              >
-                {column}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {input.rows.map((row, index) => (
-            <tr key={`valuables-row-${index}`} style={{ borderBottom: "1px solid rgba(85, 73, 48, 0.08)" }}>
-              {row.map((value, cellIndex) => (
-                <td key={`valuables-row-${index}-${cellIndex}`} style={{ padding: "0.65rem 0.75rem 0.65rem 0", verticalAlign: "top" }}>
-                  {value}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  ) : (
-    <div>{input.emptyLabel}</div>
-  );
-}
 
 export default function ValuablesAdminPage() {
   const [material, setMaterial] = useState<MaterialType>("gold");
@@ -96,50 +51,22 @@ export default function ValuablesAdminPage() {
         title="Valuables"
         summary="Read-only catalog view of system valuables templates."
         actions={
-          <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap" }}>
-            <label style={{ display: "grid", gap: "0.25rem", minWidth: 160 }}>
-              <span style={{ color: "#5f543a", fontSize: "0.9rem", fontWeight: 600 }}>Material</span>
-              <select
-                onChange={(event) => setMaterial(event.target.value as MaterialType)}
-                style={{
-                  background: "rgba(255, 252, 245, 0.95)",
-                  border: "1px solid rgba(85, 73, 48, 0.18)",
-                  borderRadius: 14,
-                  color: "#2e2619",
-                  font: "inherit",
-                  padding: "0.65rem 0.8rem",
-                }}
-                value={material}
-              >
-                {materialOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {formatLabel(option)}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label style={{ display: "grid", gap: "0.25rem", minWidth: 160 }}>
-              <span style={{ color: "#5f543a", fontSize: "0.9rem", fontWeight: 600 }}>Quality</span>
-              <select
-                onChange={(event) => setQuality(event.target.value as QualityType)}
-                style={{
-                  background: "rgba(255, 252, 245, 0.95)",
-                  border: "1px solid rgba(85, 73, 48, 0.18)",
-                  borderRadius: 14,
-                  color: "#2e2619",
-                  font: "inherit",
-                  padding: "0.65rem 0.8rem",
-                }}
-                value={quality}
-              >
-                {qualityOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {formatLabel(option)}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
+          <AdminFilterBar>
+            <AdminFilterSelect
+              label="Material"
+              options={materialOptions}
+              value={material}
+              onChange={setMaterial}
+              formatOption={formatAdminEnumLabel}
+            />
+            <AdminFilterSelect
+              label="Quality"
+              options={qualityOptions}
+              value={quality}
+              onChange={setQuality}
+              formatOption={formatAdminEnumLabel}
+            />
+          </AdminFilterBar>
         }
       />
 
@@ -147,10 +74,11 @@ export default function ValuablesAdminPage() {
         title="System Valuables Catalog"
         subtitle="Valuables templates use the same shared simple catalog structure as gear, keeping encumbrance, value, and notes aligned."
       >
-        <TableShell
+        <AdminCatalogTable
           columns={table.columns.map((column) => String(column))}
           emptyLabel="No valuables templates found."
           rows={table.rows}
+          stickyHeader
         />
       </AdminPanel>
     </section>


### PR DESCRIPTION
## Summary

- Legger til `AdminCatalogTable`, `AdminFilterBar`, `AdminFilterSelect` og `formatAdminEnumLabel` i `admin-ui.tsx`
- Fjerner 5 identiske kopier av `TableShell` fra Melee, Missile, Gear, Valuables og Shields
- Fjerner 4 identiske inline filterkontroller (label + select) fra Melee, Missile, Gear og Valuables
- `ArmorAdminPage` beholder sin lokale tabell — den har spesiell rad-styling (komponent-rader med annen bakgrunn og separatorer)

Closes #108

## Test plan

- [ ] `pnpm --filter @glantri/web typecheck` er grønn ✓
- [ ] `pnpm --filter @glantri/web test` er grønn (257 tester) ✓
- [ ] Admin-sidene for Melee, Missile, Gear, Valuables og Shields viser korrekt tabell og filtre visuelt

🤖 Generated with [Claude Code](https://claude.com/claude-code)