### PR TITLE
Feature/player general encounter screen

### DIFF
--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
@@ -33,4 +33,14 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("visibilitychange");
     expect(source).not.toContain("Accessible scenarios:");
   });
+
+  it("routes the workspace Character tab through the encounter-context panel", () => {
+    const source = readSource();
+
+    expect(source).toContain("CharacterWorkspacePanel");
+    expect(source).toContain('workspaceState.activeTab === "character"');
+    expect(source).toContain('tab: "character"');
+    expect(source).toContain("selectedParticipantId={searchParams.get(\"participantId\")}");
+    expect(source).toContain("isGameMaster={canAccessGmEncounter}");
+  });
 });

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/lib/campaigns/workspace";
 import EncounterDetail from "../../encounters/[id]/EncounterDetail";
 import CampaignDetailPageContent from "./CampaignDetailPageContent";
+import CharacterWorkspacePanel from "./CharacterWorkspacePanel";
 import ScenarioDetailPageContent from "./scenarios/[scenarioId]/ScenarioDetailPageContent";
 import ScenarioPlayerPageContent from "./scenarios/[scenarioId]/player/ScenarioPlayerPageContent";
 import ScenarioPlayerCombatPageContent from "./scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent";
@@ -286,7 +287,10 @@ export default function CampaignWorkspaceShell({
       encounterId:
         searchParams.get("encounterId") ?? workspaceState.activeEncounterId ?? null,
       participantId:
-        requestedTabFromUrl === "player-encounter" || workspaceState.activeTab === "player-encounter"
+        requestedTabFromUrl === "player-encounter" ||
+        requestedTabFromUrl === "character" ||
+        workspaceState.activeTab === "player-encounter" ||
+        workspaceState.activeTab === "character"
           ? searchParams.get("participantId")
           : null,
       scenarioId:
@@ -530,6 +534,25 @@ export default function CampaignWorkspaceShell({
             </section>
           )}
         </section>
+      ) : null}
+
+      {accessMode !== "none" && workspaceState.activeTab === "character" ? (
+        <CharacterWorkspacePanel
+          activeEncounter={activeEncounter}
+          currentUserId={currentUser?.id}
+          isGameMaster={canAccessGmEncounter}
+          onSelectParticipantId={(participantId) => {
+            router.replace(
+              buildWorkspaceHref({
+                participantId,
+                tab: "character",
+              }),
+            );
+          }}
+          scenarioId={workspaceState.activeScenarioId}
+          scenarioParticipants={scenarioParticipants}
+          selectedParticipantId={searchParams.get("participantId")}
+        />
       ) : null}
     </section>
   );

--- a/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sourcePath = join(dirname(fileURLToPath(import.meta.url)), "CharacterWorkspacePanel.tsx");
+
+function readSource(): string {
+  return readFileSync(sourcePath, "utf8");
+}
+
+describe("CharacterWorkspacePanel", () => {
+  it("reuses the loadout view without rendering future combat-state placeholders", () => {
+    const source = readSource();
+
+    expect(source).toContain("CharacterLoadoutView");
+    expect(source).toContain("<CharacterLoadoutView characterId={selectedCandidate.characterId} />");
+    expect(source).not.toContain("Physical state");
+    expect(source).not.toContain("Damage");
+    expect(source).not.toContain("Combat arena");
+  });
+
+  it("keeps player and GM character controls separate", () => {
+    const source = readSource();
+
+    expect(source).toContain("You are not currently assigned to a character in this scenario.");
+    expect(source).toContain("Select character to inspect");
+    expect(source).toContain("Previous");
+    expect(source).toContain("Next");
+  });
+});

--- a/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.test.ts
@@ -10,12 +10,13 @@ function readSource(): string {
 }
 
 describe("CharacterWorkspacePanel", () => {
-  it("reuses the loadout view without rendering future combat-state placeholders", () => {
+  it("reuses the loadout view with Physical state and without future combat-state placeholders", () => {
     const source = readSource();
 
     expect(source).toContain("CharacterLoadoutView");
-    expect(source).toContain("<CharacterLoadoutView characterId={selectedCandidate.characterId} />");
-    expect(source).not.toContain("Physical state");
+    expect(source).toContain(
+      "<CharacterLoadoutView characterId={selectedCandidate.characterId} showPhysicalState />",
+    );
     expect(source).not.toContain("Damage");
     expect(source).not.toContain("Combat arena");
   });

--- a/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.tsx
@@ -152,7 +152,7 @@ export default function CharacterWorkspacePanel({
       ) : null}
 
       {selectedCandidate ? (
-        <CharacterLoadoutView characterId={selectedCandidate.characterId} />
+        <CharacterLoadoutView characterId={selectedCandidate.characterId} showPhysicalState />
       ) : null}
     </section>
   );

--- a/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useMemo } from "react";
+
+import type { EncounterSession, ScenarioParticipant } from "@glantri/domain";
+
+import {
+  buildGmCharacterWorkspaceCandidates,
+  resolvePlayerCharacterWorkspaceCandidate,
+} from "@/lib/campaigns/characterWorkspace";
+import CharacterLoadoutView from "../../characters/[id]/components/CharacterLoadoutView";
+
+interface CharacterWorkspacePanelProps {
+  activeEncounter?: EncounterSession;
+  currentUserId?: string | null;
+  isGameMaster: boolean;
+  onSelectParticipantId?: (participantId: string) => void;
+  scenarioId?: string;
+  scenarioParticipants: ScenarioParticipant[];
+  selectedParticipantId?: string | null;
+}
+
+const panelStyle = {
+  border: "1px solid #d9ddd8",
+  borderRadius: 12,
+  display: "grid",
+  gap: "0.75rem",
+  padding: "1rem",
+} as const;
+
+export default function CharacterWorkspacePanel({
+  activeEncounter,
+  currentUserId,
+  isGameMaster,
+  onSelectParticipantId,
+  scenarioId,
+  scenarioParticipants,
+  selectedParticipantId,
+}: CharacterWorkspacePanelProps) {
+  const gmCandidates = useMemo(
+    () =>
+      buildGmCharacterWorkspaceCandidates({
+        activeEncounter,
+        scenarioId,
+        scenarioParticipants,
+      }),
+    [activeEncounter, scenarioId, scenarioParticipants],
+  );
+  const playerCandidate = useMemo(
+    () =>
+      resolvePlayerCharacterWorkspaceCandidate({
+        activeEncounter,
+        scenarioId,
+        scenarioParticipants,
+        userId: currentUserId,
+      }),
+    [activeEncounter, currentUserId, scenarioId, scenarioParticipants],
+  );
+  const selectedGmCandidate =
+    gmCandidates.find((candidate) => candidate.id === selectedParticipantId) ?? gmCandidates[0];
+  const selectedCandidate = isGameMaster ? selectedGmCandidate : playerCandidate;
+  const selectedIndex = selectedGmCandidate
+    ? gmCandidates.findIndex((candidate) => candidate.id === selectedGmCandidate.id)
+    : -1;
+  const hasMultipleGmCandidates = gmCandidates.length > 1;
+
+  function selectGmCandidate(offset: number) {
+    if (!selectedGmCandidate || gmCandidates.length === 0) {
+      return;
+    }
+
+    const nextIndex = (selectedIndex + offset + gmCandidates.length) % gmCandidates.length;
+    const nextCandidate = gmCandidates[nextIndex];
+
+    if (nextCandidate) {
+      onSelectParticipantId?.(nextCandidate.id);
+    }
+  }
+
+  if (!scenarioId) {
+    return (
+      <section style={panelStyle}>
+        <strong>No active scenario is currently available.</strong>
+      </section>
+    );
+  }
+
+  if (!isGameMaster && !selectedCandidate) {
+    return (
+      <section style={panelStyle}>
+        <strong>You are not currently assigned to a character in this scenario.</strong>
+      </section>
+    );
+  }
+
+  if (isGameMaster && gmCandidates.length === 0) {
+    return (
+      <section style={panelStyle}>
+        <strong>No character sheet is available for this participant.</strong>
+      </section>
+    );
+  }
+
+  return (
+    <section style={{ display: "grid", gap: "1rem" }}>
+      {isGameMaster ? (
+        <section style={panelStyle}>
+          <div
+            style={{
+              alignItems: "center",
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "0.75rem",
+              justifyContent: "space-between",
+            }}
+          >
+            <h2 style={{ margin: 0 }}>Character</h2>
+            <div
+              style={{
+                alignItems: "center",
+                display: "flex",
+                flexWrap: "wrap",
+                gap: "0.5rem",
+              }}
+            >
+              {hasMultipleGmCandidates ? (
+                <button type="button" onClick={() => selectGmCandidate(-1)}>
+                  Previous
+                </button>
+              ) : null}
+              <label style={{ display: "grid", gap: "0.25rem" }}>
+                <span style={{ fontWeight: 700 }}>Select character to inspect</span>
+                <select
+                  onChange={(event) => onSelectParticipantId?.(event.target.value)}
+                  value={selectedGmCandidate?.id ?? ""}
+                >
+                  {gmCandidates.map((candidate) => (
+                    <option key={candidate.id} value={candidate.id}>
+                      {candidate.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {hasMultipleGmCandidates ? (
+                <button type="button" onClick={() => selectGmCandidate(1)}>
+                  Next
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {selectedCandidate ? (
+        <CharacterLoadoutView characterId={selectedCandidate.characterId} />
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/app/(app)/characters/CharacterControlRoutes.test.ts
+++ b/apps/web/app/(app)/characters/CharacterControlRoutes.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const routePath = dirname(fileURLToPath(import.meta.url));
+
+function readRoute(relativePath: string): string {
+  return readFileSync(join(routePath, relativePath), "utf8");
+}
+
+describe("character control routes", () => {
+  it("keeps the existing Equip items route wired to the shared loadout view", () => {
+    const source = readRoute("[id]/loadout/page.tsx");
+
+    expect(source).toContain("CharacterLoadoutView");
+    expect(source).toContain("<CharacterLoadoutView characterId={id} />");
+  });
+
+  it("adds a player Character route as an Equip items replica", () => {
+    const source = readRoute("[id]/character/page.tsx");
+    const sharedViewSource = readRoute("[id]/components/CharacterLoadoutView.tsx");
+
+    expect(source).toContain("CharacterLoadoutView");
+    expect(source).toContain("<CharacterLoadoutView characterId={id} />");
+    expect(sharedViewSource).toContain("Equip items -");
+    expect(sharedViewSource).not.toContain("physical state");
+    expect(sharedViewSource).not.toContain("combat arena");
+  });
+
+  it("adds a GM inspection page with a character selector and the same loadout view", () => {
+    const source = readRoute("inspect/CharacterInspectionPageContent.tsx");
+
+    expect(source).toContain("<h1 style={{ margin: 0 }}>Character</h1>");
+    expect(source).toContain("Select character to inspect");
+    expect(source).toContain("Previous");
+    expect(source).toContain("Next");
+    expect(source).toContain("CharacterLoadoutView");
+  });
+});

--- a/apps/web/app/(app)/characters/CharacterControlRoutes.test.ts
+++ b/apps/web/app/(app)/characters/CharacterControlRoutes.test.ts
@@ -15,16 +15,17 @@ describe("character control routes", () => {
 
     expect(source).toContain("CharacterLoadoutView");
     expect(source).toContain("<CharacterLoadoutView characterId={id} />");
+    expect(source).not.toContain("showPhysicalState");
   });
 
-  it("adds a player Character route as an Equip items replica", () => {
+  it("adds a player Character route with the live Physical state section", () => {
     const source = readRoute("[id]/character/page.tsx");
     const sharedViewSource = readRoute("[id]/components/CharacterLoadoutView.tsx");
 
     expect(source).toContain("CharacterLoadoutView");
-    expect(source).toContain("<CharacterLoadoutView characterId={id} />");
+    expect(source).toContain("<CharacterLoadoutView characterId={id} showPhysicalState />");
     expect(sharedViewSource).toContain("Equip items -");
-    expect(sharedViewSource).not.toContain("physical state");
+    expect(sharedViewSource).toContain("PhysicalStateSection");
     expect(sharedViewSource).not.toContain("combat arena");
   });
 
@@ -36,5 +37,6 @@ describe("character control routes", () => {
     expect(source).toContain("Previous");
     expect(source).toContain("Next");
     expect(source).toContain("CharacterLoadoutView");
+    expect(source).toContain("showPhysicalState");
   });
 });

--- a/apps/web/app/(app)/characters/CharactersSubmenu.test.ts
+++ b/apps/web/app/(app)/characters/CharactersSubmenu.test.ts
@@ -42,11 +42,53 @@ describe("CharactersSubmenu", () => {
     expect(items.map((item) => item.href)).toEqual([
       "/characters",
       "/characters/character-1",
+      "/characters/character-1/character",
       "/characters/character-1/equipment",
       "/characters/character-1/weapons-shields-armor",
       "/characters/character-1/loadout",
       "/characters/character-1/advance",
     ]);
     expect(items.map((item) => item.label)).toContain("Progression");
+  });
+
+  it("adds a character control tab without replacing Equip items", () => {
+    const items = buildCharactersSubmenuItems({
+      currentCharacterId: "character-1",
+      isGameMaster: false,
+      pathname: "/characters/character-1/character",
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          href: "/characters/character-1/character",
+          isActive: true,
+          label: "Character",
+        }),
+        expect.objectContaining({
+          href: "/characters/character-1/loadout",
+          label: "Equip items",
+        }),
+      ]),
+    );
+  });
+
+  it("adds a GM character inspection route without treating inspect as a character id", () => {
+    const items = buildCharactersSubmenuItems({
+      currentCharacterId: null,
+      isGameMaster: true,
+      pathname: "/characters/inspect",
+    });
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          href: "/characters/inspect",
+          isActive: true,
+          label: "Inspect characters",
+        }),
+      ]),
+    );
+    expect(items.map((item) => item.href)).not.toContain("/characters/inspect/loadout");
   });
 });

--- a/apps/web/app/(app)/characters/CharactersSubmenu.tsx
+++ b/apps/web/app/(app)/characters/CharactersSubmenu.tsx
@@ -22,6 +22,10 @@ function getCurrentCharacterId(pathname: string): string | null {
     return null;
   }
 
+  if (segments[1] === "inspect") {
+    return null;
+  }
+
   return segments[1] ?? null;
 }
 
@@ -43,11 +47,25 @@ export function buildCharactersSubmenuItems(options: {
       isActive: pathname === "/characters",
       label: "Characters"
     },
+    isGameMaster
+      ? {
+          href: "/characters/inspect",
+          isActive: pathname === "/characters/inspect",
+          label: "Inspect characters"
+        }
+      : null,
     effectiveCharacterId
       ? {
           href: `/characters/${effectiveCharacterId}`,
           isActive: isCharacterSheetPath(pathname, effectiveCharacterId),
           label: "Character sheet"
+        }
+      : null,
+    effectiveCharacterId
+      ? {
+          href: `/characters/${effectiveCharacterId}/character`,
+          isActive: pathname === `/characters/${effectiveCharacterId}/character`,
+          label: "Character"
         }
       : null,
     effectiveCharacterId

--- a/apps/web/app/(app)/characters/[id]/character/page.tsx
+++ b/apps/web/app/(app)/characters/[id]/character/page.tsx
@@ -1,12 +1,12 @@
 import CharacterLoadoutView from "../components/CharacterLoadoutView";
 
-interface CharacterLoadoutPageProps {
+interface CharacterControlPageProps {
   params: Promise<{
     id: string;
   }>;
 }
 
-export default async function CharacterLoadoutPage({ params }: CharacterLoadoutPageProps) {
+export default async function CharacterControlPage({ params }: CharacterControlPageProps) {
   const { id } = await params;
 
   return <CharacterLoadoutView characterId={id} />;

--- a/apps/web/app/(app)/characters/[id]/character/page.tsx
+++ b/apps/web/app/(app)/characters/[id]/character/page.tsx
@@ -9,5 +9,5 @@ interface CharacterControlPageProps {
 export default async function CharacterControlPage({ params }: CharacterControlPageProps) {
   const { id } = await params;
 
-  return <CharacterLoadoutView characterId={id} />;
+  return <CharacterLoadoutView characterId={id} showPhysicalState />;
 }

--- a/apps/web/app/(app)/characters/[id]/components/CharacterLoadoutView.tsx
+++ b/apps/web/app/(app)/characters/[id]/components/CharacterLoadoutView.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { getEquipmentTemplateById } from "@/features/equipment/equipmentSelectors";
+import {
+  buildEquipmentLoadoutModuleModel,
+  EquipmentLoadoutModule
+} from "@/features/equipment/loadoutModule";
+import { isValidLoadoutThrowingWeaponItem } from "@/features/equipment/loadoutWeaponOptions";
+import type { EquipmentFeatureState } from "@/features/equipment/types";
+import {
+  loadCharacterEquipmentState,
+  setCharacterActiveMissileWeaponOnServer,
+  setCharacterActivePrimaryWeaponOnServer,
+  setCharacterActiveSecondaryWeaponOnServer,
+  setCharacterReadyShieldOnServer,
+  setCharacterWornArmorOnServer
+} from "@/lib/api/localServiceClient";
+import { loadLocalCharacterContext } from "@/lib/characters/loadLocalCharacterContext";
+
+interface CharacterLoadoutViewProps {
+  characterId: string;
+}
+
+function getCharacterName(name: string | undefined): string {
+  return name?.trim() || "Unnamed character";
+}
+
+function isBowOrTwoHandedTemplate(templateId: string | null, state: EquipmentFeatureState): boolean {
+  if (!templateId) {
+    return false;
+  }
+
+  const template = getEquipmentTemplateById(state, templateId);
+  return (
+    template?.category === "weapon" &&
+    (template.handlingClass === "two_handed" ||
+      template.weaponClass === "bow" ||
+      template.tags.includes("bow"))
+  );
+}
+
+export default function CharacterLoadoutView({ characterId }: CharacterLoadoutViewProps) {
+  const [state, setState] = useState<EquipmentFeatureState | null>(null);
+  const [characterContext, setCharacterContext] = useState<
+    Awaited<ReturnType<typeof loadLocalCharacterContext>> | null
+  >(null);
+  const [loading, setLoading] = useState(true);
+  const [pageError, setPageError] = useState<string>();
+  const [throwingWeaponItemId, setThrowingWeaponItemId] = useState<string>("");
+  const [errors, setErrors] = useState<
+    Record<"armor" | "missile" | "primary" | "secondary" | "shield", string | undefined>
+  >({
+    armor: undefined,
+    missile: undefined,
+    primary: undefined,
+    secondary: undefined,
+    shield: undefined
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setLoading(true);
+    Promise.all([loadCharacterEquipmentState(characterId), loadLocalCharacterContext(characterId)])
+      .then(([nextState, nextCharacterContext]) => {
+        if (cancelled) {
+          return;
+        }
+
+        setState(nextState);
+        setCharacterContext(nextCharacterContext);
+        setPageError(undefined);
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+
+        const message = error instanceof Error ? error.message : "Unable to load loadout.";
+        setPageError(
+          message === "Character not found."
+            ? "Character not found or not accessible from this account."
+            : message
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [characterId]);
+
+  useEffect(() => {
+    if (!throwingWeaponItemId || !state) {
+      return;
+    }
+
+    const selectedThrowingWeaponItem = state.itemsById[throwingWeaponItemId];
+    if (
+      !isValidLoadoutThrowingWeaponItem({
+        item: selectedThrowingWeaponItem,
+        state
+      })
+    ) {
+      setThrowingWeaponItemId("");
+    }
+  }, [state, throwingWeaponItemId]);
+
+  const model = useMemo(
+    () =>
+      buildEquipmentLoadoutModuleModel({
+        characterContext:
+          characterContext?.record && characterContext.content
+            ? {
+                content: characterContext.content,
+                record: characterContext.record
+              }
+            : null,
+        characterId,
+        errors,
+        state,
+        throwingWeaponItemId
+      }),
+    [characterContext, errors, characterId, state, throwingWeaponItemId]
+  );
+
+  async function applySelection(input: {
+    itemId: string | null;
+    kind: "armor" | "primary" | "secondary" | "missile" | "shield";
+  }) {
+    if (!state) {
+      return;
+    }
+
+    try {
+      const currentLoadout = state.activeLoadoutByCharacterId[characterId];
+      const nextSelection = {
+        armor: currentLoadout?.wornArmorItemId ?? null,
+        missile: currentLoadout?.activeMissileWeaponItemId ?? null,
+        primary: currentLoadout?.activePrimaryWeaponItemId ?? null,
+        secondary: currentLoadout?.activeSecondaryWeaponItemId ?? null,
+        shield: currentLoadout?.readyShieldItemId ?? null
+      };
+
+      nextSelection[input.kind] = input.itemId;
+
+      if (input.kind === "shield" && input.itemId) {
+        nextSelection.secondary = null;
+      }
+
+      if (input.kind === "secondary" && input.itemId) {
+        nextSelection.shield = null;
+      }
+
+      const selectedWeaponTemplateId =
+        input.kind === "primary" || input.kind === "secondary" || input.kind === "missile"
+          ? state.itemsById[input.itemId ?? ""]?.templateId ?? null
+          : null;
+
+      if (
+        (input.kind === "primary" || input.kind === "secondary") &&
+        selectedWeaponTemplateId &&
+        isBowOrTwoHandedTemplate(selectedWeaponTemplateId, state)
+      ) {
+        if (input.kind === "primary") {
+          nextSelection.secondary = null;
+        }
+        if (input.kind === "secondary") {
+          nextSelection.primary = null;
+        }
+        nextSelection.shield = null;
+      }
+
+      if (input.itemId && (input.kind === "shield" || input.kind === "secondary")) {
+        const currentPrimaryTemplateId = state.itemsById[nextSelection.primary ?? ""]?.templateId ?? null;
+        if (currentPrimaryTemplateId && isBowOrTwoHandedTemplate(currentPrimaryTemplateId, state)) {
+          nextSelection.primary = null;
+        }
+      }
+
+      const operations: Array<() => Promise<EquipmentFeatureState>> = [];
+
+      const queueOperation = (
+        kind: "armor" | "primary" | "secondary" | "missile" | "shield",
+        itemId: string | null
+      ) => {
+        const currentValue = currentLoadout
+          ? kind === "armor"
+            ? currentLoadout.wornArmorItemId ?? null
+            : kind === "shield"
+              ? currentLoadout.readyShieldItemId ?? null
+              : kind === "primary"
+                ? currentLoadout.activePrimaryWeaponItemId ?? null
+                : kind === "secondary"
+                  ? currentLoadout.activeSecondaryWeaponItemId ?? null
+                  : currentLoadout.activeMissileWeaponItemId ?? null
+          : null;
+
+        if (currentValue === itemId) {
+          return;
+        }
+
+        operations.push(() =>
+          kind === "armor"
+            ? setCharacterWornArmorOnServer({ characterId, itemId })
+            : kind === "shield"
+              ? setCharacterReadyShieldOnServer({ characterId, itemId })
+              : kind === "primary"
+                ? setCharacterActivePrimaryWeaponOnServer({ characterId, itemId })
+                : kind === "secondary"
+                  ? setCharacterActiveSecondaryWeaponOnServer({ characterId, itemId })
+                  : setCharacterActiveMissileWeaponOnServer({ characterId, itemId })
+        );
+      };
+
+      queueOperation("secondary", nextSelection.secondary);
+      queueOperation("shield", nextSelection.shield);
+      queueOperation("primary", nextSelection.primary);
+      queueOperation("armor", nextSelection.armor);
+      queueOperation("missile", nextSelection.missile);
+
+      let nextState = state;
+      for (const operation of operations) {
+        nextState = await operation();
+      }
+
+      setState(nextState);
+      setErrors((current) => ({
+        ...current,
+        [input.kind]: undefined
+      }));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to update loadout.";
+      setErrors((current) => ({
+        ...current,
+        [input.kind]: message
+      }));
+    }
+  }
+
+  const characterName = getCharacterName(characterContext?.record?.build.name);
+
+  return (
+    <section style={{ display: "grid", gap: "1rem", maxWidth: 900 }}>
+      <div style={{ display: "grid", gap: "0.35rem" }}>
+        <h1 style={{ margin: 0 }}>Equip items - {characterName}</h1>
+      </div>
+
+      {loading ? (
+        <div
+          style={{
+            background: "#f6f5ef",
+            border: "1px solid #d9ddd8",
+            borderRadius: 12,
+            padding: "1rem"
+          }}
+        >
+          Loading loadout...
+        </div>
+      ) : null}
+
+      {pageError ? (
+        <div
+          style={{
+            background: "#fdf0ea",
+            border: "1px solid #e4b9a7",
+            borderRadius: 12,
+            color: "#8b3a1a",
+            padding: "1rem"
+          }}
+        >
+          {pageError}
+        </div>
+      ) : null}
+
+      {!loading && !pageError ? (
+        <EquipmentLoadoutModule
+          mode="editable"
+          model={model}
+          onFieldChange={(fieldId, itemId) => {
+            if (fieldId === "throwing") {
+              setThrowingWeaponItemId(itemId ?? "");
+              return;
+            }
+
+            void applySelection({
+              itemId,
+              kind: fieldId
+            });
+          }}
+          stickyControls
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/app/(app)/characters/[id]/components/CharacterLoadoutView.tsx
+++ b/apps/web/app/(app)/characters/[id]/components/CharacterLoadoutView.tsx
@@ -7,6 +7,7 @@ import {
   buildEquipmentLoadoutModuleModel,
   EquipmentLoadoutModule
 } from "@/features/equipment/loadoutModule";
+import { PhysicalStateSection } from "@/features/equipment/components/PhysicalStateSection";
 import { isValidLoadoutThrowingWeaponItem } from "@/features/equipment/loadoutWeaponOptions";
 import type { EquipmentFeatureState } from "@/features/equipment/types";
 import {
@@ -18,9 +19,11 @@ import {
   setCharacterWornArmorOnServer
 } from "@/lib/api/localServiceClient";
 import { loadLocalCharacterContext } from "@/lib/characters/loadLocalCharacterContext";
+import { buildCharacterPhysicalStateView } from "@/lib/characters/physicalState";
 
 interface CharacterLoadoutViewProps {
   characterId: string;
+  showPhysicalState?: boolean;
 }
 
 function getCharacterName(name: string | undefined): string {
@@ -41,7 +44,25 @@ function isBowOrTwoHandedTemplate(templateId: string | null, state: EquipmentFea
   );
 }
 
-export default function CharacterLoadoutView({ characterId }: CharacterLoadoutViewProps) {
+function getOriginalGeneralHitpoints(
+  health: number | null | string | undefined,
+): number | null {
+  if (typeof health === "number" && Number.isFinite(health)) {
+    return health;
+  }
+
+  if (typeof health === "string" && health.trim().length > 0) {
+    const parsed = Number(health);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+export default function CharacterLoadoutView({
+  characterId,
+  showPhysicalState = false,
+}: CharacterLoadoutViewProps) {
   const [state, setState] = useState<EquipmentFeatureState | null>(null);
   const [characterContext, setCharacterContext] = useState<
     Awaited<ReturnType<typeof loadLocalCharacterContext>> | null
@@ -128,6 +149,17 @@ export default function CharacterLoadoutView({ characterId }: CharacterLoadoutVi
         throwingWeaponItemId
       }),
     [characterContext, errors, characterId, state, throwingWeaponItemId]
+  );
+  const physicalStateModel = useMemo(
+    () =>
+      showPhysicalState
+        ? buildCharacterPhysicalStateView({
+            generalHitpoints: getOriginalGeneralHitpoints(
+              characterContext?.record?.build.profile.rolledStats.health,
+            ),
+          })
+        : null,
+    [characterContext?.record?.build.profile.rolledStats.health, showPhysicalState],
   );
 
   async function applySelection(input: {
@@ -281,6 +313,9 @@ export default function CharacterLoadoutView({ characterId }: CharacterLoadoutVi
 
       {!loading && !pageError ? (
         <EquipmentLoadoutModule
+          afterEquipmentChoices={
+            physicalStateModel ? <PhysicalStateSection model={physicalStateModel} /> : undefined
+          }
           mode="editable"
           model={model}
           onFieldChange={(fieldId, itemId) => {

--- a/apps/web/app/(app)/characters/inspect/CharacterInspectionPageContent.tsx
+++ b/apps/web/app/(app)/characters/inspect/CharacterInspectionPageContent.tsx
@@ -131,7 +131,9 @@ export default function CharacterInspectionPageContent() {
       {loading ? <div>Loading characters...</div> : null}
       {error ? <div>{error}</div> : null}
       {!loading && !error && characters.length === 0 ? <div>No characters available.</div> : null}
-      {selectedCharacter ? <CharacterLoadoutView characterId={selectedCharacter.id} /> : null}
+      {selectedCharacter ? (
+        <CharacterLoadoutView characterId={selectedCharacter.id} showPhysicalState />
+      ) : null}
     </section>
   );
 }

--- a/apps/web/app/(app)/characters/inspect/CharacterInspectionPageContent.tsx
+++ b/apps/web/app/(app)/characters/inspect/CharacterInspectionPageContent.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { loadServerCharacters, type ServerCharacterRecord } from "@/lib/api/localServiceClient";
+import { useHasAnyRole } from "@/lib/auth/SessionUserContext";
+
+import CharacterLoadoutView from "../[id]/components/CharacterLoadoutView";
+
+function getCharacterLabel(character: ServerCharacterRecord): string {
+  return character.build.name?.trim() || character.name || "Unnamed character";
+}
+
+export default function CharacterInspectionPageContent() {
+  const isGameMaster = useHasAnyRole(["admin", "game_master"]);
+  const [characters, setCharacters] = useState<ServerCharacterRecord[]>([]);
+  const [selectedCharacterId, setSelectedCharacterId] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    if (!isGameMaster) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    setLoading(true);
+    loadServerCharacters()
+      .then((nextCharacters) => {
+        if (cancelled) {
+          return;
+        }
+
+        const sortedCharacters = [...nextCharacters].sort((left, right) =>
+          getCharacterLabel(left).localeCompare(getCharacterLabel(right))
+        );
+        setCharacters(sortedCharacters);
+        setSelectedCharacterId((current) => current || sortedCharacters[0]?.id || "");
+        setError(undefined);
+      })
+      .catch((caughtError) => {
+        if (cancelled) {
+          return;
+        }
+
+        setError(caughtError instanceof Error ? caughtError.message : "Unable to load characters.");
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isGameMaster]);
+
+  const selectedIndex = useMemo(
+    () => characters.findIndex((character) => character.id === selectedCharacterId),
+    [characters, selectedCharacterId]
+  );
+  const selectedCharacter = selectedIndex >= 0 ? characters[selectedIndex] : undefined;
+
+  function selectRelativeCharacter(offset: number) {
+    if (characters.length === 0) {
+      return;
+    }
+
+    const currentIndex = selectedIndex >= 0 ? selectedIndex : 0;
+    const nextIndex = (currentIndex + offset + characters.length) % characters.length;
+    setSelectedCharacterId(characters[nextIndex]?.id ?? "");
+  }
+
+  if (!isGameMaster) {
+    return (
+      <section style={{ display: "grid", gap: "1rem", maxWidth: 900 }}>
+        <h1 style={{ margin: 0 }}>Character</h1>
+        <div>Character inspection is available to GMs.</div>
+      </section>
+    );
+  }
+
+  return (
+    <section style={{ display: "grid", gap: "1rem" }}>
+      <header
+        style={{
+          alignItems: "end",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "0.75rem",
+          justifyContent: "space-between",
+          maxWidth: 900
+        }}
+      >
+        <h1 style={{ margin: 0 }}>Character</h1>
+        <div style={{ alignItems: "center", display: "flex", gap: "0.5rem" }}>
+          <button
+            disabled={characters.length <= 1}
+            onClick={() => selectRelativeCharacter(-1)}
+            type="button"
+          >
+            Previous
+          </button>
+          <label style={{ display: "grid", gap: "0.25rem" }}>
+            <span>Select character to inspect</span>
+            <select
+              disabled={characters.length === 0}
+              onChange={(event) => setSelectedCharacterId(event.target.value)}
+              value={selectedCharacterId}
+            >
+              {characters.map((character) => (
+                <option key={character.id} value={character.id}>
+                  {getCharacterLabel(character)}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            disabled={characters.length <= 1}
+            onClick={() => selectRelativeCharacter(1)}
+            type="button"
+          >
+            Next
+          </button>
+        </div>
+      </header>
+
+      {loading ? <div>Loading characters...</div> : null}
+      {error ? <div>{error}</div> : null}
+      {!loading && !error && characters.length === 0 ? <div>No characters available.</div> : null}
+      {selectedCharacter ? <CharacterLoadoutView characterId={selectedCharacter.id} /> : null}
+    </section>
+  );
+}

--- a/apps/web/app/(app)/characters/inspect/page.tsx
+++ b/apps/web/app/(app)/characters/inspect/page.tsx
@@ -1,0 +1,5 @@
+import CharacterInspectionPageContent from "./CharacterInspectionPageContent";
+
+export default function CharacterInspectionPage() {
+  return <CharacterInspectionPageContent />;
+}

--- a/apps/web/src/features/equipment/components/PhysicalStateSection.test.ts
+++ b/apps/web/src/features/equipment/components/PhysicalStateSection.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sourcePath = join(dirname(fileURLToPath(import.meta.url)), "PhysicalStateSection.tsx");
+
+function readSource(): string {
+  return readFileSync(sourcePath, "utf8");
+}
+
+describe("PhysicalStateSection", () => {
+  it("renders hitpoints, damage by type, and hit log scaffolds", () => {
+    const source = readSource();
+
+    expect(source).toContain("Physical state");
+    expect(source).toContain("Hitpoints");
+    expect(source).toContain("Damage by type");
+    expect(source).toContain("Log of hits");
+    expect(source).toContain("General hitpoints");
+    expect(source).toContain("No hits recorded.");
+  });
+
+  it("renders the hit log and damage table columns", () => {
+    const source = readSource();
+
+    expect(source).toContain("Location");
+    expect(source).toContain("Original");
+    expect(source).toContain("Current");
+    expect(source).toContain("Source");
+    expect(source).toContain("General damage");
+    expect(source).toContain("Special effects");
+    expect(source).toContain("Current effect");
+  });
+});

--- a/apps/web/src/features/equipment/components/PhysicalStateSection.tsx
+++ b/apps/web/src/features/equipment/components/PhysicalStateSection.tsx
@@ -1,0 +1,153 @@
+import type { CharacterPhysicalStateView } from "@/lib/characters/physicalState";
+
+interface PhysicalStateSectionProps {
+  model: CharacterPhysicalStateView;
+}
+
+const panelStyle = {
+  border: "1px solid #d9ddd8",
+  borderRadius: 12,
+  display: "grid",
+  gap: "0.75rem",
+  padding: "1rem",
+} as const;
+
+const tableStyle = {
+  borderCollapse: "collapse",
+  fontSize: "0.95rem",
+  width: "100%",
+} as const;
+
+const cellStyle = {
+  borderBottom: "1px solid #e6e8e3",
+  padding: "0.45rem",
+  textAlign: "left",
+} as const;
+
+function HitpointsPanel({ model }: PhysicalStateSectionProps) {
+  return (
+    <section style={panelStyle}>
+      <h3 style={{ margin: 0 }}>Hitpoints</h3>
+      <div style={{ overflowX: "auto" }}>
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th style={cellStyle}>Location</th>
+              <th style={cellStyle}>Original</th>
+              <th style={cellStyle}>Damage</th>
+              <th style={cellStyle}>Current</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style={cellStyle}>General hitpoints</td>
+              <td style={cellStyle}>{model.hitpoints.general.original}</td>
+              <td style={cellStyle}>{model.hitpoints.general.damage}</td>
+              <td style={cellStyle}>{model.hitpoints.general.current}</td>
+            </tr>
+            {model.hitpoints.locations.map((location) => (
+              <tr key={location.id}>
+                <td style={cellStyle}>
+                  {location.label} — weight {location.weightNumerator}/
+                  {location.weightDenominator}
+                </td>
+                <td style={cellStyle}>{location.original}</td>
+                <td style={cellStyle}>{location.damage}</td>
+                <td style={cellStyle}>{location.current}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function DamageByTypePanel({ model }: PhysicalStateSectionProps) {
+  return (
+    <section style={panelStyle}>
+      <h3 style={{ margin: 0 }}>Damage by type</h3>
+      <div style={{ overflowX: "auto" }}>
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th style={cellStyle}>Type</th>
+              <th style={cellStyle}>Current effect</th>
+            </tr>
+          </thead>
+          <tbody>
+            {model.damageByType.map((row) => (
+              <tr key={row.id}>
+                <td style={cellStyle}>{row.label}</td>
+                <td style={cellStyle}>{row.currentEffect}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function HitLogPanel({ model }: PhysicalStateSectionProps) {
+  return (
+    <section style={{ ...panelStyle, gridColumn: "1 / -1" }}>
+      <h3 style={{ margin: 0 }}>Log of hits</h3>
+      <div style={{ overflowX: "auto" }}>
+        <table style={tableStyle}>
+          <thead>
+            <tr>
+              <th style={cellStyle}>Source</th>
+              <th style={cellStyle}>Type</th>
+              <th style={cellStyle}>Location</th>
+              <th style={cellStyle}>Damage</th>
+              <th style={cellStyle}>General damage</th>
+              <th style={cellStyle}>Duration</th>
+              <th style={cellStyle}>Special effects</th>
+            </tr>
+          </thead>
+          <tbody>
+            {model.hitLog.length > 0 ? (
+              model.hitLog.map((entry) => (
+                <tr key={entry.id}>
+                  <td style={cellStyle}>{entry.source}</td>
+                  <td style={cellStyle}>{entry.type}</td>
+                  <td style={cellStyle}>{entry.location}</td>
+                  <td style={cellStyle}>{entry.damage}</td>
+                  <td style={cellStyle}>{entry.generalDamage}</td>
+                  <td style={cellStyle}>{entry.duration}</td>
+                  <td style={cellStyle}>{entry.specialEffects}</td>
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td colSpan={7} style={cellStyle}>
+                  No hits recorded.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export function PhysicalStateSection({ model }: PhysicalStateSectionProps) {
+  return (
+    <section style={{ display: "grid", gap: "0.75rem" }}>
+      <h2 style={{ margin: 0 }}>Physical state</h2>
+      <div
+        style={{
+          display: "grid",
+          gap: "0.75rem",
+          gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+        }}
+      >
+        <HitpointsPanel model={model} />
+        <DamageByTypePanel model={model} />
+        <HitLogPanel model={model} />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/equipment/loadoutModule.tsx
+++ b/apps/web/src/features/equipment/loadoutModule.tsx
@@ -678,6 +678,7 @@ export function buildEquipmentLoadoutModuleModel(input: {
 }
 
 export function EquipmentLoadoutModule(input: {
+  afterEquipmentChoices?: ReactNode;
   mode: EquipmentLoadoutModuleMode;
   model: EquipmentLoadoutModuleModel;
   onFieldChange?: (fieldId: LoadoutFieldId, itemId: string | null) => void;
@@ -710,6 +711,8 @@ export function EquipmentLoadoutModule(input: {
           </div>
         </ControlSection>
       ) : null}
+
+      {input.afterEquipmentChoices ?? null}
 
       {input.model.combatStatePanelModel ? (
         <CombatStatePanel model={input.model.combatStatePanelModel} />

--- a/apps/web/src/lib/campaigns/characterWorkspace.test.ts
+++ b/apps/web/src/lib/campaigns/characterWorkspace.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+
+import type { EncounterSession, ScenarioParticipant } from "@glantri/domain";
+
+import {
+  buildGmCharacterWorkspaceCandidates,
+  resolvePlayerCharacterWorkspaceCandidate,
+} from "./characterWorkspace";
+
+function participant(input: {
+  characterId?: string;
+  controlledByUserId?: string;
+  displayOrder?: number;
+  id: string;
+  isActive?: boolean;
+  name: string;
+  role?: ScenarioParticipant["role"];
+  scenarioId?: string;
+  sourceType?: ScenarioParticipant["sourceType"];
+}): ScenarioParticipant {
+  return {
+    characterId: input.characterId,
+    controlledByUserId: input.controlledByUserId,
+    createdAt: "2026-05-16T00:00:00.000Z",
+    displayOrder: input.displayOrder,
+    id: input.id,
+    isActive: input.isActive ?? true,
+    joinSource: "gm_added",
+    role: input.role ?? "player_character",
+    scenarioId: input.scenarioId ?? "scenario-1",
+    snapshot: {
+      displayName: input.name,
+    },
+    sourceType: input.sourceType ?? "character",
+    state: {
+      combat: {
+        attacksThisRound: 0,
+        declaredAction: undefined,
+        defenseMode: "none",
+        incomingAttack: undefined,
+        parryAvailable: true,
+        parrySource: undefined,
+      },
+      conditions: [],
+      health: {
+        bleeding: 0,
+        currentHp: 10,
+        dead: false,
+        maxHp: 10,
+        unconscious: false,
+        wounds: 0,
+      },
+      modifiers: [],
+      resources: {},
+      snapshotVersion: 1,
+    },
+    updatedAt: "2026-05-16T00:00:00.000Z",
+  };
+}
+
+function encounter(input: {
+  participantIds?: string[];
+  participantMembershipMode?: EncounterSession["participantMembershipMode"];
+} = {}): EncounterSession {
+  return {
+    actionLog: [],
+    campaignId: "campaign-1",
+    createdAt: "2026-05-16T00:00:00.000Z",
+    currentRound: 1,
+    currentTurnIndex: 0,
+    declarationsLocked: false,
+    id: "encounter-1",
+    kind: "roleplay",
+    participantMembershipMode: input.participantMembershipMode,
+    participants: (input.participantIds ?? []).map((participantId, index) => ({
+      id: `encounter-participant-${participantId}`,
+      initiative: 0,
+      label: participantId,
+      order: index,
+      participantType: "scenario",
+      scenarioParticipantId: participantId,
+    })),
+    scenarioId: "scenario-1",
+    status: "active",
+    title: "Market shadows",
+    turnOrderMode: "manual",
+    updatedAt: "2026-05-16T00:00:00.000Z",
+  };
+}
+
+describe("character workspace read model", () => {
+  it("resolves the player's controlled encounter participant without exposing a selector", () => {
+    const gladiator = participant({
+      characterId: "character-gladiator",
+      controlledByUserId: "player-1",
+      id: "participant-gladiator",
+      name: "The Gladiator",
+    });
+    const guard = participant({
+      characterId: "character-guard",
+      id: "participant-guard",
+      name: "City guard",
+      role: "npc",
+    });
+
+    const selected = resolvePlayerCharacterWorkspaceCandidate({
+      activeEncounter: encounter({ participantIds: [guard.id, gladiator.id] }),
+      scenarioParticipants: [guard, gladiator],
+      userId: "player-1",
+    });
+
+    expect(selected?.characterId).toBe("character-gladiator");
+    expect(selected?.label).toBe("The Gladiator");
+  });
+
+  it("denies player character resolution when explicit encounter membership excludes them", () => {
+    const gladiator = participant({
+      characterId: "character-gladiator",
+      controlledByUserId: "player-1",
+      id: "participant-gladiator",
+      name: "The Gladiator",
+    });
+    const guard = participant({
+      characterId: "character-guard",
+      id: "participant-guard",
+      name: "City guard",
+      role: "npc",
+    });
+
+    const selected = resolvePlayerCharacterWorkspaceCandidate({
+      activeEncounter: encounter({
+        participantIds: [guard.id],
+        participantMembershipMode: "explicit",
+      }),
+      scenarioParticipants: [guard, gladiator],
+      userId: "player-1",
+    });
+
+    expect(selected).toBeUndefined();
+  });
+
+  it("builds GM inspection candidates from the encounter roster when an encounter is selected", () => {
+    const scenarioParticipants = [
+      participant({
+        characterId: "character-gladiator",
+        displayOrder: 2,
+        id: "participant-gladiator",
+        name: "The Gladiator",
+      }),
+      participant({
+        characterId: "character-guard",
+        displayOrder: 1,
+        id: "participant-guard",
+        name: "City guard",
+        role: "npc",
+      }),
+      participant({
+        characterId: "character-offscreen",
+        id: "participant-offscreen",
+        name: "Offscreen witness",
+        role: "npc",
+      }),
+    ];
+
+    const candidates = buildGmCharacterWorkspaceCandidates({
+      activeEncounter: encounter({
+        participantIds: ["participant-gladiator", "participant-guard"],
+        participantMembershipMode: "explicit",
+      }),
+      scenarioParticipants,
+    });
+
+    expect(candidates.map((candidate) => candidate.label)).toEqual([
+      "City guard",
+      "The Gladiator",
+    ]);
+  });
+
+  it("excludes active scenario participants without a reusable character sheet", () => {
+    const candidates = buildGmCharacterWorkspaceCandidates({
+      scenarioId: "scenario-1",
+      scenarioParticipants: [
+        participant({
+          characterId: "character-gladiator",
+          id: "participant-gladiator",
+          name: "The Gladiator",
+        }),
+        participant({
+          id: "participant-template",
+          name: "Template guard",
+          role: "npc",
+          sourceType: "entity",
+        }),
+      ],
+    });
+
+    expect(candidates.map((candidate) => candidate.label)).toEqual(["The Gladiator"]);
+  });
+});

--- a/apps/web/src/lib/campaigns/characterWorkspace.test.ts
+++ b/apps/web/src/lib/campaigns/characterWorkspace.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { EncounterSession, ScenarioParticipant } from "@glantri/domain";
+import type { EncounterParticipant, EncounterSession, ScenarioParticipant } from "@glantri/domain";
 
 import {
   buildGmCharacterWorkspaceCandidates,
@@ -34,14 +34,17 @@ function participant(input: {
     sourceType: input.sourceType ?? "character",
     state: {
       combat: {
-        attacksThisRound: 0,
-        declaredAction: undefined,
-        defenseMode: "none",
-        incomingAttack: undefined,
-        parryAvailable: true,
-        parrySource: undefined,
+        combatContext: {
+          modifierBuckets: {
+            general: [],
+            situationDb: [],
+            situationObSkill: [],
+          },
+        },
+        engaged: false,
       },
       conditions: [],
+      equipment: {},
       health: {
         bleeding: 0,
         currentHp: 10,
@@ -55,6 +58,29 @@ function participant(input: {
       snapshotVersion: 1,
     },
     updatedAt: "2026-05-16T00:00:00.000Z",
+  };
+}
+
+function makeEncounterParticipant(
+  overrides: Partial<EncounterParticipant> = {},
+): EncounterParticipant {
+  return {
+    declaration: {
+      actionType: "none",
+      defenseFocus: "none",
+      defensePosture: "none",
+      targetLocation: "any",
+      ...overrides.declaration,
+    },
+    facing: "north",
+    id: "encounter-participant-1",
+    initiative: 0,
+    label: "The Gladiator",
+    order: 0,
+    orientation: "neutral",
+    participantType: "scenario",
+    position: { x: 0, y: 0, zone: "center" },
+    ...overrides,
   };
 }
 
@@ -72,14 +98,14 @@ function encounter(input: {
     id: "encounter-1",
     kind: "roleplay",
     participantMembershipMode: input.participantMembershipMode,
-    participants: (input.participantIds ?? []).map((participantId, index) => ({
-      id: `encounter-participant-${participantId}`,
-      initiative: 0,
-      label: participantId,
-      order: index,
-      participantType: "scenario",
-      scenarioParticipantId: participantId,
-    })),
+    participants: (input.participantIds ?? []).map((participantId, index) =>
+      makeEncounterParticipant({
+        id: `encounter-participant-${participantId}`,
+        label: participantId,
+        order: index,
+        scenarioParticipantId: participantId,
+      }),
+    ),
     scenarioId: "scenario-1",
     status: "active",
     title: "Market shadows",

--- a/apps/web/src/lib/campaigns/characterWorkspace.ts
+++ b/apps/web/src/lib/campaigns/characterWorkspace.ts
@@ -1,0 +1,165 @@
+import type { EncounterSession, ScenarioParticipant } from "@glantri/domain";
+
+import { getScenarioParticipantFallbackEncounterParticipants } from "./encounterParticipantFallback";
+
+export interface CharacterWorkspaceCandidate {
+  characterId: string;
+  id: string;
+  label: string;
+  scenarioParticipant: ScenarioParticipant;
+}
+
+function getParticipantLabel(participant: ScenarioParticipant): string {
+  return participant.snapshot.displayName || participant.id;
+}
+
+function isActiveCharacterParticipant(
+  participant: ScenarioParticipant | undefined,
+): participant is ScenarioParticipant & { characterId: string } {
+  return Boolean(
+    participant?.isActive &&
+      participant.characterId &&
+      participant.sourceType === "character",
+  );
+}
+
+function toCandidate(
+  participant: ScenarioParticipant | undefined,
+): CharacterWorkspaceCandidate | undefined {
+  if (!isActiveCharacterParticipant(participant)) {
+    return undefined;
+  }
+
+  return {
+    characterId: participant.characterId,
+    id: participant.id,
+    label: getParticipantLabel(participant),
+    scenarioParticipant: participant,
+  };
+}
+
+function uniqueCandidates(
+  candidates: Array<CharacterWorkspaceCandidate | undefined>,
+): CharacterWorkspaceCandidate[] {
+  const seen = new Set<string>();
+  const unique: CharacterWorkspaceCandidate[] = [];
+
+  for (const candidate of candidates) {
+    if (!candidate || seen.has(candidate.id)) {
+      continue;
+    }
+
+    seen.add(candidate.id);
+    unique.push(candidate);
+  }
+
+  return unique.sort(
+    (left, right) =>
+      (left.scenarioParticipant.displayOrder ?? 0) -
+        (right.scenarioParticipant.displayOrder ?? 0) ||
+      left.label.localeCompare(right.label),
+  );
+}
+
+function findScenarioParticipantForEncounterParticipant(input: {
+  characterId?: string;
+  scenarioParticipantId?: string;
+  scenarioParticipants: ScenarioParticipant[];
+}): ScenarioParticipant | undefined {
+  if (input.scenarioParticipantId) {
+    const scenarioParticipant = input.scenarioParticipants.find(
+      (participant) => participant.id === input.scenarioParticipantId,
+    );
+
+    if (scenarioParticipant) {
+      return scenarioParticipant;
+    }
+  }
+
+  if (input.characterId) {
+    return input.scenarioParticipants.find(
+      (participant) => participant.characterId === input.characterId,
+    );
+  }
+
+  return undefined;
+}
+
+export function buildGmCharacterWorkspaceCandidates(input: {
+  activeEncounter?: EncounterSession;
+  scenarioId?: string;
+  scenarioParticipants: ScenarioParticipant[];
+}): CharacterWorkspaceCandidate[] {
+  if (input.activeEncounter) {
+    return uniqueCandidates(
+      getScenarioParticipantFallbackEncounterParticipants({
+        encounter: input.activeEncounter,
+        scenarioParticipants: input.scenarioParticipants,
+      }).map((participant) =>
+        toCandidate(
+          findScenarioParticipantForEncounterParticipant({
+            characterId: participant.characterId,
+            scenarioParticipantId: participant.scenarioParticipantId,
+            scenarioParticipants: input.scenarioParticipants,
+          }),
+        ),
+      ),
+    );
+  }
+
+  return uniqueCandidates(
+    input.scenarioParticipants
+      .filter((participant) => !input.scenarioId || participant.scenarioId === input.scenarioId)
+      .map((participant) => toCandidate(participant)),
+  );
+}
+
+export function resolvePlayerCharacterWorkspaceCandidate(input: {
+  activeEncounter?: EncounterSession;
+  scenarioId?: string;
+  scenarioParticipants: ScenarioParticipant[];
+  userId?: string | null;
+}): CharacterWorkspaceCandidate | undefined {
+  if (!input.userId) {
+    return undefined;
+  }
+
+  const controlledParticipants = input.scenarioParticipants.filter(
+    (participant) =>
+      participant.controlledByUserId === input.userId &&
+      participant.role === "player_character" &&
+      isActiveCharacterParticipant(participant) &&
+      (!input.scenarioId || participant.scenarioId === input.scenarioId),
+  );
+
+  if (input.activeEncounter) {
+    const effectiveEncounterParticipants = getScenarioParticipantFallbackEncounterParticipants({
+      encounter: input.activeEncounter,
+      scenarioParticipants: input.scenarioParticipants,
+    });
+    const controlledIds = new Set(controlledParticipants.map((participant) => participant.id));
+    const controlledCharacterIds = new Set(
+      controlledParticipants.map((participant) => participant.characterId),
+    );
+    const encounterControlledParticipant = effectiveEncounterParticipants.find(
+      (participant) =>
+        (participant.scenarioParticipantId &&
+          controlledIds.has(participant.scenarioParticipantId)) ||
+        (participant.characterId && controlledCharacterIds.has(participant.characterId)),
+    );
+
+    if (!encounterControlledParticipant) {
+      return undefined;
+    }
+
+    return toCandidate(
+      findScenarioParticipantForEncounterParticipant({
+        characterId: encounterControlledParticipant.characterId,
+        scenarioParticipantId: encounterControlledParticipant.scenarioParticipantId,
+        scenarioParticipants: controlledParticipants,
+      }),
+    );
+  }
+
+  return toCandidate(controlledParticipants[0]);
+}

--- a/apps/web/src/lib/campaigns/workspace.test.ts
+++ b/apps/web/src/lib/campaigns/workspace.test.ts
@@ -80,11 +80,26 @@ describe("campaign workspace", () => {
   it("keeps the intended left-to-right tab order and hides the GM tab for players", () => {
     expect(
       buildCampaignWorkspaceTabs({ canAccessGmEncounter: true }).map((tab) => tab.id)
-    ).toEqual(["campaign", "scenario", "gm-encounter", "player-encounter"]);
+    ).toEqual(["campaign", "scenario", "gm-encounter", "player-encounter", "character"]);
 
     expect(
       buildCampaignWorkspaceTabs({ canAccessGmEncounter: false }).map((tab) => tab.id)
-    ).toEqual(["campaign", "scenario", "player-encounter"]);
+    ).toEqual(["campaign", "scenario", "player-encounter", "character"]);
+  });
+
+  it("opens the Character tab against the active scenario context", () => {
+    const state = resolveCampaignWorkspaceState({
+      activeCampaignId: "camp-1",
+      canAccessGmEncounter: false,
+      encounters: [],
+      requestedEncounterId: null,
+      requestedScenarioId: null,
+      requestedTab: "character",
+      scenarios: [scenario({ id: "scn-1", name: "Session one" })],
+    });
+
+    expect(state.activeScenarioId).toBe("scn-1");
+    expect(state.activeTab).toBe("character");
   });
 
   it("sanitizes scenario and encounter selection against the current campaign flow", () => {

--- a/apps/web/src/lib/campaigns/workspace.ts
+++ b/apps/web/src/lib/campaigns/workspace.ts
@@ -6,7 +6,8 @@ export type CampaignWorkspaceTabId =
   | "campaign"
   | "scenario"
   | "gm-encounter"
-  | "player-encounter";
+  | "player-encounter"
+  | "character";
 
 export interface CampaignWorkspaceTab {
   id: CampaignWorkspaceTabId;
@@ -32,7 +33,8 @@ const orderedTabs: CampaignWorkspaceTab[] = [
   { id: "campaign", label: "Campaign" },
   { id: "scenario", label: "Scenario" },
   { id: "gm-encounter", label: "GM Encounter" },
-  { id: "player-encounter", label: "Player Encounter" }
+  { id: "player-encounter", label: "Player Encounter" },
+  { id: "character", label: "Character" }
 ];
 
 export function buildCampaignWorkspaceHref(input: CampaignWorkspaceHrefInput): string {
@@ -111,6 +113,8 @@ function resolveRequestedCampaignWorkspaceTab(input: {
       }
 
       return input.activeScenarioId && input.activeEncounterId ? "player-encounter" : fallbackTab;
+    case "character":
+      return input.activeScenarioId ? "character" : fallbackTab;
     default:
       return fallbackTab;
   }
@@ -213,7 +217,11 @@ export function resolveCampaignWorkspaceState(input: {
     : undefined;
 
   if (!input.canAccessGmEncounter) {
-    if (!activeScenarioId && requestedTab === "scenario" && input.scenarios.length === 1) {
+    if (
+      !activeScenarioId &&
+      (requestedTab === "scenario" || requestedTab === "character") &&
+      input.scenarios.length === 1
+    ) {
       activeScenarioId = input.scenarios[0]?.id;
     }
 

--- a/apps/web/src/lib/characters/physicalState.test.ts
+++ b/apps/web/src/lib/characters/physicalState.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCharacterPhysicalStateView,
+  calculateLocationHitpoints,
+  HIT_LOCATION_DEFINITIONS,
+} from "./physicalState";
+
+describe("character physical state read model", () => {
+  it("defines all hit locations and weights total 22/11", () => {
+    expect(HIT_LOCATION_DEFINITIONS.map((location) => location.label)).toEqual([
+      "Head",
+      "Left arm",
+      "Right arm",
+      "Chest/back",
+      "Abdomen/lower back",
+      "Upper left leg",
+      "Lower left leg",
+      "Upper right leg",
+      "Lower right leg",
+    ]);
+
+    const totalNumerator = HIT_LOCATION_DEFINITIONS.reduce(
+      (total, location) => total + location.weightNumerator,
+      0,
+    );
+
+    expect(totalNumerator).toBe(22);
+  });
+
+  it("rounds location hitpoints with Math.round and keeps positive locations at least 1", () => {
+    expect(
+      calculateLocationHitpoints({
+        generalHitpoints: 22,
+        weightDenominator: 11,
+        weightNumerator: 2,
+      }),
+    ).toBe(4);
+    expect(
+      calculateLocationHitpoints({
+        generalHitpoints: 1,
+        weightDenominator: 11,
+        weightNumerator: 2,
+      }),
+    ).toBe(1);
+  });
+
+  it("builds location hitpoints that total double general hitpoints for exact weights", () => {
+    const view = buildCharacterPhysicalStateView({ generalHitpoints: 22 });
+    const totalLocationHitpoints = view.hitpoints.locations.reduce(
+      (total, location) => total + location.original,
+      0,
+    );
+
+    expect(view.hitpoints.general.original).toBe(22);
+    expect(totalLocationHitpoints).toBe(44);
+  });
+
+  it("subtracts general and location damage from current hitpoints", () => {
+    const view = buildCharacterPhysicalStateView({
+      generalDamage: 3,
+      generalHitpoints: 22,
+      locationDamageById: {
+        head: 2,
+      },
+    });
+
+    expect(view.hitpoints.general).toEqual({
+      current: 19,
+      damage: 3,
+      original: 22,
+    });
+    expect(view.hitpoints.locations.find((location) => location.id === "head")).toMatchObject({
+      current: 2,
+      damage: 2,
+      original: 4,
+    });
+  });
+
+  it("defaults damage by type and hit log to empty scaffold values", () => {
+    const view = buildCharacterPhysicalStateView({ generalHitpoints: 10 });
+
+    expect(view.damageByType.map((row) => [row.label, row.currentEffect])).toEqual([
+      ["General", 0],
+      ["OB/Skill", 0],
+      ["DB", 0],
+      ["Other", 0],
+      ["Bleed", 0],
+      ["Special", "—"],
+    ]);
+    expect(view.hitLog).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/characters/physicalState.ts
+++ b/apps/web/src/lib/characters/physicalState.ts
@@ -1,0 +1,144 @@
+export interface HitLocationDefinition {
+  id: string;
+  label: string;
+  weightDenominator: 11;
+  weightNumerator: 2 | 4;
+}
+
+export interface HitpointRowView {
+  current: number;
+  damage: number;
+  original: number;
+}
+
+export interface HitLocationView extends HitLocationDefinition, HitpointRowView {}
+
+export interface DamageByTypeView {
+  currentEffect: number | string;
+  id: "general" | "obSkill" | "db" | "other" | "bleed" | "special";
+  label: string;
+}
+
+export interface HitLogEntryView {
+  damage: number;
+  duration: string;
+  generalDamage: number;
+  id: string;
+  location: string;
+  source: string;
+  specialEffects: string;
+  type: string;
+}
+
+export interface CharacterPhysicalStateView {
+  damageByType: DamageByTypeView[];
+  hitLog: HitLogEntryView[];
+  hitpoints: {
+    general: HitpointRowView;
+    locations: HitLocationView[];
+  };
+}
+
+export const HIT_LOCATION_DEFINITIONS: HitLocationDefinition[] = [
+  { id: "head", label: "Head", weightDenominator: 11, weightNumerator: 2 },
+  { id: "leftArm", label: "Left arm", weightDenominator: 11, weightNumerator: 2 },
+  { id: "rightArm", label: "Right arm", weightDenominator: 11, weightNumerator: 2 },
+  { id: "chestBack", label: "Chest/back", weightDenominator: 11, weightNumerator: 4 },
+  {
+    id: "abdomenLowerBack",
+    label: "Abdomen/lower back",
+    weightDenominator: 11,
+    weightNumerator: 4,
+  },
+  {
+    id: "upperLeftLeg",
+    label: "Upper left leg",
+    weightDenominator: 11,
+    weightNumerator: 2,
+  },
+  {
+    id: "lowerLeftLeg",
+    label: "Lower left leg",
+    weightDenominator: 11,
+    weightNumerator: 2,
+  },
+  {
+    id: "upperRightLeg",
+    label: "Upper right leg",
+    weightDenominator: 11,
+    weightNumerator: 2,
+  },
+  {
+    id: "lowerRightLeg",
+    label: "Lower right leg",
+    weightDenominator: 11,
+    weightNumerator: 2,
+  },
+];
+
+const DEFAULT_DAMAGE_BY_TYPE: DamageByTypeView[] = [
+  { currentEffect: 0, id: "general", label: "General" },
+  { currentEffect: 0, id: "obSkill", label: "OB/Skill" },
+  { currentEffect: 0, id: "db", label: "DB" },
+  { currentEffect: 0, id: "other", label: "Other" },
+  { currentEffect: 0, id: "bleed", label: "Bleed" },
+  { currentEffect: "—", id: "special", label: "Special" },
+];
+
+export function calculateLocationHitpoints(input: {
+  generalHitpoints: number;
+  weightDenominator: number;
+  weightNumerator: number;
+}): number {
+  if (input.generalHitpoints <= 0) {
+    return 0;
+  }
+
+  return Math.max(
+    1,
+    Math.round(
+      (input.generalHitpoints * input.weightNumerator) / input.weightDenominator,
+    ),
+  );
+}
+
+export function buildCharacterPhysicalStateView(input: {
+  damageByType?: Partial<Record<DamageByTypeView["id"], number | string>>;
+  generalDamage?: number;
+  generalHitpoints?: number | null;
+  hitLog?: HitLogEntryView[];
+  locationDamageById?: Partial<Record<string, number>>;
+}): CharacterPhysicalStateView {
+  const originalGeneral = Math.max(0, Math.round(input.generalHitpoints ?? 0));
+  const generalDamage = input.generalDamage ?? 0;
+
+  return {
+    damageByType: DEFAULT_DAMAGE_BY_TYPE.map((row) => ({
+      ...row,
+      currentEffect: input.damageByType?.[row.id] ?? row.currentEffect,
+    })),
+    hitLog: input.hitLog ?? [],
+    hitpoints: {
+      general: {
+        current: originalGeneral - generalDamage,
+        damage: generalDamage,
+        original: originalGeneral,
+      },
+      locations: HIT_LOCATION_DEFINITIONS.map((location) => {
+        const original = calculateLocationHitpoints({
+          generalHitpoints: originalGeneral,
+          weightDenominator: location.weightDenominator,
+          weightNumerator: location.weightNumerator,
+        });
+        const damage = input.locationDamageById?.[location.id] ?? 0;
+
+        return {
+          ...location,
+          current: original - damage,
+          damage,
+          original,
+        };
+      }),
+    },
+  };
+}

--- a/docs/product/campaign-scenario-encounter-workflows.md
+++ b/docs/product/campaign-scenario-encounter-workflows.md
@@ -122,6 +122,17 @@ Player Encounter pages should not show:
 - Admin-only controls.
 - Raw session JSON, read-model source names, fallback labels, or internal IDs.
 
+## Character Workspace
+
+The Character workspace answers: "What can this character do and control right now?"
+
+Current first-pass rule:
+
+- The Character page intentionally reuses the existing Equip Items interface exactly.
+- Equip Items remains available as its own route.
+- Physical state, damage effects, bleed, fatigue, mental/combat effects, GM-set modifiers, adjusted stats, and combat action modules are future work.
+- Future modules should not appear as visible placeholders until they are actionable.
+
 ## Player-Facing Copy Rules
 
 Player pages should avoid admin/internal mechanics. If a player cannot act, the page should explain the actionable circumstance, not the implementation reason.

--- a/docs/product/campaign-scenario-encounter-workflows.md
+++ b/docs/product/campaign-scenario-encounter-workflows.md
@@ -130,6 +130,9 @@ Current first-pass rule:
 
 - The Character page intentionally reuses the existing Equip Items interface exactly.
 - Equip Items remains available as its own route.
+- The primary live-play workflow is the Campaign workspace Character tab.
+- Player Character tab shows only the player's current controlled scenario or encounter character.
+- GM Character tab lets the GM inspect and shuffle through character-backed scenario or encounter participants.
 - Physical state, damage effects, bleed, fatigue, mental/combat effects, GM-set modifiers, adjusted stats, and combat action modules are future work.
 - Future modules should not appear as visible placeholders until they are actionable.
 

--- a/docs/product/campaign-scenario-encounter-workflows.md
+++ b/docs/product/campaign-scenario-encounter-workflows.md
@@ -128,12 +128,13 @@ The Character workspace answers: "What can this character do and control right n
 
 Current first-pass rule:
 
-- The Character page intentionally reuses the existing Equip Items interface exactly.
+- The Character page intentionally reuses the existing Equip Items interface as its equipment/loadout core.
 - Equip Items remains available as its own route.
 - The primary live-play workflow is the Campaign workspace Character tab.
 - Player Character tab shows only the player's current controlled scenario or encounter character.
 - GM Character tab lets the GM inspect and shuffle through character-backed scenario or encounter participants.
-- Physical state, damage effects, bleed, fatigue, mental/combat effects, GM-set modifiers, adjusted stats, and combat action modules are future work.
+- Character control now includes a first Physical state scaffold with Hitpoints, Damage by type, and Log of hits.
+- Detailed damage application, bleed, stun, fatigue, duration processing, mental/combat effects, GM-set modifiers, adjusted stats, and combat action modules are future rule work.
 - Future modules should not appear as visible placeholders until they are actionable.
 
 ## Player-Facing Copy Rules


### PR DESCRIPTION
## PR update

This PR now also includes the new encounter-context **Character** screen / Character control page, plus the CI typecheck fixture fix.

## New Character screen

Added a new **Character** tab in the Campaign workspace, intended as the live character control/inspection page during scenarios and encounters.

### Player behavior

- The Player Character tab auto-resolves the player’s current controlled scenario/encounter character.
- The player does not get a character selector.
- The page currently renders the same loadout/equipment interface as Equip Items.
- The page also now includes the first **Physical state** section.

### GM behavior

- The GM Character tab includes a participant selector.
- GM can switch inspected character with a dropdown plus Previous / Next controls.
- The page renders the same loadout/equipment interface for the selected participant.
- Participants without a saved character sheet get a safe empty state.

### Reuse / scope

- Reuses `CharacterLoadoutView`.
- Existing `/characters/[id]/loadout` remains the plain Equip Items page.
- Existing `/characters/[id]/character` and `/characters/inspect` remain available.
- No equipment rules, character sheet calculations, encounter rules, persistence model, or DB schema changed.

## Physical state section

Added the first **Physical state** scaffold to the new Character control pages only.

It currently includes:

- **Hitpoints**
  - General HP
  - Location HP by body location
  - Original / Damage / Current columns
- **Damage by type**
  - General
  - OB/Skill
  - DB
  - Other
  - Bleed
  - Special
- **Log of hits**
  - Source
  - Type
  - Location
  - Damage
  - General damage
  - Duration
  - Special effects

### Current scope

- This is a display/read-model scaffold only.
- Damage, bleed, fatigue, stun, duration processing, and combat arena actions are not implemented yet.
- No visual placeholders for future combat modules were added beyond the requested physical-state containers.
- `/characters/[id]/loadout` does **not** show Physical state; it remains the original Equip Items view.

## CI/typecheck fix

Fixed the CI typecheck failure with a test-fixture-only change in:

`apps/web/src/lib/campaigns/characterWorkspace.test.ts`

### What changed

Updated the fixture to match the current encounter/session shapes:

- Removed obsolete scenario combat fields:
  - `attacksThisRound`
  - `declaredAction`
  - `defenseMode`
  - `incomingAttack`
  - `parryAvailable`
  - `parrySource`
- Added current valid scenario combat fixture fields:
  - `combatContext` with empty modifier buckets
  - `engaged: false`
- Added required `equipment: {}` to scenario participant state.
- Added a local `makeEncounterParticipant()` test factory with complete encounter participant defaults:
  - `declaration`
  - `position`
  - `facing`
  - `orientation`
  - `initiative`
  - `order`
  - other required fields.

### Production behavior

No production behavior changed in the CI fix. It was a test-fixture-only update.

## Verification

Passed locally: