### PR TITLE
ci: tving JavaScript-actions til Node.js 24 før deprecation 2026-06-02

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["**"]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,7 @@ env:
   REGISTRY: ${{ secrets.REGISTRY_LOGIN_SERVER }}
   API_IMAGE: ${{ secrets.REGISTRY_LOGIN_SERVER }}/glantri-api
   WEB_IMAGE: ${{ secrets.REGISTRY_LOGIN_SERVER }}/glantri-web
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   detect-changes:


### PR DESCRIPTION
## Summary

GitHub flagger at `actions/checkout@v4`, `actions/setup-node@v4` og `pnpm/action-setup@v4` kjører på Node.js 20-runtime, og at disse tvinges over til Node.js 24 fra **2. juni 2026**. Vi opt-er inn nå ved å sette `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` på workflow-nivå i begge workflowene.

- `ci.yml` får nytt `env`-blokk
- `deploy.yml` får tillegg i eksisterende `env`-blokk

Etter merge skal deprecation-advarselen forsvinne fra CI-logger.

Ingen kodeendring, ingen test-impact. Kun GitHub Actions-runtime.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Test plan

- [ ] CI kjører grønt på denne PR-en (verifiserer at Node 24-runtime fungerer for actions)
- [ ] Sjekk at "Node.js 20 actions are deprecated"-advarselen er borte fra workflow-loggen

🤖 Generated with [Claude Code](https://claude.com/claude-code)