### PR TITLE
chore: rydd ubrukte workspace-deps + filstørrelsesrapport i CI (T-22, T-25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: File-size report
+        run: node scripts/checkFileSize.mjs
+
   docker-test:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,8 +18,5 @@
     "@glantri/rules-engine": "workspace:*",
     "@glantri/shared": "workspace:*",
     "fastify": "^5.6.1"
-  },
-  "devDependencies": {
-    "@glantri/test-scenarios": "workspace:*"
   }
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -30,7 +30,6 @@
     "@glantri/content": "workspace:*",
     "@glantri/domain": "workspace:*",
     "@glantri/rules-engine": "workspace:*",
-    "@glantri/shared": "workspace:*",
     "@prisma/client": "^6.6.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,10 +72,6 @@ importers:
       fastify:
         specifier: ^5.6.1
         version: 5.8.2
-    devDependencies:
-      '@glantri/test-scenarios':
-        specifier: workspace:*
-        version: link:../../packages/test-scenarios
 
   apps/web:
     dependencies:
@@ -179,9 +175,6 @@ importers:
       '@glantri/rules-engine':
         specifier: workspace:*
         version: link:../rules-engine
-      '@glantri/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@prisma/client':
         specifier: ^6.6.0
         version: 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)

--- a/scripts/checkFileSize.mjs
+++ b/scripts/checkFileSize.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const THRESHOLD = Number(process.env.FILE_SIZE_THRESHOLD ?? 500);
+const REPO_ROOT = process.cwd();
+
+const SCAN_DIRS = [
+  "apps/api/src",
+  "apps/web/src",
+  "apps/web/app",
+  "packages/auth/src",
+  "packages/content/src",
+  "packages/database/src",
+  "packages/domain/src",
+  "packages/importers/src",
+  "packages/rules-engine/src",
+  "packages/shared/src",
+];
+
+const SKIP_DIR_NAMES = new Set([
+  "node_modules",
+  "dist",
+  ".next",
+  "coverage",
+  "data",
+]);
+
+function shouldSkipFile(name) {
+  if (name.endsWith(".test.ts")) return true;
+  if (name.endsWith(".test.tsx")) return true;
+  if (name.endsWith(".component.test.tsx")) return true;
+  if (name.endsWith(".d.ts")) return true;
+  if (name.endsWith(".json")) return true;
+  return false;
+}
+
+function shouldScanFile(name) {
+  return name.endsWith(".ts") || name.endsWith(".tsx");
+}
+
+function walk(dir, results) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(entry.name)) continue;
+      walk(join(dir, entry.name), results);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (shouldSkipFile(entry.name)) continue;
+    if (!shouldScanFile(entry.name)) continue;
+    const fullPath = join(dir, entry.name);
+    const content = readFileSync(fullPath, "utf8");
+    const lines = content.split("\n").length;
+    if (lines >= THRESHOLD) {
+      results.push({ path: relative(REPO_ROOT, fullPath).replaceAll("\\", "/"), lines });
+    }
+  }
+}
+
+const results = [];
+for (const dir of SCAN_DIRS) {
+  walk(join(REPO_ROOT, dir), results);
+}
+results.sort((a, b) => b.lines - a.lines);
+
+const summaryLines = [];
+summaryLines.push(`## File-size report (threshold: ${THRESHOLD} lines)`);
+summaryLines.push("");
+if (results.length === 0) {
+  summaryLines.push(`No production files at or above ${THRESHOLD} lines. ✅`);
+} else {
+  summaryLines.push(`Found **${results.length}** file(s) at or above the threshold:`);
+  summaryLines.push("");
+  summaryLines.push("| Lines | File |");
+  summaryLines.push("|------:|------|");
+  for (const r of results) {
+    summaryLines.push(`| ${r.lines} | \`${r.path}\` |`);
+  }
+  summaryLines.push("");
+  summaryLines.push("> Not a hard fail. Refactor large files when convenient — see `docs/architecture/system-overview.md` and the feature-mappe-mønsteret in `CLAUDE.md`.");
+}
+
+const summary = summaryLines.join("\n");
+console.log(summary);
+
+const githubSummary = process.env.GITHUB_STEP_SUMMARY;
+if (githubSummary) {
+  try {
+    const { appendFileSync } = await import("node:fs");
+    appendFileSync(githubSummary, summary + "\n");
+  } catch (err) {
+    console.error("Failed to write GITHUB_STEP_SUMMARY:", err.message);
+  }
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary

**T-22 — Rydd ubrukte workspace-deps:**
- Fjernet `@glantri/test-scenarios` fra `apps/api/devDependencies` (0 imports i `src/`)
- Fjernet `@glantri/shared` fra `packages/database/dependencies` (0 imports i `src/`)
- `pnpm-lock.yaml` oppdatert
- Aliasene i `tsconfig.base.json` og `vitest.base.ts` beholdes — `test-scenarios` er planlagt brukt i tester

**T-25 — Filstørrelsesrapport:**
- Nytt script `scripts/checkFileSize.mjs`
- Scanner produksjonskode i `apps/api/src`, `apps/web/{src,app}` og `packages/*/src` for filer ≥ 500 linjer
- Terskel kan justeres via `FILE_SIZE_THRESHOLD` env-var
- Skipper `*.test.ts(x)`, `*.d.ts`, `*.json`, `data/`, `dist/`, `node_modules/`, `.next/`, `coverage/`
- Skriver markdown-tabell til stdout og `GITHUB_STEP_SUMMARY` (synlig på workflow-runen)
- Avslutter alltid med kode 0 — **advarsel, ikke fail**
- Lagt til som siste steg i `ci.yml` etter `build`

Closes #178, #181

## Lokal kjøring

```bash
node scripts/checkFileSize.mjs
# 44 filer over terskel i dag (RoleplayEncounterScreens 2420, TemplatesPageContent 2189, ...)
```

## Test plan

- [x] `pnpm typecheck` — ren etter dep-fjerning
- [x] `node scripts/checkFileSize.mjs` lokalt — output stemmer
- [ ] CI verifiserer at file-size-stegen kjører på GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)