### PR TITLE
refactor: syncClient feilmodell + gitignore stor JSON-eksport (T-23, T-24)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ apps/web/e2e/.auth/
 apps/web/e2e/test-state.json
 apps/web/playwright-report/
 apps/web/test-results/
+
+# Large generated export artifacts (regenerate with `pnpm --filter @glantri/content export:skill-system-ai`)
+exports/skill-system-ai/*.json

--- a/apps/web/src/lib/sync/syncClient.ts
+++ b/apps/web/src/lib/sync/syncClient.ts
@@ -5,6 +5,8 @@ import type {
   SyncPushResponse
 } from "@glantri/shared";
 
+import { parseResponse } from "../api/apiClient";
+
 export interface SyncClient {
   pull<TPayload = unknown>(request: SyncPullRequest): Promise<SyncPullResponse<TPayload>>;
   push<TPayload = unknown>(request: SyncPushRequest<TPayload>): Promise<SyncPushResponse>;
@@ -22,8 +24,10 @@ export class HttpSyncClient implements SyncClient {
       url.searchParams.set("cursor", request.cursor);
     }
 
-    const response = await fetch(url);
-    return response.json();
+    const response = await fetch(url, {
+      credentials: "include"
+    });
+    return parseResponse<SyncPullResponse<TPayload>>(response);
   }
 
   async push<TPayload = unknown>(
@@ -31,12 +35,13 @@ export class HttpSyncClient implements SyncClient {
   ): Promise<SyncPushResponse> {
     const response = await fetch(new URL("/sync", this.baseUrl), {
       body: JSON.stringify(request),
+      credentials: "include",
       headers: {
         "content-type": "application/json"
       },
       method: "POST"
     });
 
-    return response.json();
+    return parseResponse<SyncPushResponse>(response);
   }
 }

--- a/exports/skill-system-ai/glantri-skill-system-note.md
+++ b/exports/skill-system-ai/glantri-skill-system-note.md
@@ -1,5 +1,13 @@
 # Glantri Skill System AI Export Notes
 
+## Regenerating the export
+
+`glantri-skill-system-export.json` is gitignored (~190k lines). Regenerate locally with:
+
+```bash
+pnpm --filter @glantri/content export:skill-system-ai
+```
+
 ## Purpose
 This export is for AI review/modeling and possible later import proposals. It is not canonical content by itself, and generated suggestions must not be reimported without validation.
 


### PR DESCRIPTION
## Summary

**T-23 — syncClient feilmodell:**
- `HttpSyncClient.pull()` og `push()` bruker nå `parseResponse` fra `apiClient.ts`
- Konsistent feilhåndtering: non-2xx kaster `ApiRequestError` med status og payload
- `credentials: "include"` lagt til på begge fetch-kall for konsistens med apiClient
- `HttpSyncClient` er per nå ikke importert noe sted — backend `/sync`-ruter eksisterer, klienten venter på fremtidig integrasjon. Refactoren sikrer at den er konsistent når den tas i bruk.

**T-24 — Stor JSON-eksport ut av git:**
- `exports/skill-system-ai/glantri-skill-system-export.json` (~194k linjer) lagt i `.gitignore`
- Filen fjernet fra git tracking — lokal kopi beholdes
- Regenereres med `pnpm --filter @glantri/content export:skill-system-ai`
- `note.md` og `schema.md` beholdes (små, dokumenterer eksporten)
- Regenerering-instruksjon lagt i `note.md`

Closes #179, #180

## Test plan

- [x] `pnpm --filter @glantri/web typecheck` — ren
- [ ] CI verifiserer at fjerning av tracked JSON ikke bryter andre scripts

## Reviewer-notater

- syncClient endrer beteende: tidligere returnerte den parsed JSON uansett HTTP-status. Nå kaster den `ApiRequestError` på non-2xx. Siden klienten ikke brukes ennå, er det ingen call sites å oppdatere.
- Hvis eksport-JSON fortsatt trengs for ekstern AI-review, regenerer på laptop og deler manuelt — den ligger ikke lenger i repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)