### PR TITLE
Feature/player general encounter screen

### DIFF
--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
@@ -54,15 +54,20 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("currentRoundNumber={activeScenario?.liveState?.roundNumber}");
   });
 
-  it("lets the GM inspect player-facing Skill rolls for a selected participant", () => {
+  it("keeps GM Skill rolls focused on GM tools and routes player inspection separately", () => {
     const source = readSource();
 
-    expect(source).toContain('screenName="Skill rolls"');
-    expect(source).toContain("Player view");
+    expect(source).toContain('workspaceState.activeTab === "skill-rolls"');
+    expect(source).toContain('workspaceState.activeTab === "player-skill-rolls"');
+    expect(source).toContain('screenName="Player skill rolls"');
     expect(source).toContain("inspectionParticipantId={selectedGmInspectableCandidate.id}");
     expect(source).toContain("readOnlyInspection");
     expect(source).toContain("showWorkspaceHeader={false}");
-    expect(source).toContain('selectInspectableParticipant({ participantId, tab: "skill-rolls" })');
+    expect(source).toContain(
+      'selectInspectableParticipant({ participantId, tab: "player-skill-rolls" })',
+    );
+    expect(source).toContain('workspaceScreenName="Player skill rolls"');
+    expect(source).not.toContain("Player view");
   });
 
   it("routes the workspace Combat tab through the recovered combat panel", () => {
@@ -77,11 +82,24 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("onEncounterUpdated");
     expect(source).toContain("ScenarioPlayerCombatPageContent");
     expect(source).toContain('workspaceTab="combat"');
-    expect(source).toContain('screenName="Combat"');
-    expect(source).toContain("Player combat inspection");
-    expect(source).toContain("showParticipantSelector={false}");
-    expect(source).toContain("readOnlyInspection");
     expect(source).toContain("Select a scenario to open the combat panel.");
     expect(source).toContain("No encounter is currently available for combat tools.");
+    expect(source).not.toContain("Player combat inspection");
+    expect(source).not.toContain('screenName="Combat"');
+  });
+
+  it("routes Player combat through its own GM inspection tab", () => {
+    const source = readSource();
+
+    expect(source).toContain('workspaceState.activeTab === "player-combat"');
+    expect(source).toContain('screenName="Player combat"');
+    expect(source).toContain("ScenarioPlayerCombatPageContent");
+    expect(source).toContain('workspaceTab="player-combat"');
+    expect(source).toContain("showParticipantSelector={false}");
+    expect(source).toContain("readOnlyInspection");
+    expect(source).toContain(
+      'selectInspectableParticipant({ participantId, tab: "player-combat" })',
+    );
+    expect(source).toContain("No participant is available for player combat inspection.");
   });
 });

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
@@ -24,6 +24,8 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("loadScenarioMyParticipant");
     expect(source).toContain('workspaceAccess.accessMode === "player"');
     expect(source).toContain("currentUserId: currentUser?.id");
+    expect(source).toContain("WorkspaceParticipantInspectionHeader");
+    expect(source).toContain("buildGmCharacterWorkspaceCandidates");
   });
 
   it("renders player scenario links and useful empty states", () => {
@@ -47,9 +49,20 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("CharacterWorkspacePanel");
     expect(source).toContain('workspaceState.activeTab === "character"');
     expect(source).toContain('tab: "character"');
-    expect(source).toContain("selectedParticipantId={searchParams.get(\"participantId\")}");
+    expect(source).toContain('selectedParticipantId={searchParams.get("participantId")}');
     expect(source).toContain("isGameMaster={canAccessGmEncounter}");
     expect(source).toContain("currentRoundNumber={activeScenario?.liveState?.roundNumber}");
+  });
+
+  it("lets the GM inspect player-facing Skill rolls for a selected participant", () => {
+    const source = readSource();
+
+    expect(source).toContain('screenName="Skill rolls"');
+    expect(source).toContain("Player view");
+    expect(source).toContain("inspectionParticipantId={selectedGmInspectableCandidate.id}");
+    expect(source).toContain("readOnlyInspection");
+    expect(source).toContain("showWorkspaceHeader={false}");
+    expect(source).toContain('selectInspectableParticipant({ participantId, tab: "skill-rolls" })');
   });
 
   it("routes the workspace Combat tab through the recovered combat panel", () => {
@@ -64,6 +77,10 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("onEncounterUpdated");
     expect(source).toContain("ScenarioPlayerCombatPageContent");
     expect(source).toContain('workspaceTab="combat"');
+    expect(source).toContain('screenName="Combat"');
+    expect(source).toContain("Player combat inspection");
+    expect(source).toContain("showParticipantSelector={false}");
+    expect(source).toContain("readOnlyInspection");
     expect(source).toContain("Select a scenario to open the combat panel.");
     expect(source).toContain("No encounter is currently available for combat tools.");
   });

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
@@ -10,11 +10,15 @@ function readSource(): string {
 }
 
 describe("CampaignWorkspaceShell roleplay encounter routing", () => {
-  it("routes player roleplay encounters to the player roleplaying screen", () => {
+  it("routes shared Encounter and Skill rolls tabs through player-safe roleplay surfaces", () => {
     const source = readSource();
 
     expect(source).toContain("PlayerRoleplayingEncounterScreen");
-    expect(source).toContain('activeEncounter?.kind === "roleplay"');
+    expect(source).toContain('workspaceState.activeTab === "encounter"');
+    expect(source).toContain('workspaceState.activeTab === "skill-rolls"');
+    expect(source).toContain('surface="encounter"');
+    expect(source).toContain('surface="skill-rolls"');
+    expect(source).toContain("EncounterDetail");
     expect(source).toContain("ScenarioPlayerCombatPageContent");
     expect(source).toContain("loadScenarioParticipants");
     expect(source).toContain("loadScenarioMyParticipant");
@@ -28,7 +32,8 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("Available scenarios");
     expect(source).toContain('tab: "scenario"');
     expect(source).toContain("No active scenario is currently available.");
-    expect(source).toContain("No player encounter is currently available.");
+    expect(source).toContain("No encounter is currently available.");
+    expect(source).toContain("No skill rolls are currently available.");
     expect(source).toContain("Waiting for GM to add you to an encounter.");
     expect(source).toContain("You are in this scenario, but not assigned to this encounter.");
     expect(source).toContain("refreshWorkspaceContextWithErrorHandling");
@@ -52,17 +57,14 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
 
     expect(source).toContain('workspaceState.activeTab === "combat"');
     expect(source).toContain("CombatRoundManagerPanel");
-    expect(source).toContain('activeEncounter?.kind === "combat"');
-    expect(source).toContain("activeScenarioCombatEncounters");
-    expect(source).toContain("sortedActiveScenarioCombatEncounters");
+    expect(source).toContain("canAccessGmEncounter && activeEncounter");
+    expect(source).toContain("sortedActiveScenarioEncounters");
     expect(source).toContain("Select an encounter to open the Combat Round Manager.");
-    expect(source).toContain("The selected encounter is roleplaying.");
-    expect(source).toContain("Select or create a combat encounter to use the Combat Round Manager.");
-    expect(source).toContain("Create combat encounter on Scenario tab");
+    expect(source).toContain("Create or open an encounter on Scenario tab");
     expect(source).toContain("onEncounterUpdated");
     expect(source).toContain("ScenarioPlayerCombatPageContent");
     expect(source).toContain('workspaceTab="combat"');
     expect(source).toContain("Select a scenario to open the combat panel.");
-    expect(source).toContain("No combat encounter is currently available.");
+    expect(source).toContain("No encounter is currently available for combat tools.");
   });
 });

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
@@ -51,6 +51,11 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     const source = readSource();
 
     expect(source).toContain('workspaceState.activeTab === "combat"');
+    expect(source).toContain("CombatRoundManagerPanel");
+    expect(source).toContain('activeEncounter?.kind === "combat"');
+    expect(source).toContain("activeScenarioCombatEncounters");
+    expect(source).toContain("Select an encounter to open the Combat Round Manager.");
+    expect(source).toContain("onEncounterUpdated");
     expect(source).toContain("ScenarioPlayerCombatPageContent");
     expect(source).toContain('workspaceTab="combat"');
     expect(source).toContain("Select a scenario to open the combat panel.");

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
@@ -54,7 +54,11 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("CombatRoundManagerPanel");
     expect(source).toContain('activeEncounter?.kind === "combat"');
     expect(source).toContain("activeScenarioCombatEncounters");
+    expect(source).toContain("sortedActiveScenarioCombatEncounters");
     expect(source).toContain("Select an encounter to open the Combat Round Manager.");
+    expect(source).toContain("The selected encounter is roleplaying.");
+    expect(source).toContain("Select or create a combat encounter to use the Combat Round Manager.");
+    expect(source).toContain("Create combat encounter on Scenario tab");
     expect(source).toContain("onEncounterUpdated");
     expect(source).toContain("ScenarioPlayerCombatPageContent");
     expect(source).toContain('workspaceTab="combat"');

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
@@ -49,6 +49,25 @@ const panelStyle = {
   padding: "1rem"
 } as const;
 
+function getEncounterStatusRank(status: EncounterSession["status"]): number {
+  switch (status) {
+    case "active":
+      return 0;
+    case "planned":
+      return 1;
+    case "paused":
+      return 2;
+    case "setup":
+      return 3;
+    case "complete":
+      return 4;
+    case "archived":
+      return 99;
+    default:
+      return 50;
+  }
+}
+
 export default function CampaignWorkspaceShell({
   campaignId
 }: CampaignWorkspaceShellProps) {
@@ -210,7 +229,12 @@ export default function CampaignWorkspaceShell({
     scenarioId: workspaceState.activeScenarioId,
   });
   const activeScenarioCombatEncounters = activeScenarioEncounters.filter(
-    (encounter) => encounter.kind === "combat",
+    (encounter) => encounter.kind === "combat" && encounter.status !== "archived",
+  );
+  const sortedActiveScenarioCombatEncounters = [...activeScenarioCombatEncounters].sort(
+    (left, right) =>
+      getEncounterStatusRank(left.status) - getEncounterStatusRank(right.status) ||
+      left.title.localeCompare(right.title),
   );
   const activeScenario = scenarios.find(
     (scenario) => scenario.id === workspaceState.activeScenarioId
@@ -583,22 +607,52 @@ export default function CampaignWorkspaceShell({
       {accessMode !== "none" && workspaceState.activeTab === "combat" ? (
         <section style={{ display: "grid", gap: "1rem" }}>
           {canAccessGmEncounter && activeEncounter?.kind === "combat" ? (
-            <CombatRoundManagerPanel
-              encounter={activeEncounter}
-              onEncounterUpdated={(nextEncounter) => {
-                setEncounters((current) =>
-                  current.map((encounter) =>
-                    encounter.id === nextEncounter.id ? nextEncounter : encounter,
-                  ),
-                );
-              }}
-            />
+            <>
+              {sortedActiveScenarioCombatEncounters.length > 1 ? (
+                <section style={panelStyle}>
+                  <strong>Combat encounters</strong>
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
+                    {sortedActiveScenarioCombatEncounters.map((encounter) => (
+                      <Link
+                        key={encounter.id}
+                        href={buildWorkspaceHref({
+                          encounterId: encounter.id,
+                          scenarioId: encounter.scenarioId,
+                          tab: "combat",
+                        })}
+                      >
+                        {encounter.title}
+                      </Link>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+              <CombatRoundManagerPanel
+                encounter={activeEncounter}
+                onEncounterUpdated={(nextEncounter) => {
+                  setEncounters((current) =>
+                    current.map((encounter) =>
+                      encounter.id === nextEncounter.id ? nextEncounter : encounter,
+                    ),
+                  );
+                }}
+              />
+            </>
           ) : canAccessGmEncounter ? (
             <section style={panelStyle}>
-              <strong>Select an encounter to open the Combat Round Manager.</strong>
-              {activeScenarioCombatEncounters.length > 0 ? (
+              {activeEncounter?.kind === "roleplay" ? (
+                <>
+                  <strong>The selected encounter is roleplaying.</strong>
+                  <div>
+                    Select or create a combat encounter to use the Combat Round Manager.
+                  </div>
+                </>
+              ) : (
+                <strong>Select an encounter to open the Combat Round Manager.</strong>
+              )}
+              {sortedActiveScenarioCombatEncounters.length > 0 ? (
                 <div style={{ display: "grid", gap: "0.5rem" }}>
-                  {activeScenarioCombatEncounters.map((encounter) => (
+                  {sortedActiveScenarioCombatEncounters.map((encounter) => (
                     <Link
                       key={encounter.id}
                       href={buildWorkspaceHref({
@@ -612,7 +666,19 @@ export default function CampaignWorkspaceShell({
                   ))}
                 </div>
               ) : (
-                <div>No combat encounter is currently available.</div>
+                <>
+                  <div>No combat encounter is currently available.</div>
+                  {workspaceState.activeScenarioId ? (
+                    <Link
+                      href={buildWorkspaceHref({
+                        scenarioId: workspaceState.activeScenarioId,
+                        tab: "scenario",
+                      })}
+                    >
+                      Create combat encounter on Scenario tab
+                    </Link>
+                  ) : null}
+                </>
               )}
             </section>
           ) : workspaceState.activeScenarioId ? (

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
@@ -228,14 +228,13 @@ export default function CampaignWorkspaceShell({
     encounters,
     scenarioId: workspaceState.activeScenarioId,
   });
-  const activeScenarioCombatEncounters = activeScenarioEncounters.filter(
-    (encounter) => encounter.kind === "combat" && encounter.status !== "archived",
-  );
-  const sortedActiveScenarioCombatEncounters = [...activeScenarioCombatEncounters].sort(
-    (left, right) =>
-      getEncounterStatusRank(left.status) - getEncounterStatusRank(right.status) ||
-      left.title.localeCompare(right.title),
-  );
+  const sortedActiveScenarioEncounters = [...activeScenarioEncounters]
+    .filter((encounter) => encounter.status !== "archived")
+    .sort(
+      (left, right) =>
+        getEncounterStatusRank(left.status) - getEncounterStatusRank(right.status) ||
+        left.title.localeCompare(right.title),
+    );
   const activeScenario = scenarios.find(
     (scenario) => scenario.id === workspaceState.activeScenarioId
   );
@@ -329,9 +328,13 @@ export default function CampaignWorkspaceShell({
         searchParams.get("encounterId") ?? workspaceState.activeEncounterId ?? null,
       participantId:
         requestedTabFromUrl === "player-encounter" ||
+        requestedTabFromUrl === "encounter" ||
+        requestedTabFromUrl === "skill-rolls" ||
         requestedTabFromUrl === "character" ||
         requestedTabFromUrl === "combat" ||
         workspaceState.activeTab === "player-encounter" ||
+        workspaceState.activeTab === "encounter" ||
+        workspaceState.activeTab === "skill-rolls" ||
         workspaceState.activeTab === "character" ||
         workspaceState.activeTab === "combat"
           ? searchParams.get("participantId")
@@ -509,45 +512,54 @@ export default function CampaignWorkspaceShell({
         </section>
       ) : null}
 
-      {accessMode !== "none" && workspaceState.activeTab === "gm-encounter" ? (
+      {accessMode !== "none" && workspaceState.activeTab === "encounter" ? (
         <section style={{ display: "grid", gap: "1rem" }}>
-          {workspaceState.activeScenarioId && workspaceState.activeEncounterId ? (
+          {workspaceState.activeScenarioId && workspaceState.activeEncounterId && canAccessGmEncounter ? (
             <EncounterDetail
               campaignId={campaignId}
               embedded
               id={workspaceState.activeEncounterId}
+              surface="encounter"
               scenarioId={workspaceState.activeScenarioId}
             />
-          ) : (
-            <section style={panelStyle}>
-              Select a scenario and encounter from the workspace picker to open the GM encounter
-              tab.
-            </section>
-          )}
-        </section>
-      ) : null}
-
-      {accessMode !== "none" && workspaceState.activeTab === "player-encounter" ? (
-        <section style={{ display: "grid", gap: "1rem" }}>
-          {workspaceState.activeScenarioId && workspaceState.activeEncounterId && activeEncounter?.kind === "roleplay" ? (
+          ) : workspaceState.activeScenarioId && workspaceState.activeEncounterId ? (
             <PlayerRoleplayingEncounterScreen
               campaignId={campaignId}
               embedded
               encounterId={workspaceState.activeEncounterId}
               scenarioId={workspaceState.activeScenarioId}
-            />
-          ) : workspaceState.activeScenarioId && workspaceState.activeEncounterId ? (
-            <ScenarioPlayerCombatPageContent
-              campaignId={campaignId}
-              encounterId={workspaceState.activeEncounterId}
-              embedded
-              encounterTitle={activeEncounter?.title}
-              participantId={searchParams.get("participantId") ?? undefined}
-              scenarioId={workspaceState.activeScenarioId}
+              surface="encounter"
             />
           ) : (
             <section style={panelStyle}>
-              <strong>No player encounter is currently available.</strong>
+              <strong>No encounter is currently available.</strong>
+              <div>{playerEncounterEmptyDetail}</div>
+            </section>
+          )}
+        </section>
+      ) : null}
+
+      {accessMode !== "none" && workspaceState.activeTab === "skill-rolls" ? (
+        <section style={{ display: "grid", gap: "1rem" }}>
+          {workspaceState.activeScenarioId && workspaceState.activeEncounterId && canAccessGmEncounter ? (
+            <EncounterDetail
+              campaignId={campaignId}
+              embedded
+              id={workspaceState.activeEncounterId}
+              surface="skill-rolls"
+              scenarioId={workspaceState.activeScenarioId}
+            />
+          ) : workspaceState.activeScenarioId && workspaceState.activeEncounterId ? (
+            <PlayerRoleplayingEncounterScreen
+              campaignId={campaignId}
+              embedded
+              encounterId={workspaceState.activeEncounterId}
+              scenarioId={workspaceState.activeScenarioId}
+              surface="skill-rolls"
+            />
+          ) : (
+            <section style={panelStyle}>
+              <strong>No skill rolls are currently available.</strong>
               <div>{playerEncounterEmptyDetail}</div>
               {workspaceState.activeScenarioId ? (
                 <Link
@@ -566,7 +578,7 @@ export default function CampaignWorkspaceShell({
                       key={scenario.id}
                       href={buildWorkspaceHref({
                         scenarioId: scenario.id,
-                        tab: "player-encounter",
+                        tab: "skill-rolls",
                       })}
                     >
                       {scenario.name}
@@ -606,13 +618,13 @@ export default function CampaignWorkspaceShell({
 
       {accessMode !== "none" && workspaceState.activeTab === "combat" ? (
         <section style={{ display: "grid", gap: "1rem" }}>
-          {canAccessGmEncounter && activeEncounter?.kind === "combat" ? (
+          {canAccessGmEncounter && activeEncounter ? (
             <>
-              {sortedActiveScenarioCombatEncounters.length > 1 ? (
+              {sortedActiveScenarioEncounters.length > 1 ? (
                 <section style={panelStyle}>
-                  <strong>Combat encounters</strong>
+                  <strong>Encounters</strong>
                   <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem" }}>
-                    {sortedActiveScenarioCombatEncounters.map((encounter) => (
+                    {sortedActiveScenarioEncounters.map((encounter) => (
                       <Link
                         key={encounter.id}
                         href={buildWorkspaceHref({
@@ -640,19 +652,10 @@ export default function CampaignWorkspaceShell({
             </>
           ) : canAccessGmEncounter ? (
             <section style={panelStyle}>
-              {activeEncounter?.kind === "roleplay" ? (
-                <>
-                  <strong>The selected encounter is roleplaying.</strong>
-                  <div>
-                    Select or create a combat encounter to use the Combat Round Manager.
-                  </div>
-                </>
-              ) : (
-                <strong>Select an encounter to open the Combat Round Manager.</strong>
-              )}
-              {sortedActiveScenarioCombatEncounters.length > 0 ? (
+              <strong>Select an encounter to open the Combat Round Manager.</strong>
+              {sortedActiveScenarioEncounters.length > 0 ? (
                 <div style={{ display: "grid", gap: "0.5rem" }}>
-                  {sortedActiveScenarioCombatEncounters.map((encounter) => (
+                  {sortedActiveScenarioEncounters.map((encounter) => (
                     <Link
                       key={encounter.id}
                       href={buildWorkspaceHref({
@@ -667,7 +670,7 @@ export default function CampaignWorkspaceShell({
                 </div>
               ) : (
                 <>
-                  <div>No combat encounter is currently available.</div>
+                  <div>No encounter is currently available for combat tools.</div>
                   {workspaceState.activeScenarioId ? (
                     <Link
                       href={buildWorkspaceHref({
@@ -675,7 +678,7 @@ export default function CampaignWorkspaceShell({
                         tab: "scenario",
                       })}
                     >
-                      Create combat encounter on Scenario tab
+                      Create or open an encounter on Scenario tab
                     </Link>
                   ) : null}
                 </>

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
@@ -35,6 +35,7 @@ import ScenarioDetailPageContent from "./scenarios/[scenarioId]/ScenarioDetailPa
 import ScenarioPlayerPageContent from "./scenarios/[scenarioId]/player/ScenarioPlayerPageContent";
 import ScenarioPlayerCombatPageContent from "./scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent";
 import { PlayerRoleplayingEncounterScreen } from "@/features/roleplay/RoleplayEncounterScreens";
+import CombatRoundManagerPanel from "@/features/combat-round-manager/CombatRoundManagerPanel";
 
 interface CampaignWorkspaceShellProps {
   campaignId: string;
@@ -208,6 +209,9 @@ export default function CampaignWorkspaceShell({
     encounters,
     scenarioId: workspaceState.activeScenarioId,
   });
+  const activeScenarioCombatEncounters = activeScenarioEncounters.filter(
+    (encounter) => encounter.kind === "combat",
+  );
   const activeScenario = scenarios.find(
     (scenario) => scenario.id === workspaceState.activeScenarioId
   );
@@ -578,7 +582,40 @@ export default function CampaignWorkspaceShell({
 
       {accessMode !== "none" && workspaceState.activeTab === "combat" ? (
         <section style={{ display: "grid", gap: "1rem" }}>
-          {workspaceState.activeScenarioId ? (
+          {canAccessGmEncounter && activeEncounter?.kind === "combat" ? (
+            <CombatRoundManagerPanel
+              encounter={activeEncounter}
+              onEncounterUpdated={(nextEncounter) => {
+                setEncounters((current) =>
+                  current.map((encounter) =>
+                    encounter.id === nextEncounter.id ? nextEncounter : encounter,
+                  ),
+                );
+              }}
+            />
+          ) : canAccessGmEncounter ? (
+            <section style={panelStyle}>
+              <strong>Select an encounter to open the Combat Round Manager.</strong>
+              {activeScenarioCombatEncounters.length > 0 ? (
+                <div style={{ display: "grid", gap: "0.5rem" }}>
+                  {activeScenarioCombatEncounters.map((encounter) => (
+                    <Link
+                      key={encounter.id}
+                      href={buildWorkspaceHref({
+                        encounterId: encounter.id,
+                        scenarioId: encounter.scenarioId,
+                        tab: "combat",
+                      })}
+                    >
+                      {encounter.title}
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <div>No combat encounter is currently available.</div>
+              )}
+            </section>
+          ) : workspaceState.activeScenarioId ? (
             <ScenarioPlayerCombatPageContent
               campaignId={campaignId}
               encounterId={workspaceState.activeEncounterId}

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
@@ -16,7 +16,10 @@ import {
   useRememberedSelection,
 } from "@/lib/browser/rememberedSelection";
 import { useSessionUser } from "@/lib/auth/SessionUserContext";
-import { canManageCampaignWorkspace, loadCampaignWorkspaceAccessForUser } from "@/lib/campaigns/access";
+import {
+  canManageCampaignWorkspace,
+  loadCampaignWorkspaceAccessForUser,
+} from "@/lib/campaigns/access";
 import {
   getCampaignWorkspaceVisibleEncounters,
   getScenarioVisibleEncounters,
@@ -26,11 +29,13 @@ import {
   buildCampaignWorkspaceHref,
   buildCampaignWorkspaceTabs,
   resolveCampaignWorkspaceState,
-  type CampaignWorkspaceTabId
+  type CampaignWorkspaceTabId,
 } from "@/lib/campaigns/workspace";
+import { buildGmCharacterWorkspaceCandidates } from "@/lib/campaigns/characterWorkspace";
 import EncounterDetail from "@/features/encounters/EncounterDetail";
 import CampaignDetailPageContent from "./CampaignDetailPageContent";
 import CharacterWorkspacePanel from "./CharacterWorkspacePanel";
+import WorkspaceParticipantInspectionHeader from "./WorkspaceParticipantInspectionHeader";
 import ScenarioDetailPageContent from "./scenarios/[scenarioId]/ScenarioDetailPageContent";
 import ScenarioPlayerPageContent from "./scenarios/[scenarioId]/player/ScenarioPlayerPageContent";
 import ScenarioPlayerCombatPageContent from "./scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent";
@@ -46,7 +51,7 @@ const panelStyle = {
   borderRadius: 12,
   display: "grid",
   gap: "0.75rem",
-  padding: "1rem"
+  padding: "1rem",
 } as const;
 
 function getEncounterStatusRank(status: EncounterSession["status"]): number {
@@ -68,9 +73,7 @@ function getEncounterStatusRank(status: EncounterSession["status"]): number {
   }
 }
 
-export default function CampaignWorkspaceShell({
-  campaignId
-}: CampaignWorkspaceShellProps) {
+export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspaceShellProps) {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -83,22 +86,14 @@ export default function CampaignWorkspaceShell({
   const [scenarioParticipants, setScenarioParticipants] = useState<ScenarioParticipant[]>([]);
   const [scenarios, setScenarios] = useState<Scenario[]>([]);
   const canAccessGmEncounter = canManageCampaignWorkspace(currentUser);
-  const rememberedCampaignSelection = useRememberedSelection(
-    REMEMBERED_SELECTION_KEYS.campaignId,
-  );
+  const rememberedCampaignSelection = useRememberedSelection(REMEMBERED_SELECTION_KEYS.campaignId);
   const workspaceSelectionKeys = useMemo(
     () => getCampaignWorkspaceSelectionKeys(campaignId),
     [campaignId],
   );
-  const rememberedScenarioSelection = useRememberedSelection(
-    workspaceSelectionKeys.scenarioId,
-  );
-  const rememberedEncounterSelection = useRememberedSelection(
-    workspaceSelectionKeys.encounterId,
-  );
-  const rememberedWorkspaceTab = useRememberedSelection(
-    workspaceSelectionKeys.workspaceTab,
-  );
+  const rememberedScenarioSelection = useRememberedSelection(workspaceSelectionKeys.scenarioId);
+  const rememberedEncounterSelection = useRememberedSelection(workspaceSelectionKeys.encounterId);
+  const rememberedWorkspaceTab = useRememberedSelection(workspaceSelectionKeys.workspaceTab);
 
   const refreshWorkspaceContext = useCallback(async () => {
     const workspaceAccess = await loadCampaignWorkspaceAccessForUser({
@@ -156,8 +151,7 @@ export default function CampaignWorkspaceShell({
     }
 
     setLoading(true);
-    refreshWorkspaceContextWithErrorHandling()
-      .finally(() => setLoading(false));
+    refreshWorkspaceContextWithErrorHandling().finally(() => setLoading(false));
   }, [refreshWorkspaceContextWithErrorHandling, sessionLoading]);
 
   useEffect(() => {
@@ -204,7 +198,7 @@ export default function CampaignWorkspaceShell({
         requestedScenarioId: searchParams.get("scenarioId"),
         requestedTab: searchParams.get("tab"),
         scenarioParticipants,
-        scenarios
+        scenarios,
       }),
     [
       campaignId,
@@ -217,12 +211,12 @@ export default function CampaignWorkspaceShell({
       scenarioParticipants,
       scenarios,
       searchParams,
-    ]
+    ],
   );
 
   const tabs = useMemo(
     () => buildCampaignWorkspaceTabs({ canAccessGmEncounter }),
-    [canAccessGmEncounter]
+    [canAccessGmEncounter],
   );
   const activeScenarioEncounters = getScenarioVisibleEncounters({
     encounters,
@@ -236,18 +230,31 @@ export default function CampaignWorkspaceShell({
         left.title.localeCompare(right.title),
     );
   const activeScenario = scenarios.find(
-    (scenario) => scenario.id === workspaceState.activeScenarioId
+    (scenario) => scenario.id === workspaceState.activeScenarioId,
   );
   const activeEncounter = activeScenarioEncounters.find(
-    (encounter) => encounter.id === workspaceState.activeEncounterId
+    (encounter) => encounter.id === workspaceState.activeEncounterId,
   );
+  const gmInspectableCandidates = useMemo(
+    () =>
+      buildGmCharacterWorkspaceCandidates({
+        activeEncounter,
+        scenarioId: workspaceState.activeScenarioId,
+        scenarioParticipants,
+      }),
+    [activeEncounter, scenarioParticipants, workspaceState.activeScenarioId],
+  );
+  const selectedGmInspectableCandidate =
+    gmInspectableCandidates.find(
+      (candidate) => candidate.id === searchParams.get("participantId"),
+    ) ?? gmInspectableCandidates[0];
   const currentUserActiveScenarioParticipant = scenarioParticipants.find(
     (participant) =>
       Boolean(currentUser?.id) &&
       participant.scenarioId === workspaceState.activeScenarioId &&
       participant.isActive &&
       participant.role === "player_character" &&
-      participant.controlledByUserId === currentUser?.id
+      participant.controlledByUserId === currentUser?.id,
   );
   const playerEncounterEmptyDetail =
     workspaceState.activeScenarioId &&
@@ -297,6 +304,18 @@ export default function CampaignWorkspaceShell({
     });
   }
 
+  function selectInspectableParticipant(input: {
+    participantId: string;
+    tab: Extract<CampaignWorkspaceTabId, "character" | "combat" | "skill-rolls">;
+  }) {
+    router.replace(
+      buildWorkspaceHref({
+        participantId: input.participantId,
+        tab: input.tab,
+      }),
+    );
+  }
+
   useEffect(() => {
     if (accessMode === "none") {
       return;
@@ -314,18 +333,25 @@ export default function CampaignWorkspaceShell({
       return;
     }
 
-    if (!searchParams.get("scenarioId") && rememberedScenarioSelection.value && !workspaceState.activeScenarioId) {
+    if (
+      !searchParams.get("scenarioId") &&
+      rememberedScenarioSelection.value &&
+      !workspaceState.activeScenarioId
+    ) {
       rememberedScenarioSelection.setValue(undefined);
     }
 
-    if (!searchParams.get("encounterId") && rememberedEncounterSelection.value && !workspaceState.activeEncounterId) {
+    if (
+      !searchParams.get("encounterId") &&
+      rememberedEncounterSelection.value &&
+      !workspaceState.activeEncounterId
+    ) {
       rememberedEncounterSelection.setValue(undefined);
     }
 
     const requestedTabFromUrl = tabs.find((tab) => tab.id === searchParams.get("tab"))?.id;
     const nextHref = buildWorkspaceHref({
-      encounterId:
-        searchParams.get("encounterId") ?? workspaceState.activeEncounterId ?? null,
+      encounterId: searchParams.get("encounterId") ?? workspaceState.activeEncounterId ?? null,
       participantId:
         requestedTabFromUrl === "player-encounter" ||
         requestedTabFromUrl === "encounter" ||
@@ -339,11 +365,12 @@ export default function CampaignWorkspaceShell({
         workspaceState.activeTab === "combat"
           ? searchParams.get("participantId")
           : null,
-      scenarioId:
-        searchParams.get("scenarioId") ?? workspaceState.activeScenarioId ?? null,
+      scenarioId: searchParams.get("scenarioId") ?? workspaceState.activeScenarioId ?? null,
       tab: requestedTabFromUrl ?? workspaceState.activeTab,
     });
-    const currentHref = searchParams.toString() ? `${pathname}?${searchParams.toString()}` : pathname;
+    const currentHref = searchParams.toString()
+      ? `${pathname}?${searchParams.toString()}`
+      : pathname;
 
     if (nextHref !== currentHref) {
       router.replace(nextHref);
@@ -383,7 +410,7 @@ export default function CampaignWorkspaceShell({
           display: "flex",
           flexWrap: "wrap",
           gap: "1rem",
-          paddingBottom: "0.5rem"
+          paddingBottom: "0.5rem",
         }}
       >
         <Link
@@ -393,7 +420,7 @@ export default function CampaignWorkspaceShell({
             color: "#2f5d62",
             fontWeight: 700,
             paddingBottom: "0.35rem",
-            textDecoration: "none"
+            textDecoration: "none",
           }}
         >
           Campaigns
@@ -413,7 +440,7 @@ export default function CampaignWorkspaceShell({
                 color: "#2f5d62",
                 fontWeight: 700,
                 paddingBottom: "0.35rem",
-                textDecoration: "none"
+                textDecoration: "none",
               }}
             >
               {tab.label}
@@ -514,7 +541,9 @@ export default function CampaignWorkspaceShell({
 
       {accessMode !== "none" && workspaceState.activeTab === "encounter" ? (
         <section style={{ display: "grid", gap: "1rem" }}>
-          {workspaceState.activeScenarioId && workspaceState.activeEncounterId && canAccessGmEncounter ? (
+          {workspaceState.activeScenarioId &&
+          workspaceState.activeEncounterId &&
+          canAccessGmEncounter ? (
             <EncounterDetail
               campaignId={campaignId}
               embedded
@@ -541,14 +570,44 @@ export default function CampaignWorkspaceShell({
 
       {accessMode !== "none" && workspaceState.activeTab === "skill-rolls" ? (
         <section style={{ display: "grid", gap: "1rem" }}>
-          {workspaceState.activeScenarioId && workspaceState.activeEncounterId && canAccessGmEncounter ? (
-            <EncounterDetail
-              campaignId={campaignId}
-              embedded
-              id={workspaceState.activeEncounterId}
-              surface="skill-rolls"
-              scenarioId={workspaceState.activeScenarioId}
-            />
+          {workspaceState.activeScenarioId &&
+          workspaceState.activeEncounterId &&
+          canAccessGmEncounter ? (
+            <>
+              <WorkspaceParticipantInspectionHeader
+                candidates={gmInspectableCandidates}
+                isGameMaster={canAccessGmEncounter}
+                onSelectParticipantId={(participantId) =>
+                  selectInspectableParticipant({ participantId, tab: "skill-rolls" })
+                }
+                screenName="Skill rolls"
+                selectedCandidate={selectedGmInspectableCandidate}
+              />
+              <EncounterDetail
+                campaignId={campaignId}
+                embedded
+                id={workspaceState.activeEncounterId}
+                surface="skill-rolls"
+                scenarioId={workspaceState.activeScenarioId}
+              />
+              <section style={panelStyle}>
+                <h2 style={{ margin: 0 }}>Player view</h2>
+                {selectedGmInspectableCandidate ? (
+                  <PlayerRoleplayingEncounterScreen
+                    campaignId={campaignId}
+                    embedded
+                    encounterId={workspaceState.activeEncounterId}
+                    inspectionParticipantId={selectedGmInspectableCandidate.id}
+                    readOnlyInspection
+                    scenarioId={workspaceState.activeScenarioId}
+                    showWorkspaceHeader={false}
+                    surface="skill-rolls"
+                  />
+                ) : (
+                  <div>No participant is available for player-view inspection.</div>
+                )}
+              </section>
+            </>
           ) : workspaceState.activeScenarioId && workspaceState.activeEncounterId ? (
             <PlayerRoleplayingEncounterScreen
               campaignId={campaignId}
@@ -598,12 +657,7 @@ export default function CampaignWorkspaceShell({
           currentUserId={currentUser?.id}
           isGameMaster={canAccessGmEncounter}
           onSelectParticipantId={(participantId) => {
-            router.replace(
-              buildWorkspaceHref({
-                participantId,
-                tab: "character",
-              }),
-            );
+            selectInspectableParticipant({ participantId, tab: "character" });
           }}
           onScenarioParticipantUpdated={(participant) => {
             setScenarioParticipants((current) =>
@@ -620,6 +674,15 @@ export default function CampaignWorkspaceShell({
         <section style={{ display: "grid", gap: "1rem" }}>
           {canAccessGmEncounter && activeEncounter ? (
             <>
+              <WorkspaceParticipantInspectionHeader
+                candidates={gmInspectableCandidates}
+                isGameMaster={canAccessGmEncounter}
+                onSelectParticipantId={(participantId) =>
+                  selectInspectableParticipant({ participantId, tab: "combat" })
+                }
+                screenName="Combat"
+                selectedCandidate={selectedGmInspectableCandidate}
+              />
               {sortedActiveScenarioEncounters.length > 1 ? (
                 <section style={panelStyle}>
                   <strong>Encounters</strong>
@@ -649,6 +712,25 @@ export default function CampaignWorkspaceShell({
                   );
                 }}
               />
+              <section style={panelStyle}>
+                <h2 style={{ margin: 0 }}>Player combat inspection</h2>
+                {workspaceState.activeScenarioId && selectedGmInspectableCandidate ? (
+                  <ScenarioPlayerCombatPageContent
+                    campaignId={campaignId}
+                    encounterId={workspaceState.activeEncounterId}
+                    embedded
+                    encounterTitle={activeEncounter.title}
+                    participantId={selectedGmInspectableCandidate.id}
+                    readOnlyInspection
+                    scenarioId={workspaceState.activeScenarioId}
+                    showParticipantSelector={false}
+                    showWorkspaceHeader={false}
+                    workspaceTab="combat"
+                  />
+                ) : (
+                  <div>No participant is available for player combat inspection.</div>
+                )}
+              </section>
             </>
           ) : canAccessGmEncounter ? (
             <section style={panelStyle}>
@@ -692,6 +774,7 @@ export default function CampaignWorkspaceShell({
               encounterTitle={activeEncounter?.title}
               participantId={searchParams.get("participantId") ?? undefined}
               scenarioId={workspaceState.activeScenarioId}
+              showParticipantSelector={false}
               workspaceTab="combat"
             />
           ) : (

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
@@ -306,7 +306,10 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
 
   function selectInspectableParticipant(input: {
     participantId: string;
-    tab: Extract<CampaignWorkspaceTabId, "character" | "combat" | "skill-rolls">;
+    tab: Extract<
+      CampaignWorkspaceTabId,
+      "character" | "player-combat" | "player-skill-rolls"
+    >;
   }) {
     router.replace(
       buildWorkspaceHref({
@@ -356,13 +359,17 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
         requestedTabFromUrl === "player-encounter" ||
         requestedTabFromUrl === "encounter" ||
         requestedTabFromUrl === "skill-rolls" ||
+        requestedTabFromUrl === "player-skill-rolls" ||
         requestedTabFromUrl === "character" ||
         requestedTabFromUrl === "combat" ||
+        requestedTabFromUrl === "player-combat" ||
         workspaceState.activeTab === "player-encounter" ||
         workspaceState.activeTab === "encounter" ||
         workspaceState.activeTab === "skill-rolls" ||
+        workspaceState.activeTab === "player-skill-rolls" ||
         workspaceState.activeTab === "character" ||
-        workspaceState.activeTab === "combat"
+        workspaceState.activeTab === "combat" ||
+        workspaceState.activeTab === "player-combat"
           ? searchParams.get("participantId")
           : null,
       scenarioId: searchParams.get("scenarioId") ?? workspaceState.activeScenarioId ?? null,
@@ -573,41 +580,13 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
           {workspaceState.activeScenarioId &&
           workspaceState.activeEncounterId &&
           canAccessGmEncounter ? (
-            <>
-              <WorkspaceParticipantInspectionHeader
-                candidates={gmInspectableCandidates}
-                isGameMaster={canAccessGmEncounter}
-                onSelectParticipantId={(participantId) =>
-                  selectInspectableParticipant({ participantId, tab: "skill-rolls" })
-                }
-                screenName="Skill rolls"
-                selectedCandidate={selectedGmInspectableCandidate}
-              />
-              <EncounterDetail
-                campaignId={campaignId}
-                embedded
-                id={workspaceState.activeEncounterId}
-                surface="skill-rolls"
-                scenarioId={workspaceState.activeScenarioId}
-              />
-              <section style={panelStyle}>
-                <h2 style={{ margin: 0 }}>Player view</h2>
-                {selectedGmInspectableCandidate ? (
-                  <PlayerRoleplayingEncounterScreen
-                    campaignId={campaignId}
-                    embedded
-                    encounterId={workspaceState.activeEncounterId}
-                    inspectionParticipantId={selectedGmInspectableCandidate.id}
-                    readOnlyInspection
-                    scenarioId={workspaceState.activeScenarioId}
-                    showWorkspaceHeader={false}
-                    surface="skill-rolls"
-                  />
-                ) : (
-                  <div>No participant is available for player-view inspection.</div>
-                )}
-              </section>
-            </>
+            <EncounterDetail
+              campaignId={campaignId}
+              embedded
+              id={workspaceState.activeEncounterId}
+              surface="skill-rolls"
+              scenarioId={workspaceState.activeScenarioId}
+            />
           ) : workspaceState.activeScenarioId && workspaceState.activeEncounterId ? (
             <PlayerRoleplayingEncounterScreen
               campaignId={campaignId}
@@ -650,6 +629,81 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
         </section>
       ) : null}
 
+      {accessMode !== "none" && workspaceState.activeTab === "player-skill-rolls" ? (
+        <section style={{ display: "grid", gap: "1rem" }}>
+          {workspaceState.activeScenarioId &&
+          workspaceState.activeEncounterId &&
+          canAccessGmEncounter ? (
+            <>
+              <WorkspaceParticipantInspectionHeader
+                candidates={gmInspectableCandidates}
+                isGameMaster={canAccessGmEncounter}
+                onSelectParticipantId={(participantId) =>
+                  selectInspectableParticipant({ participantId, tab: "player-skill-rolls" })
+                }
+                screenName="Player skill rolls"
+                selectedCandidate={selectedGmInspectableCandidate}
+              />
+              {selectedGmInspectableCandidate ? (
+                <PlayerRoleplayingEncounterScreen
+                  campaignId={campaignId}
+                  embedded
+                  encounterId={workspaceState.activeEncounterId}
+                  inspectionParticipantId={selectedGmInspectableCandidate.id}
+                  readOnlyInspection
+                  scenarioId={workspaceState.activeScenarioId}
+                  showWorkspaceHeader={false}
+                  surface="skill-rolls"
+                />
+              ) : (
+                <section style={panelStyle}>
+                  <div>No participant is available for player skill roll inspection.</div>
+                </section>
+              )}
+            </>
+          ) : workspaceState.activeScenarioId && workspaceState.activeEncounterId ? (
+            <PlayerRoleplayingEncounterScreen
+              campaignId={campaignId}
+              embedded
+              encounterId={workspaceState.activeEncounterId}
+              scenarioId={workspaceState.activeScenarioId}
+              surface="skill-rolls"
+              workspaceScreenName="Player skill rolls"
+            />
+          ) : (
+            <section style={panelStyle}>
+              <strong>No player skill rolls are currently available.</strong>
+              <div>{playerEncounterEmptyDetail}</div>
+              {workspaceState.activeScenarioId ? (
+                <Link
+                  href={buildWorkspaceHref({
+                    scenarioId: workspaceState.activeScenarioId,
+                    tab: "scenario",
+                  })}
+                >
+                  Back to scenario
+                </Link>
+              ) : scenarios.length > 0 ? (
+                <div style={{ display: "grid", gap: "0.5rem" }}>
+                  <div>Choose a scenario to check for player skill rolls.</div>
+                  {scenarios.map((scenario) => (
+                    <Link
+                      key={scenario.id}
+                      href={buildWorkspaceHref({
+                        scenarioId: scenario.id,
+                        tab: "player-skill-rolls",
+                      })}
+                    >
+                      {scenario.name}
+                    </Link>
+                  ))}
+                </div>
+              ) : null}
+            </section>
+          )}
+        </section>
+      ) : null}
+
       {accessMode !== "none" && workspaceState.activeTab === "character" ? (
         <CharacterWorkspacePanel
           activeEncounter={activeEncounter}
@@ -674,15 +728,6 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
         <section style={{ display: "grid", gap: "1rem" }}>
           {canAccessGmEncounter && activeEncounter ? (
             <>
-              <WorkspaceParticipantInspectionHeader
-                candidates={gmInspectableCandidates}
-                isGameMaster={canAccessGmEncounter}
-                onSelectParticipantId={(participantId) =>
-                  selectInspectableParticipant({ participantId, tab: "combat" })
-                }
-                screenName="Combat"
-                selectedCandidate={selectedGmInspectableCandidate}
-              />
               {sortedActiveScenarioEncounters.length > 1 ? (
                 <section style={panelStyle}>
                   <strong>Encounters</strong>
@@ -712,25 +757,6 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
                   );
                 }}
               />
-              <section style={panelStyle}>
-                <h2 style={{ margin: 0 }}>Player combat inspection</h2>
-                {workspaceState.activeScenarioId && selectedGmInspectableCandidate ? (
-                  <ScenarioPlayerCombatPageContent
-                    campaignId={campaignId}
-                    encounterId={workspaceState.activeEncounterId}
-                    embedded
-                    encounterTitle={activeEncounter.title}
-                    participantId={selectedGmInspectableCandidate.id}
-                    readOnlyInspection
-                    scenarioId={workspaceState.activeScenarioId}
-                    showParticipantSelector={false}
-                    showWorkspaceHeader={false}
-                    workspaceTab="combat"
-                  />
-                ) : (
-                  <div>No participant is available for player combat inspection.</div>
-                )}
-              </section>
             </>
           ) : canAccessGmEncounter ? (
             <section style={panelStyle}>
@@ -796,6 +822,96 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
                 </div>
               ) : (
                 <div>No combat encounter is currently available.</div>
+              )}
+            </section>
+          )}
+        </section>
+      ) : null}
+
+      {accessMode !== "none" && workspaceState.activeTab === "player-combat" ? (
+        <section style={{ display: "grid", gap: "1rem" }}>
+          {canAccessGmEncounter && workspaceState.activeScenarioId && activeEncounter ? (
+            <>
+              <WorkspaceParticipantInspectionHeader
+                candidates={gmInspectableCandidates}
+                isGameMaster={canAccessGmEncounter}
+                onSelectParticipantId={(participantId) =>
+                  selectInspectableParticipant({ participantId, tab: "player-combat" })
+                }
+                screenName="Player combat"
+                selectedCandidate={selectedGmInspectableCandidate}
+              />
+              {selectedGmInspectableCandidate ? (
+                <ScenarioPlayerCombatPageContent
+                  campaignId={campaignId}
+                  encounterId={workspaceState.activeEncounterId}
+                  embedded
+                  encounterTitle={activeEncounter.title}
+                  participantId={selectedGmInspectableCandidate.id}
+                  readOnlyInspection
+                  scenarioId={workspaceState.activeScenarioId}
+                  showParticipantSelector={false}
+                  showWorkspaceHeader={false}
+                  workspaceTab="player-combat"
+                />
+              ) : (
+                <section style={panelStyle}>
+                  <div>No participant is available for player combat inspection.</div>
+                </section>
+              )}
+            </>
+          ) : canAccessGmEncounter ? (
+            <section style={panelStyle}>
+              <strong>Select an encounter to inspect player combat.</strong>
+              {sortedActiveScenarioEncounters.length > 0 ? (
+                <div style={{ display: "grid", gap: "0.5rem" }}>
+                  {sortedActiveScenarioEncounters.map((encounter) => (
+                    <Link
+                      key={encounter.id}
+                      href={buildWorkspaceHref({
+                        encounterId: encounter.id,
+                        scenarioId: encounter.scenarioId,
+                        tab: "player-combat",
+                      })}
+                    >
+                      {encounter.title}
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <div>No player combat view is currently available.</div>
+              )}
+            </section>
+          ) : workspaceState.activeScenarioId ? (
+            <ScenarioPlayerCombatPageContent
+              campaignId={campaignId}
+              encounterId={workspaceState.activeEncounterId}
+              embedded
+              encounterTitle={activeEncounter?.title}
+              participantId={searchParams.get("participantId") ?? undefined}
+              scenarioId={workspaceState.activeScenarioId}
+              showParticipantSelector={false}
+              workspaceTab="player-combat"
+            />
+          ) : (
+            <section style={panelStyle}>
+              <strong>Select a scenario to open player combat.</strong>
+              {scenarios.length > 0 ? (
+                <div style={{ display: "grid", gap: "0.5rem" }}>
+                  {scenarios.map((scenario) => (
+                    <Link
+                      key={scenario.id}
+                      href={buildWorkspaceHref({
+                        scenarioId: scenario.id,
+                        tab: "player-combat",
+                      })}
+                    >
+                      {scenario.name}
+                    </Link>
+                  ))}
+                </div>
+              ) : (
+                <div>No player combat view is currently available.</div>
               )}
             </section>
           )}

--- a/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.test.ts
@@ -24,10 +24,9 @@ describe("CharacterWorkspacePanel", () => {
     const source = readSource();
 
     expect(source).toContain("You are not currently assigned to a character in this scenario.");
-    expect(source).toContain("Character{selectedCandidate?.label ? ` — ${selectedCandidate.label}` : \"\"}");
-    expect(source).toContain("Select character to inspect");
-    expect(source).toContain("Previous");
-    expect(source).toContain("Next");
+    expect(source).toContain("WorkspaceParticipantInspectionHeader");
+    expect(source).toContain('screenName="Character"');
+    expect(source).toContain("onSelectParticipantId={onSelectParticipantId}");
   });
 
   it("enables manual combat effect editing only for the GM character workspace", () => {
@@ -36,6 +35,8 @@ describe("CharacterWorkspacePanel", () => {
     expect(source).toContain("updateScenarioParticipantStateOnServer");
     expect(source).toContain("combatEffects: nextCombatEffects");
     expect(source).toContain("canEditCombatEffects={isGameMaster}");
-    expect(source).toContain("onCombatEffectsChange={isGameMaster ? updateSelectedCombatEffects : undefined}");
+    expect(source).toContain(
+      "onCombatEffectsChange={isGameMaster ? updateSelectedCombatEffects : undefined}",
+    );
   });
 });

--- a/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/campaigns/characterWorkspace";
 import { updateScenarioParticipantStateOnServer } from "@/lib/api/scenarioClient";
 import CharacterLoadoutView from "../../characters/[id]/components/CharacterLoadoutView";
+import WorkspaceParticipantInspectionHeader from "./WorkspaceParticipantInspectionHeader";
 
 interface CharacterWorkspacePanelProps {
   activeEncounter?: EncounterSession;
@@ -64,24 +65,7 @@ export default function CharacterWorkspacePanel({
   const selectedGmCandidate =
     gmCandidates.find((candidate) => candidate.id === selectedParticipantId) ?? gmCandidates[0];
   const selectedCandidate = isGameMaster ? selectedGmCandidate : playerCandidate;
-  const selectedIndex = selectedGmCandidate
-    ? gmCandidates.findIndex((candidate) => candidate.id === selectedGmCandidate.id)
-    : -1;
-  const hasMultipleGmCandidates = gmCandidates.length > 1;
   const [saveError, setSaveError] = useState<string>();
-
-  function selectGmCandidate(offset: number) {
-    if (!selectedGmCandidate || gmCandidates.length === 0) {
-      return;
-    }
-
-    const nextIndex = (selectedIndex + offset + gmCandidates.length) % gmCandidates.length;
-    const nextCandidate = gmCandidates[nextIndex];
-
-    if (nextCandidate) {
-      onSelectParticipantId?.(nextCandidate.id);
-    }
-  }
 
   async function updateSelectedCombatEffects(
     nextCombatEffects: NonNullable<ScenarioParticipant["state"]["combatEffects"]>,
@@ -136,55 +120,13 @@ export default function CharacterWorkspacePanel({
 
   return (
     <section style={{ display: "grid", gap: "1rem" }}>
-      <section style={panelStyle}>
-        <div
-          style={{
-            alignItems: "center",
-            display: "flex",
-            flexWrap: "wrap",
-            gap: "0.75rem",
-            justifyContent: "space-between",
-          }}
-        >
-          <h2 style={{ margin: 0 }}>
-            Character{selectedCandidate?.label ? ` — ${selectedCandidate.label}` : ""}
-          </h2>
-          {isGameMaster ? (
-            <div
-              style={{
-                alignItems: "center",
-                display: "flex",
-                flexWrap: "wrap",
-                gap: "0.5rem",
-              }}
-            >
-              {hasMultipleGmCandidates ? (
-                <button type="button" onClick={() => selectGmCandidate(-1)}>
-                  Previous
-                </button>
-              ) : null}
-              <label style={{ display: "grid", gap: "0.25rem" }}>
-                <span style={{ fontWeight: 700 }}>Select character to inspect</span>
-                <select
-                  onChange={(event) => onSelectParticipantId?.(event.target.value)}
-                  value={selectedGmCandidate?.id ?? ""}
-                >
-                  {gmCandidates.map((candidate) => (
-                    <option key={candidate.id} value={candidate.id}>
-                      {candidate.label}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              {hasMultipleGmCandidates ? (
-                <button type="button" onClick={() => selectGmCandidate(1)}>
-                  Next
-                </button>
-              ) : null}
-            </div>
-          ) : null}
-        </div>
-      </section>
+      <WorkspaceParticipantInspectionHeader
+        candidates={gmCandidates}
+        isGameMaster={isGameMaster}
+        onSelectParticipantId={onSelectParticipantId}
+        screenName="Character"
+        selectedCandidate={selectedCandidate}
+      />
 
       {selectedCandidate ? (
         <>

--- a/apps/web/app/(app)/campaigns/[campaignId]/WorkspaceParticipantInspectionHeader.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/WorkspaceParticipantInspectionHeader.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sourcePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "WorkspaceParticipantInspectionHeader.tsx",
+);
+
+function readSource(): string {
+  return readFileSync(sourcePath, "utf8");
+}
+
+describe("WorkspaceParticipantInspectionHeader", () => {
+  it("renders shared screen title and GM participant shuffler controls", () => {
+    const source = readSource();
+
+    expect(source).toContain("{screenName}");
+    expect(source).toContain("selectedCandidate?.label");
+    expect(source).toContain("Select character to inspect");
+    expect(source).toContain("Previous");
+    expect(source).toContain("Next");
+    expect(source).toContain("onSelectParticipantId");
+    expect(source).toContain("isGameMaster");
+  });
+});

--- a/apps/web/app/(app)/campaigns/[campaignId]/WorkspaceParticipantInspectionHeader.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/WorkspaceParticipantInspectionHeader.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import type { CharacterWorkspaceCandidate } from "@/lib/campaigns/characterWorkspace";
+
+interface WorkspaceParticipantInspectionHeaderProps {
+  candidates?: CharacterWorkspaceCandidate[];
+  isGameMaster: boolean;
+  onSelectParticipantId?: (participantId: string) => void;
+  screenName: string;
+  selectedCandidate?: CharacterWorkspaceCandidate;
+  selectorLabel?: string;
+}
+
+const panelStyle = {
+  border: "1px solid #d9ddd8",
+  borderRadius: 12,
+  display: "grid",
+  gap: "0.75rem",
+  padding: "1rem",
+} as const;
+
+export default function WorkspaceParticipantInspectionHeader({
+  candidates = [],
+  isGameMaster,
+  onSelectParticipantId,
+  screenName,
+  selectedCandidate,
+  selectorLabel = "Select character to inspect",
+}: WorkspaceParticipantInspectionHeaderProps) {
+  const selectedIndex = selectedCandidate
+    ? candidates.findIndex((candidate) => candidate.id === selectedCandidate.id)
+    : -1;
+  const hasMultipleCandidates = candidates.length > 1;
+
+  function selectCandidate(offset: number) {
+    if (!selectedCandidate || candidates.length === 0) {
+      return;
+    }
+
+    const nextIndex = (selectedIndex + offset + candidates.length) % candidates.length;
+    const nextCandidate = candidates[nextIndex];
+
+    if (nextCandidate) {
+      onSelectParticipantId?.(nextCandidate.id);
+    }
+  }
+
+  return (
+    <section style={panelStyle}>
+      <div
+        style={{
+          alignItems: "center",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "0.75rem",
+          justifyContent: "space-between",
+        }}
+      >
+        <h2 style={{ margin: 0 }}>
+          {screenName}
+          {selectedCandidate?.label ? ` — ${selectedCandidate.label}` : ""}
+        </h2>
+        {isGameMaster ? (
+          <div
+            style={{
+              alignItems: "center",
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "0.5rem",
+            }}
+          >
+            {hasMultipleCandidates ? (
+              <button type="button" onClick={() => selectCandidate(-1)}>
+                Previous
+              </button>
+            ) : null}
+            <label style={{ display: "grid", gap: "0.25rem" }}>
+              <span style={{ fontWeight: 700 }}>{selectorLabel}</span>
+              <select
+                onChange={(event) => onSelectParticipantId?.(event.target.value)}
+                value={selectedCandidate?.id ?? ""}
+              >
+                {candidates.length === 0 ? (
+                  <option value="">No participants available</option>
+                ) : null}
+                {candidates.map((candidate) => (
+                  <option key={candidate.id} value={candidate.id}>
+                    {candidate.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            {hasMultipleCandidates ? (
+              <button type="button" onClick={() => selectCandidate(1)}>
+                Next
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/ScenarioDetailPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/ScenarioDetailPageContent.tsx
@@ -880,19 +880,19 @@ export default function ScenarioDetailPageContent({
               href={buildCampaignWorkspaceHref({
                 campaignId,
                 scenarioId,
-                tab: "gm-encounter",
+                tab: "encounter",
               })}
             >
-              Open GM encounter workspace
+              Open encounter workspace
             </Link>
             <Link
               href={buildCampaignWorkspaceHref({
                 campaignId,
                 scenarioId,
-                tab: "player-encounter",
+                tab: "skill-rolls",
               })}
             >
-              Open player encounter workspace
+              Open skill rolls
             </Link>
           </div>
         ) : null}

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/components/ScenarioEncountersSection.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/components/ScenarioEncountersSection.tsx
@@ -130,20 +130,20 @@ export function ScenarioEncountersSection({
                           campaignId,
                           encounterId: encounter.id,
                           scenarioId,
-                          tab: "gm-encounter",
+                          tab: "encounter",
                         })}
                       >
-                        GM
+                        Encounter
                       </Link>
                       <Link
                         href={buildCampaignWorkspaceHref({
                           campaignId,
                           encounterId: encounter.id,
                           scenarioId,
-                          tab: "player-encounter",
+                          tab: "skill-rolls",
                         })}
                       >
-                        Player
+                        Skill rolls
                       </Link>
                     </div>
                   </td>

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/encounters/[encounterId]/page.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/encounters/[encounterId]/page.tsx
@@ -20,7 +20,7 @@ export default async function ScenarioEncounterDetailPage({
       campaignId,
       encounterId,
       scenarioId,
-      tab: "gm-encounter",
+      tab: "encounter",
     }),
   );
 }

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/encounters/page.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/encounters/page.tsx
@@ -18,7 +18,7 @@ export default async function ScenarioEncountersPage({
     buildCampaignWorkspaceHref({
       campaignId,
       scenarioId,
-      tab: "gm-encounter",
+      tab: "encounter",
     }),
   );
 }

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/ScenarioPlayerPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/ScenarioPlayerPageContent.tsx
@@ -168,7 +168,7 @@ export default function ScenarioPlayerPageContent({
                       campaignId,
                       encounterId: encounter.id,
                       scenarioId,
-                      tab: "player-encounter",
+                      tab: "encounter",
                     })}
                   >
                     Open encounter

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.test.ts
@@ -3,7 +3,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-const sourcePath = join(dirname(fileURLToPath(import.meta.url)), "ScenarioPlayerCombatPageContent.tsx");
+const sourcePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "ScenarioPlayerCombatPageContent.tsx",
+);
 
 function readSource(): string {
   return readFileSync(sourcePath, "utf8");
@@ -16,7 +19,12 @@ describe("ScenarioPlayerCombatPageContent", () => {
     expect(source).toContain("export default function ScenarioPlayerCombatPageContent");
     expect(source).toContain("Action selector");
     expect(source).toContain("EquipmentLoadoutModule");
-    expect(source).toContain("workspaceTab = \"player-encounter\"");
+    expect(source).toContain('workspaceTab = "player-encounter"');
+    expect(source).toContain("displayedParticipant?.displayName ? ` — ${displayedParticipant.displayName}`");
+    expect(source).toContain("showParticipantSelector = true");
+    expect(source).toContain("readOnlyInspection = false");
+    expect(source).toContain("GM player-view inspection is read-only.");
+    expect(source).toContain("controlsDisabled || savingCombatContext");
     expect(source).not.toContain("will appear here in the next phase");
     expect(source).not.toContain("will expand into this area");
   });

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.tsx
@@ -65,7 +65,7 @@ interface ScenarioPlayerCombatPageContentProps {
   scenarioId: string;
   showParticipantSelector?: boolean;
   showWorkspaceHeader?: boolean;
-  workspaceTab?: Extract<CampaignWorkspaceTabId, "combat" | "player-encounter">;
+  workspaceTab?: Extract<CampaignWorkspaceTabId, "combat" | "player-combat" | "player-encounter">;
 }
 
 const panelStyle = {

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.tsx
@@ -61,7 +61,10 @@ interface ScenarioPlayerCombatPageContentProps {
   embedded?: boolean;
   encounterTitle?: string;
   participantId?: string;
+  readOnlyInspection?: boolean;
   scenarioId: string;
+  showParticipantSelector?: boolean;
+  showWorkspaceHeader?: boolean;
   workspaceTab?: Extract<CampaignWorkspaceTabId, "combat" | "player-encounter">;
 }
 
@@ -93,10 +96,7 @@ function isEquipmentFeatureState(value: unknown): value is EquipmentFeatureState
   );
 }
 
-function getCombatTableColumnIndex(input: {
-  columns: string[];
-  label: string;
-}): number {
+function getCombatTableColumnIndex(input: { columns: string[]; label: string }): number {
   return input.columns.indexOf(input.label);
 }
 
@@ -120,12 +120,7 @@ function getCombatTableCell(input: {
 
 function getRelevantLoadoutFieldId(
   actionId: PlayerEncounterActionId | "",
-):
-  | "missile"
-  | "primary"
-  | "secondary"
-  | "throwing"
-  | null {
+): "missile" | "primary" | "secondary" | "throwing" | null {
   switch (actionId) {
     case "attack_parry":
     case "parry_attack":
@@ -169,7 +164,10 @@ export default function ScenarioPlayerCombatPageContent({
   embedded = false,
   encounterTitle,
   participantId,
+  readOnlyInspection = false,
   scenarioId,
+  showParticipantSelector = true,
+  showWorkspaceHeader = true,
   workspaceTab = "player-encounter",
 }: ScenarioPlayerCombatPageContentProps) {
   const pathname = usePathname();
@@ -200,8 +198,9 @@ export default function ScenarioPlayerCombatPageContent({
     "hold",
   );
   const [additionalActionNotes, setAdditionalActionNotes] = useState("");
-  const [combatContextDraft, setCombatContextDraft] =
-    useState<ScenarioParticipantCombatContext>(createEmptyPlayerEncounterCombatContext());
+  const [combatContextDraft, setCombatContextDraft] = useState<ScenarioParticipantCombatContext>(
+    createEmptyPlayerEncounterCombatContext(),
+  );
   const [savingCombatContext, setSavingCombatContext] = useState(false);
   const [actionRollResult, setActionRollResult] = useState<{
     interpretedResult: string;
@@ -209,8 +208,9 @@ export default function ScenarioPlayerCombatPageContent({
     value: number;
   } | null>(null);
   const isGameMaster = Boolean(
-    currentUser?.roles.includes("game_master") || currentUser?.roles.includes("admin")
+    currentUser?.roles.includes("game_master") || currentUser?.roles.includes("admin"),
   );
+  const controlsDisabled = readOnlyInspection;
   const rememberedParticipantSelection = useRememberedSelection(
     buildRememberedScopedSelectionKey({
       baseKey: REMEMBERED_SELECTION_KEYS.playerEncounterParticipantId,
@@ -260,7 +260,7 @@ export default function ScenarioPlayerCombatPageContent({
         setError(
           caughtError instanceof Error
             ? caughtError.message
-            : "Unable to load the player combat screen."
+            : "Unable to load the player combat screen.",
         );
       } finally {
         if (!cancelled) {
@@ -300,14 +300,15 @@ export default function ScenarioPlayerCombatPageContent({
     const rememberedParticipantId = rememberedParticipantSelection.value;
     const preferredId =
       accessibleParticipants.find((participant) => participant.id === explicitParticipantId)?.id ??
-      accessibleParticipants.find((participant) => participant.id === rememberedParticipantId)?.id ??
+      accessibleParticipants.find((participant) => participant.id === rememberedParticipantId)
+        ?.id ??
       accessibleParticipants.find((participant) => participant.id === projectionControlledId)?.id ??
       accessibleParticipants[0]?.id;
 
     setSelectedParticipantId((current) =>
       accessibleParticipants.some((participant) => participant.id === current)
         ? current
-        : (preferredId ?? "")
+        : (preferredId ?? ""),
     );
   }, [
     accessibleParticipants,
@@ -335,7 +336,9 @@ export default function ScenarioPlayerCombatPageContent({
       nextParams.delete("participantId");
     }
 
-    const currentHref = searchParams.toString() ? `${pathname}?${searchParams.toString()}` : pathname;
+    const currentHref = searchParams.toString()
+      ? `${pathname}?${searchParams.toString()}`
+      : pathname;
     const nextQuery = nextParams.toString();
     const nextHref = nextQuery ? `${pathname}?${nextQuery}` : pathname;
 
@@ -352,7 +355,7 @@ export default function ScenarioPlayerCombatPageContent({
     () =>
       accessibleParticipants.find((participant) => participant.id === selectedParticipantId) ??
       null,
-    [accessibleParticipants, selectedParticipantId]
+    [accessibleParticipants, selectedParticipantId],
   );
 
   const visibleOpponentOptions: { displayName: string; id: string }[] = useMemo(() => {
@@ -364,7 +367,12 @@ export default function ScenarioPlayerCombatPageContent({
     return (projection?.visibleParticipants ?? [])
       .filter((p) => p.isActive && !p.isControlledByPlayer && p.id !== selectedParticipantId)
       .map((p) => ({ displayName: p.displayName, id: p.id }));
-  }, [isGameMaster, projection?.visibleParticipants, selectableParticipants, selectedParticipantId]);
+  }, [
+    isGameMaster,
+    projection?.visibleParticipants,
+    selectableParticipants,
+    selectedParticipantId,
+  ]);
 
   useEffect(() => {
     setSelectedActionId(
@@ -598,6 +606,10 @@ export default function ScenarioPlayerCombatPageContent({
   }
 
   async function saveCombatContext() {
+    if (readOnlyInspection) {
+      return;
+    }
+
     if (!selectedParticipant) {
       return;
     }
@@ -653,15 +665,16 @@ export default function ScenarioPlayerCombatPageContent({
 
     const referenceRow =
       preferredWeaponLabels
-        .map((weaponLabel) =>
-          combatPanelModel.weaponModeTable.rows.find(
-            (row) =>
-              getCombatTableCell({
-                columns: combatPanelModel.weaponModeTable.columns,
-                label: "Weapon",
-                row,
-              }) === weaponLabel,
-          ) ?? null,
+        .map(
+          (weaponLabel) =>
+            combatPanelModel.weaponModeTable.rows.find(
+              (row) =>
+                getCombatTableCell({
+                  columns: combatPanelModel.weaponModeTable.columns,
+                  label: "Weapon",
+                  row,
+                }) === weaponLabel,
+            ) ?? null,
         )
         .find((row) => row !== null) ??
       combatPanelModel.weaponModeTable.rows[0] ??
@@ -774,12 +787,7 @@ export default function ScenarioPlayerCombatPageContent({
         row: referenceRow,
       }),
     };
-  }, [
-    combatPanelModel,
-    loadoutFieldDisplayMap,
-    selectedActionId,
-    selectedSecondaryActionId,
-  ]);
+  }, [combatPanelModel, loadoutFieldDisplayMap, selectedActionId, selectedSecondaryActionId]);
 
   const currentPhaseNumber = projection?.scenario.phase === 2 ? 2 : 1;
   const phaseCards = useMemo(() => {
@@ -857,10 +865,9 @@ export default function ScenarioPlayerCombatPageContent({
         title: phaseSummary.phaseOne,
       },
       {
-        description:
-          selectedSecondaryActionId
-            ? `${phaseSummary.phaseTwo} · ${getPlayerEncounterMovementLabel(selectedMovementId)}`
-            : "Open",
+        description: selectedSecondaryActionId
+          ? `${phaseSummary.phaseTwo} · ${getPlayerEncounterMovementLabel(selectedMovementId)}`
+          : "Open",
         phaseLabel: "Phase 2",
         stats:
           selectedSecondaryActionId && selectedCombatReference
@@ -958,24 +965,32 @@ export default function ScenarioPlayerCombatPageContent({
             </Link>
           </div>
         ) : null}
-        <h1 style={{ margin: 0 }}>{projection.scenario.name} combat</h1>
+        {showWorkspaceHeader ? (
+          <h1 style={{ margin: 0 }}>
+            Combat
+            {displayedParticipant?.displayName ? ` — ${displayedParticipant.displayName}` : ""}
+          </h1>
+        ) : null}
         {encounterTitle ? <div>Encounter: {encounterTitle}</div> : null}
-        <label style={{ display: "grid", gap: "0.25rem", maxWidth: 360 }}>
-          <span>Character</span>
-          <select
-            onChange={(event) => setSelectedParticipantId(event.target.value)}
-            value={selectedParticipantId}
-          >
-            {accessibleParticipants.length === 0 ? (
-              <option value="">No accessible participant</option>
-            ) : null}
-            {accessibleParticipants.map((participant) => (
-              <option key={participant.id} value={participant.id}>
-                {participant.snapshot.displayName} ({participant.role})
-              </option>
-            ))}
-          </select>
-        </label>
+        {readOnlyInspection ? <div>GM player-view inspection is read-only.</div> : null}
+        {showParticipantSelector ? (
+          <label style={{ display: "grid", gap: "0.25rem", maxWidth: 360 }}>
+            <span>Character</span>
+            <select
+              onChange={(event) => setSelectedParticipantId(event.target.value)}
+              value={selectedParticipantId}
+            >
+              {accessibleParticipants.length === 0 ? (
+                <option value="">No accessible participant</option>
+              ) : null}
+              {accessibleParticipants.map((participant) => (
+                <option key={participant.id} value={participant.id}>
+                  {participant.snapshot.displayName} ({participant.role})
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
       </div>
 
       <section
@@ -992,6 +1007,7 @@ export default function ScenarioPlayerCombatPageContent({
               <label style={{ display: "grid", gap: "0.25rem" }}>
                 <span>Action</span>
                 <select
+                  disabled={controlsDisabled}
                   onChange={(event) =>
                     setSelectedActionId(event.target.value as PlayerEncounterActionId | "")
                   }
@@ -1009,10 +1025,9 @@ export default function ScenarioPlayerCombatPageContent({
               <label style={{ display: "grid", gap: "0.25rem" }}>
                 <span>Secondary action</span>
                 <select
+                  disabled={controlsDisabled}
                   onChange={(event) =>
-                    setSelectedSecondaryActionId(
-                      event.target.value as PlayerEncounterActionId | "",
-                    )
+                    setSelectedSecondaryActionId(event.target.value as PlayerEncounterActionId | "")
                   }
                   value={selectedSecondaryActionId}
                 >
@@ -1028,6 +1043,7 @@ export default function ScenarioPlayerCombatPageContent({
               <label style={{ display: "grid", gap: "0.25rem" }}>
                 <span>Movement</span>
                 <select
+                  disabled={controlsDisabled}
                   onChange={(event) =>
                     setSelectedMovementId(event.target.value as PlayerEncounterMovementId | "")
                   }
@@ -1044,6 +1060,7 @@ export default function ScenarioPlayerCombatPageContent({
               <label style={{ display: "grid", gap: "0.25rem" }}>
                 <span>Additional</span>
                 <input
+                  disabled={controlsDisabled}
                   onChange={(event) => setAdditionalActionNotes(event.target.value)}
                   placeholder="Free text for intent, target, or table notes"
                   type="text"
@@ -1070,7 +1087,11 @@ export default function ScenarioPlayerCombatPageContent({
                       "Situation OB/Skill",
                       combatContextDraft.modifierBuckets.situationObSkill,
                     ],
-                    ["situation_db", "Situation DB", combatContextDraft.modifierBuckets.situationDb],
+                    [
+                      "situation_db",
+                      "Situation DB",
+                      combatContextDraft.modifierBuckets.situationDb,
+                    ],
                   ] as const
                 ).map(([bucketKey, label, entries]) => (
                   <div key={bucketKey} style={{ display: "grid", gap: "0.35rem" }}>
@@ -1085,6 +1106,7 @@ export default function ScenarioPlayerCombatPageContent({
                         }}
                       >
                         <input
+                          disabled={controlsDisabled}
                           onChange={(event) =>
                             updateModifierBucket(bucketKey, (current) =>
                               current.map((currentEntry) =>
@@ -1104,6 +1126,7 @@ export default function ScenarioPlayerCombatPageContent({
                           value={entry.value}
                         />
                         <select
+                          disabled={controlsDisabled}
                           onChange={(event) =>
                             updateModifierBucket(bucketKey, (current) =>
                               current.map((currentEntry) =>
@@ -1122,6 +1145,7 @@ export default function ScenarioPlayerCombatPageContent({
                           <option value="save">Save</option>
                         </select>
                         <input
+                          disabled={controlsDisabled}
                           onChange={(event) =>
                             updateModifierBucket(bucketKey, (current) =>
                               current.map((currentEntry) =>
@@ -1139,6 +1163,7 @@ export default function ScenarioPlayerCombatPageContent({
                           value={entry.notes ?? ""}
                         />
                         <button
+                          disabled={controlsDisabled}
                           onClick={() =>
                             updateModifierBucket(bucketKey, (current) =>
                               current.filter((currentEntry) => currentEntry.id !== entry.id),
@@ -1151,6 +1176,7 @@ export default function ScenarioPlayerCombatPageContent({
                       </div>
                     ))}
                     <button
+                      disabled={controlsDisabled}
                       onClick={() =>
                         updateModifierBucket(bucketKey, (current) => [
                           ...current,
@@ -1185,6 +1211,7 @@ export default function ScenarioPlayerCombatPageContent({
                   <label style={{ display: "grid", gap: "0.25rem" }}>
                     <span>Incoming attack side</span>
                     <select
+                      disabled={controlsDisabled}
                       onChange={(event) =>
                         setCombatContextDraft((current) => ({
                           ...current,
@@ -1206,6 +1233,7 @@ export default function ScenarioPlayerCombatPageContent({
                   <label style={{ display: "grid", gap: "0.25rem" }}>
                     <span>Parry source</span>
                     <select
+                      disabled={controlsDisabled}
                       onChange={(event) =>
                         setCombatContextDraft((current) => ({
                           ...current,
@@ -1240,7 +1268,11 @@ export default function ScenarioPlayerCombatPageContent({
                 <div style={{ color: "#5e5a50", fontSize: "0.9rem" }}>
                   Saved on the selected participant combat state.
                 </div>
-                <button disabled={savingCombatContext} onClick={() => void saveCombatContext()} type="button">
+                <button
+                  disabled={controlsDisabled || savingCombatContext}
+                  onClick={() => void saveCombatContext()}
+                  type="button"
+                >
                   {savingCombatContext ? "Saving..." : "Save combat context"}
                 </button>
               </div>
@@ -1277,6 +1309,7 @@ export default function ScenarioPlayerCombatPageContent({
                   <label style={{ display: "grid", gap: "0.25rem" }}>
                     <span>Opponent</span>
                     <select
+                      disabled={controlsDisabled}
                       onChange={(event) =>
                         setCombatContextDraft((current) => ({
                           ...current,
@@ -1318,7 +1351,7 @@ export default function ScenarioPlayerCombatPageContent({
           >
             <div>
               <button
-                disabled={!activeActionButton.enabled}
+                disabled={controlsDisabled || !activeActionButton.enabled}
                 onClick={() =>
                   setActionRollResult({
                     interpretedResult: selectedCombatReference
@@ -1413,9 +1446,7 @@ export default function ScenarioPlayerCombatPageContent({
             </div>
           )
         ) : (
-          <div style={panelStyle}>
-            No accessible participant is available.
-          </div>
+          <div style={panelStyle}>No accessible participant is available.</div>
         )}
       </section>
     </section>

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/page.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/page.tsx
@@ -16,7 +16,7 @@ export default async function ScenarioPlayerPage({ params }: ScenarioPlayerPageP
     buildCampaignWorkspaceHref({
       campaignId,
       scenarioId,
-      tab: "player-encounter",
+      tab: "encounter",
     }),
   );
 }

--- a/apps/web/app/(app)/encounters/EncountersBrowser.tsx
+++ b/apps/web/app/(app)/encounters/EncountersBrowser.tsx
@@ -65,7 +65,7 @@ export default function EncountersBrowser({
         campaignId: campaignId as string,
         encounterId: encounter.id,
         scenarioId: scenarioId as string,
-        tab: "gm-encounter",
+        tab: "encounter",
       });
     }
 

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
@@ -16,18 +16,21 @@ describe("CombatRoundManagerPanel", () => {
     expect(source).toContain("Combat Round Manager");
     expect(source).toContain("Round {roundState.roundNumber}");
     expect(source).toContain("Current step:");
-    expect(source).toContain("Advance to");
+    expect(source).toContain("Rows are participants. Columns are the round timeline.");
+    expect(source).toContain("Commit");
+    expect(source).toContain("and advance to");
     expect(source).toContain("Step controller");
   });
 
-  it("renders participant step status table and active marker controls", () => {
+  it("renders participants as rows and round steps as timeline columns", () => {
     const source = readSource();
 
     expect(source).toContain("COMBAT_ROUND_STEPS.map");
     expect(source).toContain("Participant");
-    expect(source).toContain("Active");
+    expect(source).toContain("Active participant");
     expect(source).toContain("Set active");
     expect(source).toContain("participant.stepStatuses[step]");
+    expect(source).toContain("step === roundState.currentStep");
   });
 
   it("renders inspector details for the selected participant and step", () => {
@@ -35,6 +38,8 @@ describe("CombatRoundManagerPanel", () => {
 
     expect(source).toContain("Combat round inspector");
     expect(source).toContain("Inspector");
+    expect(source).toContain("Selected cell:");
+    expect(source).toContain("Advance commits this step");
     expect(source).toContain("buildCombatRoundInspector");
     expect(source).toContain("Phase 1 initiative:");
     expect(source).toContain("Phase 2 initiative:");

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
@@ -16,7 +16,7 @@ describe("CombatRoundManagerPanel", () => {
     expect(source).toContain("Combat Round Manager");
     expect(source).toContain("Round {roundState.roundNumber}");
     expect(source).toContain("Current step:");
-    expect(source).toContain("Rows are participants. Columns are the round timeline.");
+    expect(source).toContain("Rows are participants. Columns are round timeline cells.");
     expect(source).toContain("Commit");
     expect(source).toContain("and advance to");
     expect(source).toContain("Step controller");
@@ -25,24 +25,36 @@ describe("CombatRoundManagerPanel", () => {
   it("renders participants as rows and round steps as timeline columns", () => {
     const source = readSource();
 
+    expect(source).toContain("Combat round timeline grid");
+    expect(source).toContain("timelineRoundNumbers");
+    expect(source).toContain("Round {roundNumber}");
     expect(source).toContain("COMBAT_ROUND_STEPS.map");
+    expect(source).toContain("COMBAT_ROUND_STEP_ABBREVIATIONS[step]");
+    expect(source).toContain("COMBAT_ROUND_STEP_LABELS[step]");
     expect(source).toContain("Participant");
-    expect(source).toContain("Active participant");
+    expect(source).toContain("activeParticipantId");
     expect(source).toContain("Set active");
+    expect(source).toContain("getStatusMarker");
     expect(source).toContain("participant.stepStatuses[step]");
     expect(source).toContain("step === roundState.currentStep");
+    expect(source).toContain('overflowX: "auto"');
   });
 
   it("renders inspector details for the selected participant and step", () => {
     const source = readSource();
 
     expect(source).toContain("Combat round inspector");
-    expect(source).toContain("Inspector");
+    expect(source).toContain("Combat inspector");
     expect(source).toContain("Selected cell:");
-    expect(source).toContain("Advance commits this step");
+    expect(source).toContain("This is the current step. Advance commits this step");
     expect(source).toContain("buildCombatRoundInspector");
     expect(source).toContain("Phase 1 initiative:");
     expect(source).toContain("Phase 2 initiative:");
+    expect(source).toContain("No data recorded for this step.");
+    expect(source).toContain("Previous participant");
+    expect(source).toContain("Next participant");
+    expect(source).toContain("Previous step");
+    expect(source).toContain("Next step");
   });
 
   it("persists only combat round state through the existing encounter update path", () => {

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sourcePath = join(dirname(fileURLToPath(import.meta.url)), "CombatRoundManagerPanel.tsx");
+
+function readSource(): string {
+  return readFileSync(sourcePath, "utf8");
+}
+
+describe("CombatRoundManagerPanel", () => {
+  it("renders the GM round manager orchestration controls", () => {
+    const source = readSource();
+
+    expect(source).toContain("Combat Round Manager");
+    expect(source).toContain("Round {roundState.roundNumber}");
+    expect(source).toContain("Current step:");
+    expect(source).toContain("Advance to");
+    expect(source).toContain("Step controller");
+  });
+
+  it("renders participant step status table and active marker controls", () => {
+    const source = readSource();
+
+    expect(source).toContain("COMBAT_ROUND_STEPS.map");
+    expect(source).toContain("Participant");
+    expect(source).toContain("Active");
+    expect(source).toContain("Set active");
+    expect(source).toContain("participant.stepStatuses[step]");
+  });
+
+  it("renders inspector details for the selected participant and step", () => {
+    const source = readSource();
+
+    expect(source).toContain("Combat round inspector");
+    expect(source).toContain("Inspector");
+    expect(source).toContain("buildCombatRoundInspector");
+    expect(source).toContain("Phase 1 initiative:");
+    expect(source).toContain("Phase 2 initiative:");
+  });
+
+  it("persists only combat round state through the existing encounter update path", () => {
+    const source = readSource();
+
+    expect(source).toContain("updateEncounterOnServer");
+    expect(source).toContain("combatRoundState: nextRoundState");
+    expect(source).toContain("currentRound: nextRoundState.roundNumber");
+    expect(source).not.toContain("combatEffects");
+    expect(source).not.toContain("actionLog:");
+  });
+});

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
@@ -4,12 +4,15 @@ import { useEffect, useMemo, useState } from "react";
 
 import type { CombatRoundStep, EncounterSession } from "@glantri/domain";
 import {
+  COMBAT_ROUND_STEP_ABBREVIATIONS,
+  COMBAT_ROUND_STEP_LABELS,
   COMBAT_ROUND_STEPS,
   advanceCombatRoundStep,
   buildCombatRoundInspector,
   initializeCombatRoundState,
   setCombatRoundActiveParticipant,
   setCombatRoundSelection,
+  sortCombatRoundParticipantsByInitiative,
 } from "@glantri/domain";
 
 import { updateEncounterOnServer } from "@/lib/api/encounterClient";
@@ -29,47 +32,110 @@ const panelStyle = {
 } as const;
 
 const tableWrapStyle = {
+  border: "1px solid #e3e1dc",
+  borderRadius: 10,
   overflowX: "auto",
 } as const;
 
-const stepLabels: Record<CombatRoundStep, string> = {
-  initiative_phase_1: "Init P1",
-  initiative_phase_2: "Init P2",
-  phase_1_actions: "Phase 1",
-  phase_2_actions: "Phase 2",
-  review_action_modifiers: "Review mods",
-  review_phase_2_actions: "Review P2",
-  review_phase_2_modifiers: "P2 mods",
-  round_summary: "Summary",
-  select_actions: "Select",
-};
+const stickyParticipantCellStyle = {
+  background: "#fbfaf7",
+  boxShadow: "1px 0 0 #e3e1dc",
+  left: 0,
+  minWidth: "13rem",
+  position: "sticky",
+  zIndex: 2,
+} as const;
+
+const stepCellStyle = {
+  height: "2.35rem",
+  minWidth: "3rem",
+  padding: "0.2rem",
+  textAlign: "center",
+} as const;
+
+const inspectorNavStyle = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.5rem",
+} as const;
+
+const timelineRounds = 1;
 
 function getNextStepLabel(step: CombatRoundStep): string {
   const currentIndex = COMBAT_ROUND_STEPS.indexOf(step);
   const nextStep = COMBAT_ROUND_STEPS[currentIndex + 1] ?? "select_actions";
 
-  return stepLabels[nextStep];
+  return COMBAT_ROUND_STEP_ABBREVIATIONS[nextStep];
 }
 
 function getAdvanceButtonLabel(step: CombatRoundStep): string {
-  return `Commit ${stepLabels[step]} and advance to ${getNextStepLabel(step)}`;
+  return `Commit ${COMBAT_ROUND_STEP_ABBREVIATIONS[step]} and advance to ${getNextStepLabel(step)}`;
 }
 
 function formatInitiative(value: number | undefined): string {
   return value === undefined ? "init --" : `init ${value}`;
 }
 
+function getStatusMarker(input: { current: boolean; status: string | undefined }): string {
+  if (input.current) {
+    return "▶";
+  }
+
+  switch (input.status) {
+    case "complete":
+      return "✓";
+    case "ready":
+      return "R";
+    case "skipped":
+      return "–";
+    case "pending":
+    default:
+      return "·";
+  }
+}
+
+function shouldSortByInitiative(step: CombatRoundStep): "phase1" | "phase2" | undefined {
+  if (step === "phase_1_actions" || step === "review_phase_2_actions") {
+    return "phase1";
+  }
+
+  if (step === "phase_2_actions" || step === "review_phase_2_damage") {
+    return "phase2";
+  }
+
+  return undefined;
+}
+
 export default function CombatRoundManagerPanel({
   encounter,
   onEncounterUpdated,
 }: CombatRoundManagerPanelProps) {
-  const initialRoundState = useMemo(
-    () => initializeCombatRoundState({ encounter }),
-    [encounter],
-  );
+  const initialRoundState = useMemo(() => initializeCombatRoundState({ encounter }), [encounter]);
   const [roundState, setRoundState] = useState(initialRoundState);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string>();
+  const selectedRoundNumber = roundState.roundNumber;
+  const initiativeSortPhase = shouldSortByInitiative(roundState.currentStep);
+  const displayParticipants = useMemo(() => {
+    if (!initiativeSortPhase) {
+      return roundState.participants;
+    }
+
+    const hasInitiative = roundState.participants.some(
+      (participant) => participant.initiatives[initiativeSortPhase] !== undefined,
+    );
+
+    return hasInitiative
+      ? sortCombatRoundParticipantsByInitiative({
+          phase: initiativeSortPhase,
+          state: roundState,
+        })
+      : roundState.participants;
+  }, [initiativeSortPhase, roundState]);
+  const timelineRoundNumbers = Array.from(
+    { length: timelineRounds },
+    (_, index) => roundState.roundNumber + index,
+  );
   const inspector = buildCombatRoundInspector({
     participantId: roundState.selectedParticipantId,
     state: roundState,
@@ -115,6 +181,38 @@ export default function CombatRoundManagerPanel({
     );
   }
 
+  function moveSelection(input: { participantOffset?: number; stepOffset?: number }) {
+    setRoundState((current) => {
+      const participantIndex = displayParticipants.findIndex(
+        (participant) => participant.participantId === current.selectedParticipantId,
+      );
+      const stepIndex = COMBAT_ROUND_STEPS.indexOf(current.selectedStep ?? current.currentStep);
+      const nextParticipant =
+        displayParticipants[
+          Math.min(
+            Math.max(
+              (participantIndex === -1 ? 0 : participantIndex) + (input.participantOffset ?? 0),
+              0,
+            ),
+            Math.max(displayParticipants.length - 1, 0),
+          )
+        ];
+      const nextStep =
+        COMBAT_ROUND_STEPS[
+          Math.min(
+            Math.max((stepIndex === -1 ? 0 : stepIndex) + (input.stepOffset ?? 0), 0),
+            COMBAT_ROUND_STEPS.length - 1,
+          )
+        ];
+
+      return setCombatRoundSelection({
+        participantId: nextParticipant?.participantId,
+        state: current,
+        step: nextStep,
+      });
+    });
+  }
+
   return (
     <section style={panelStyle}>
       <div
@@ -129,10 +227,11 @@ export default function CombatRoundManagerPanel({
         <div>
           <h2 style={{ margin: 0 }}>Combat Round Manager</h2>
           <div>
-            Round {roundState.roundNumber} · Current step: {stepLabels[roundState.currentStep]}
+            Round {roundState.roundNumber} · Current step:{" "}
+            {COMBAT_ROUND_STEP_ABBREVIATIONS[roundState.currentStep]}
           </div>
           <div style={{ color: "#5e5a50" }}>
-            Rows are participants. Columns are the round timeline. Select a cell to inspect it.
+            Rows are participants. Columns are round timeline cells. Select a cell to inspect it.
           </div>
         </div>
         <section
@@ -168,83 +267,168 @@ export default function CombatRoundManagerPanel({
         </div>
       ) : null}
 
-      <div style={tableWrapStyle}>
-        <table style={{ borderCollapse: "collapse", minWidth: 980, width: "100%" }}>
+      <div aria-label="Combat round timeline grid" style={tableWrapStyle}>
+        <table
+          style={{
+            borderCollapse: "separate",
+            borderSpacing: 0,
+            minWidth: 620,
+            width: "max-content",
+          }}
+        >
           <thead>
             <tr>
-              <th style={{ padding: "0.45rem", textAlign: "left" }}>Participant</th>
-              {COMBAT_ROUND_STEPS.map((step) => (
-                <th key={step} style={{ padding: "0.45rem", textAlign: "left" }}>
-                  {stepLabels[step]}
+              <th
+                rowSpan={2}
+                style={{
+                  ...stickyParticipantCellStyle,
+                  padding: "0.45rem",
+                  textAlign: "left",
+                  top: 0,
+                }}
+              >
+                Participant
+              </th>
+              {timelineRoundNumbers.map((roundNumber) => (
+                <th
+                  colSpan={COMBAT_ROUND_STEPS.length}
+                  key={roundNumber}
+                  style={{
+                    background: "#efe7d3",
+                    borderBottom: "1px solid #d1c7aa",
+                    borderLeft: "1px solid #e3e1dc",
+                    padding: "0.35rem",
+                    textAlign: "center",
+                  }}
+                >
+                  Round {roundNumber}
                 </th>
               ))}
             </tr>
+            <tr>
+              {timelineRoundNumbers.flatMap((roundNumber) =>
+                COMBAT_ROUND_STEPS.map((step) => (
+                  <th
+                    key={`${roundNumber}-${step}`}
+                    style={{
+                      ...stepCellStyle,
+                      background: step === roundState.currentStep ? "#f6f0dd" : "#fbfaf7",
+                      borderBottom: "1px solid #e3e1dc",
+                      borderLeft: "1px solid #e3e1dc",
+                      fontWeight: step === roundState.currentStep ? 800 : 700,
+                    }}
+                    title={COMBAT_ROUND_STEP_LABELS[step]}
+                  >
+                    {COMBAT_ROUND_STEP_ABBREVIATIONS[step]}
+                  </th>
+                )),
+              )}
+            </tr>
           </thead>
           <tbody>
-            {roundState.participants.map((participant) => (
-              <tr key={participant.participantId}>
-                <td style={{ borderTop: "1px solid #e3e1dc", padding: "0.45rem" }}>
-                  <div style={{ display: "grid", gap: "0.25rem" }}>
-                    <strong>{participant.label}</strong>
-                    {roundState.activeParticipantId === participant.participantId ? (
-                      <span>Active participant</span>
-                    ) : (
-                      <button
-                        disabled={saving}
-                        onClick={() =>
-                          void persistRoundState(
-                            setCombatRoundActiveParticipant(roundState, participant.participantId),
-                          )
-                        }
-                        type="button"
-                      >
-                        Set active
-                      </button>
-                    )}
-                  </div>
-                </td>
-                {COMBAT_ROUND_STEPS.map((step) => {
-                  const selected =
-                    roundState.selectedParticipantId === participant.participantId &&
-                    roundState.selectedStep === step;
-                  const currentStepCell = step === roundState.currentStep;
-                  const initiative =
-                    step === "initiative_phase_1"
-                      ? formatInitiative(participant.initiatives.phase1)
-                      : step === "initiative_phase_2"
-                        ? formatInitiative(participant.initiatives.phase2)
-                        : undefined;
+            {displayParticipants.map((participant) => {
+              const selectedRow = roundState.selectedParticipantId === participant.participantId;
 
-                  return (
-                    <td
-                      key={step}
-                      style={{
-                        background: selected ? "#efe7d3" : currentStepCell ? "#f6f0dd" : undefined,
-                        borderTop: "1px solid #e3e1dc",
-                        padding: "0.45rem",
-                      }}
-                    >
-                      <button
-                        onClick={() => selectInspector(participant.participantId, step)}
-                        style={{
-                          background: "transparent",
-                          border: "none",
-                          color: "#2f5d62",
-                          cursor: "pointer",
-                          fontWeight: currentStepCell ? 700 : 400,
-                          padding: 0,
-                          textAlign: "left",
-                        }}
-                        type="button"
-                      >
-                        {participant.stepStatuses[step]}
-                        {initiative ? ` · ${initiative}` : ""}
-                      </button>
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
+              return (
+                <tr
+                  key={participant.participantId}
+                  style={{ background: selectedRow ? "#fff8e8" : undefined }}
+                >
+                  <td
+                    style={{
+                      ...stickyParticipantCellStyle,
+                      borderTop: "1px solid #e3e1dc",
+                      padding: "0.45rem",
+                    }}
+                  >
+                    <div style={{ display: "grid", gap: "0.25rem" }}>
+                      <strong>{participant.label}</strong>
+                      {roundState.activeParticipantId === participant.participantId ? (
+                        <span aria-label={`${participant.label} is active`}>▶ Active</span>
+                      ) : (
+                        <button
+                          disabled={saving}
+                          onClick={() =>
+                            void persistRoundState(
+                              setCombatRoundActiveParticipant(
+                                roundState,
+                                participant.participantId,
+                              ),
+                            )
+                          }
+                          type="button"
+                        >
+                          Set active
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                  {timelineRoundNumbers.flatMap((roundNumber) =>
+                    COMBAT_ROUND_STEPS.map((step) => {
+                      const selected =
+                        roundNumber === selectedRoundNumber &&
+                        roundState.selectedParticipantId === participant.participantId &&
+                        roundState.selectedStep === step;
+                      const currentStepCell =
+                        roundNumber === roundState.roundNumber && step === roundState.currentStep;
+                      const marker = getStatusMarker({
+                        current: currentStepCell,
+                        status: participant.stepStatuses[step],
+                      });
+                      const initiative =
+                        step === "initiative_phase_1"
+                          ? formatInitiative(participant.initiatives.phase1)
+                          : step === "initiative_phase_2"
+                            ? formatInitiative(participant.initiatives.phase2)
+                            : undefined;
+                      const title = `${participant.label}, round ${roundNumber}, ${COMBAT_ROUND_STEP_LABELS[step]}, status ${participant.stepStatuses[step]}`;
+
+                      return (
+                        <td
+                          key={`${roundNumber}-${step}`}
+                          style={{
+                            ...stepCellStyle,
+                            background: selected
+                              ? "#efe7d3"
+                              : currentStepCell
+                                ? "#f6f0dd"
+                                : undefined,
+                            borderLeft: "1px solid #e3e1dc",
+                            borderTop: "1px solid #e3e1dc",
+                            outline: selected ? "2px solid #2f5d62" : undefined,
+                            outlineOffset: "-2px",
+                          }}
+                        >
+                          <button
+                            aria-label={title}
+                            onClick={() => selectInspector(participant.participantId, step)}
+                            style={{
+                              alignItems: "center",
+                              background: "transparent",
+                              border: "none",
+                              color: "#2f5d62",
+                              cursor: "pointer",
+                              display: "grid",
+                              fontSize: "0.85rem",
+                              fontWeight: currentStepCell ? 800 : 600,
+                              justifyItems: "center",
+                              lineHeight: 1.1,
+                              minHeight: "1.8rem",
+                              padding: 0,
+                              width: "100%",
+                            }}
+                            title={initiative ? `${title}, ${initiative}` : title}
+                            type="button"
+                          >
+                            <span aria-hidden="true">{marker}</span>
+                          </button>
+                        </td>
+                      );
+                    }),
+                  )}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
@@ -259,16 +443,18 @@ export default function CombatRoundManagerPanel({
           padding: "0.75rem",
         }}
       >
-        <h3 style={{ margin: 0 }}>Inspector</h3>
+        <h3 style={{ margin: 0 }}>Combat inspector</h3>
         {inspector.participant ? (
           <>
             <div>
-              Selected cell: <strong>{inspector.participant.label}</strong> · {stepLabels[inspector.step]}
+              Selected cell: <strong>{inspector.participant.label}</strong> · Round{" "}
+              {selectedRoundNumber} · {COMBAT_ROUND_STEP_ABBREVIATIONS[inspector.step]} (
+              {COMBAT_ROUND_STEP_LABELS[inspector.step]})
             </div>
             <div>Status: {inspector.status ?? "pending"}</div>
             <div>
               {inspector.step === roundState.currentStep
-                ? "This is in the current step. Advance commits this step for the round timeline."
+                ? "This is the current step. Advance commits this step and moves the process forward."
                 : "This is a timeline cell for review or preparation."}
             </div>
             <div>
@@ -276,6 +462,21 @@ export default function CombatRoundManagerPanel({
             </div>
             <div>
               Phase 2 initiative: {formatInitiative(inspector.participant.initiatives.phase2)}
+            </div>
+            <div>No data recorded for this step.</div>
+            <div style={inspectorNavStyle}>
+              <button onClick={() => moveSelection({ participantOffset: -1 })} type="button">
+                Previous participant
+              </button>
+              <button onClick={() => moveSelection({ participantOffset: 1 })} type="button">
+                Next participant
+              </button>
+              <button onClick={() => moveSelection({ stepOffset: -1 })} type="button">
+                Previous step
+              </button>
+              <button onClick={() => moveSelection({ stepOffset: 1 })} type="button">
+                Next step
+              </button>
             </div>
           </>
         ) : (

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import type { CombatRoundStep, EncounterSession } from "@glantri/domain";
+import {
+  COMBAT_ROUND_STEPS,
+  advanceCombatRoundStep,
+  buildCombatRoundInspector,
+  initializeCombatRoundState,
+  setCombatRoundActiveParticipant,
+  setCombatRoundSelection,
+} from "@glantri/domain";
+
+import { updateEncounterOnServer } from "@/lib/api/encounterClient";
+
+interface CombatRoundManagerPanelProps {
+  encounter: EncounterSession;
+  onEncounterUpdated?: (encounter: EncounterSession) => void;
+}
+
+const panelStyle = {
+  background: "#fbfaf7",
+  border: "1px solid #d9ddd8",
+  borderRadius: 12,
+  display: "grid",
+  gap: "1rem",
+  padding: "1rem",
+} as const;
+
+const tableWrapStyle = {
+  overflowX: "auto",
+} as const;
+
+const stepLabels: Record<CombatRoundStep, string> = {
+  initiative_phase_1: "Init P1",
+  initiative_phase_2: "Init P2",
+  phase_1_actions: "Phase 1",
+  phase_2_actions: "Phase 2",
+  review_action_modifiers: "Review mods",
+  review_phase_2_actions: "Review P2",
+  review_phase_2_modifiers: "P2 mods",
+  round_summary: "Summary",
+  select_actions: "Select",
+};
+
+function getNextStepLabel(step: CombatRoundStep): string {
+  const currentIndex = COMBAT_ROUND_STEPS.indexOf(step);
+  const nextStep = COMBAT_ROUND_STEPS[currentIndex + 1] ?? "select_actions";
+
+  return stepLabels[nextStep];
+}
+
+function formatInitiative(value: number | undefined): string {
+  return value === undefined ? "init --" : `init ${value}`;
+}
+
+export default function CombatRoundManagerPanel({
+  encounter,
+  onEncounterUpdated,
+}: CombatRoundManagerPanelProps) {
+  const initialRoundState = useMemo(
+    () => initializeCombatRoundState({ encounter }),
+    [encounter],
+  );
+  const [roundState, setRoundState] = useState(initialRoundState);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string>();
+  const inspector = buildCombatRoundInspector({
+    participantId: roundState.selectedParticipantId,
+    state: roundState,
+    step: roundState.selectedStep,
+  });
+
+  useEffect(() => {
+    setRoundState(initialRoundState);
+  }, [initialRoundState]);
+
+  async function persistRoundState(nextRoundState: typeof roundState) {
+    setRoundState(nextRoundState);
+    setSaving(true);
+
+    try {
+      const nextEncounter = await updateEncounterOnServer({
+        encounterId: encounter.id,
+        session: {
+          ...encounter,
+          combatRoundState: nextRoundState,
+          currentRound: nextRoundState.roundNumber,
+        },
+      });
+
+      onEncounterUpdated?.(nextEncounter);
+      setSaveError(undefined);
+    } catch (caughtError) {
+      setSaveError(
+        caughtError instanceof Error ? caughtError.message : "Unable to save combat round state.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function selectInspector(participantId: string, step: CombatRoundStep) {
+    setRoundState((current) =>
+      setCombatRoundSelection({
+        participantId,
+        state: current,
+        step,
+      }),
+    );
+  }
+
+  return (
+    <section style={panelStyle}>
+      <div
+        style={{
+          alignItems: "start",
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "1rem",
+          justifyContent: "space-between",
+        }}
+      >
+        <div>
+          <h2 style={{ margin: 0 }}>Combat Round Manager</h2>
+          <div>
+            Round {roundState.roundNumber} · Current step: {stepLabels[roundState.currentStep]}
+          </div>
+        </div>
+        <section
+          aria-label="Step controller"
+          style={{
+            alignItems: "center",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "0.5rem",
+          }}
+        >
+          <button
+            disabled={saving}
+            onClick={() => void persistRoundState(advanceCombatRoundStep(roundState))}
+            type="button"
+          >
+            {saving ? "Saving..." : `Advance to ${getNextStepLabel(roundState.currentStep)}`}
+          </button>
+        </section>
+      </div>
+
+      {saveError ? (
+        <div
+          style={{
+            background: "#fdf0ea",
+            border: "1px solid #e4b9a7",
+            borderRadius: 10,
+            color: "#8b3a1a",
+            padding: "0.75rem",
+          }}
+        >
+          {saveError}
+        </div>
+      ) : null}
+
+      <div style={tableWrapStyle}>
+        <table style={{ borderCollapse: "collapse", minWidth: 980, width: "100%" }}>
+          <thead>
+            <tr>
+              <th style={{ padding: "0.45rem", textAlign: "left" }}>Participant</th>
+              <th style={{ padding: "0.45rem", textAlign: "left" }}>Active</th>
+              {COMBAT_ROUND_STEPS.map((step) => (
+                <th key={step} style={{ padding: "0.45rem", textAlign: "left" }}>
+                  {stepLabels[step]}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {roundState.participants.map((participant) => (
+              <tr key={participant.participantId}>
+                <td style={{ borderTop: "1px solid #e3e1dc", padding: "0.45rem" }}>
+                  {participant.label}
+                </td>
+                <td style={{ borderTop: "1px solid #e3e1dc", padding: "0.45rem" }}>
+                  {roundState.activeParticipantId === participant.participantId ? (
+                    <strong>Active</strong>
+                  ) : (
+                    <button
+                      disabled={saving}
+                      onClick={() =>
+                        void persistRoundState(
+                          setCombatRoundActiveParticipant(roundState, participant.participantId),
+                        )
+                      }
+                      type="button"
+                    >
+                      Set active
+                    </button>
+                  )}
+                </td>
+                {COMBAT_ROUND_STEPS.map((step) => {
+                  const selected =
+                    roundState.selectedParticipantId === participant.participantId &&
+                    roundState.selectedStep === step;
+                  const initiative =
+                    step === "initiative_phase_1"
+                      ? formatInitiative(participant.initiatives.phase1)
+                      : step === "initiative_phase_2"
+                        ? formatInitiative(participant.initiatives.phase2)
+                        : undefined;
+
+                  return (
+                    <td
+                      key={step}
+                      style={{
+                        background: selected ? "#efe7d3" : undefined,
+                        borderTop: "1px solid #e3e1dc",
+                        padding: "0.45rem",
+                      }}
+                    >
+                      <button
+                        onClick={() => selectInspector(participant.participantId, step)}
+                        style={{
+                          background: "transparent",
+                          border: "none",
+                          color: "#2f5d62",
+                          cursor: "pointer",
+                          padding: 0,
+                          textAlign: "left",
+                        }}
+                        type="button"
+                      >
+                        {participant.stepStatuses[step]}
+                        {initiative ? ` · ${initiative}` : ""}
+                      </button>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <section
+        aria-label="Combat round inspector"
+        style={{
+          border: "1px solid #e3e1dc",
+          borderRadius: 10,
+          display: "grid",
+          gap: "0.5rem",
+          padding: "0.75rem",
+        }}
+      >
+        <h3 style={{ margin: 0 }}>Inspector</h3>
+        {inspector.participant ? (
+          <>
+            <div>
+              <strong>{inspector.participant.label}</strong> · {stepLabels[inspector.step]}
+            </div>
+            <div>Status: {inspector.status ?? "pending"}</div>
+            <div>
+              Phase 1 initiative: {formatInitiative(inspector.participant.initiatives.phase1)}
+            </div>
+            <div>
+              Phase 2 initiative: {formatInitiative(inspector.participant.initiatives.phase2)}
+            </div>
+          </>
+        ) : (
+          <div>No participant selected.</div>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
@@ -51,6 +51,10 @@ function getNextStepLabel(step: CombatRoundStep): string {
   return stepLabels[nextStep];
 }
 
+function getAdvanceButtonLabel(step: CombatRoundStep): string {
+  return `Commit ${stepLabels[step]} and advance to ${getNextStepLabel(step)}`;
+}
+
 function formatInitiative(value: number | undefined): string {
   return value === undefined ? "init --" : `init ${value}`;
 }
@@ -127,6 +131,9 @@ export default function CombatRoundManagerPanel({
           <div>
             Round {roundState.roundNumber} · Current step: {stepLabels[roundState.currentStep]}
           </div>
+          <div style={{ color: "#5e5a50" }}>
+            Rows are participants. Columns are the round timeline. Select a cell to inspect it.
+          </div>
         </div>
         <section
           aria-label="Step controller"
@@ -142,7 +149,7 @@ export default function CombatRoundManagerPanel({
             onClick={() => void persistRoundState(advanceCombatRoundStep(roundState))}
             type="button"
           >
-            {saving ? "Saving..." : `Advance to ${getNextStepLabel(roundState.currentStep)}`}
+            {saving ? "Saving..." : getAdvanceButtonLabel(roundState.currentStep)}
           </button>
         </section>
       </div>
@@ -166,7 +173,6 @@ export default function CombatRoundManagerPanel({
           <thead>
             <tr>
               <th style={{ padding: "0.45rem", textAlign: "left" }}>Participant</th>
-              <th style={{ padding: "0.45rem", textAlign: "left" }}>Active</th>
               {COMBAT_ROUND_STEPS.map((step) => (
                 <th key={step} style={{ padding: "0.45rem", textAlign: "left" }}>
                   {stepLabels[step]}
@@ -178,29 +184,30 @@ export default function CombatRoundManagerPanel({
             {roundState.participants.map((participant) => (
               <tr key={participant.participantId}>
                 <td style={{ borderTop: "1px solid #e3e1dc", padding: "0.45rem" }}>
-                  {participant.label}
-                </td>
-                <td style={{ borderTop: "1px solid #e3e1dc", padding: "0.45rem" }}>
-                  {roundState.activeParticipantId === participant.participantId ? (
-                    <strong>Active</strong>
-                  ) : (
-                    <button
-                      disabled={saving}
-                      onClick={() =>
-                        void persistRoundState(
-                          setCombatRoundActiveParticipant(roundState, participant.participantId),
-                        )
-                      }
-                      type="button"
-                    >
-                      Set active
-                    </button>
-                  )}
+                  <div style={{ display: "grid", gap: "0.25rem" }}>
+                    <strong>{participant.label}</strong>
+                    {roundState.activeParticipantId === participant.participantId ? (
+                      <span>Active participant</span>
+                    ) : (
+                      <button
+                        disabled={saving}
+                        onClick={() =>
+                          void persistRoundState(
+                            setCombatRoundActiveParticipant(roundState, participant.participantId),
+                          )
+                        }
+                        type="button"
+                      >
+                        Set active
+                      </button>
+                    )}
+                  </div>
                 </td>
                 {COMBAT_ROUND_STEPS.map((step) => {
                   const selected =
                     roundState.selectedParticipantId === participant.participantId &&
                     roundState.selectedStep === step;
+                  const currentStepCell = step === roundState.currentStep;
                   const initiative =
                     step === "initiative_phase_1"
                       ? formatInitiative(participant.initiatives.phase1)
@@ -212,7 +219,7 @@ export default function CombatRoundManagerPanel({
                     <td
                       key={step}
                       style={{
-                        background: selected ? "#efe7d3" : undefined,
+                        background: selected ? "#efe7d3" : currentStepCell ? "#f6f0dd" : undefined,
                         borderTop: "1px solid #e3e1dc",
                         padding: "0.45rem",
                       }}
@@ -224,6 +231,7 @@ export default function CombatRoundManagerPanel({
                           border: "none",
                           color: "#2f5d62",
                           cursor: "pointer",
+                          fontWeight: currentStepCell ? 700 : 400,
                           padding: 0,
                           textAlign: "left",
                         }}
@@ -255,9 +263,14 @@ export default function CombatRoundManagerPanel({
         {inspector.participant ? (
           <>
             <div>
-              <strong>{inspector.participant.label}</strong> · {stepLabels[inspector.step]}
+              Selected cell: <strong>{inspector.participant.label}</strong> · {stepLabels[inspector.step]}
             </div>
             <div>Status: {inspector.status ?? "pending"}</div>
+            <div>
+              {inspector.step === roundState.currentStep
+                ? "This is in the current step. Advance commits this step for the round timeline."
+                : "This is a timeline cell for review or preparation."}
+            </div>
             <div>
               Phase 1 initiative: {formatInitiative(inspector.participant.initiatives.phase1)}
             </div>

--- a/apps/web/src/features/encounters/EncounterDetail.tsx
+++ b/apps/web/src/features/encounters/EncounterDetail.tsx
@@ -48,6 +48,7 @@ interface EncounterDetailProps {
   campaignId?: string;
   embedded?: boolean;
   id: string;
+  surface?: "encounter" | "full" | "skill-rolls";
   scenarioId?: string;
 }
 
@@ -96,6 +97,7 @@ export default function EncounterDetail({
   campaignId,
   embedded = false,
   id,
+  surface = "full",
   scenarioId
 }: EncounterDetailProps) {
   const [adHocName, setAdHocName] = useState("");
@@ -295,7 +297,7 @@ export default function EncounterDetail({
         campaignId: campaignId as string,
         encounterId: id,
         scenarioId: scenarioId as string,
-        tab: "player-encounter",
+        tab: "encounter",
       })
     : undefined;
 
@@ -522,7 +524,7 @@ export default function EncounterDetail({
     );
   }
 
-  if (encounter.kind === "roleplay") {
+  if (encounter.kind === "roleplay" || surface === "encounter" || surface === "skill-rolls") {
     return (
       <GmRoleplayingEncounterScreen
         campaignId={campaignId}
@@ -533,6 +535,7 @@ export default function EncounterDetail({
         scenario={scenarioRecord}
         scenarioId={scenarioId}
         scenarioParticipants={scenarioParticipants}
+        surface={surface === "full" ? undefined : surface}
       />
     );
   }
@@ -546,7 +549,7 @@ export default function EncounterDetail({
           campaignId={campaignId as string}
           encounterId={id}
           scenarioId={scenarioId as string}
-          tab="gm-encounter"
+          tab="encounter"
         />
       ) : null}
       {!embedded ? (
@@ -573,7 +576,7 @@ export default function EncounterDetail({
         <h1 style={{ marginBottom: "0.5rem" }}>{encounter.title}</h1>
         <p style={{ margin: 0 }}>
           {isNestedScenarioFlow
-            ? "GM encounter management for this scenario, with round scaffolding, declarations, turn order, and the handoff point to the player combat screen."
+            ? "Encounter management for this scenario, with round scaffolding, declarations, turn order, and the handoff point to the player combat screen."
             : "Legacy local encounter shell with participant summaries, round declarations, manual turn ordering, and position/orientation placeholders for future combat resolution work."}
         </p>
       </div>
@@ -614,7 +617,7 @@ export default function EncounterDetail({
             <div style={{ display: "grid", gap: "0.25rem" }}>
               <h2 style={{ margin: 0 }}>GM combat test view</h2>
               <div style={{ color: "#5e5a50" }}>
-                Shared scenario participant declarations for the canonical GM encounter workspace.
+                Shared scenario participant declarations for the canonical encounter workspace.
               </div>
             </div>
             <button

--- a/apps/web/src/features/roleplay/RoleplayEncounterScreens.test.ts
+++ b/apps/web/src/features/roleplay/RoleplayEncounterScreens.test.ts
@@ -140,7 +140,8 @@ describe("RoleplayEncounterScreens", () => {
     expect(playerSource).toContain("GM player-view inspection is read-only.");
     expect(playerSource).toContain("disabled={!canUsePlayerActions || Boolean(roll.result)}");
     expect(playerSource).toContain("showWorkspaceHeader");
-    expect(playerSource).toContain("Skill rolls{selectedPlayerFacingName");
+    expect(playerSource).toContain('workspaceScreenName = "Skill rolls"');
+    expect(playerSource).toContain("{workspaceScreenName}");
   });
 
   it("preserves opposed result matching and player submitted roll identity", () => {

--- a/apps/web/src/features/roleplay/RoleplayEncounterScreens.test.ts
+++ b/apps/web/src/features/roleplay/RoleplayEncounterScreens.test.ts
@@ -122,12 +122,25 @@ describe("RoleplayEncounterScreens", () => {
     expect(playerSource).toContain("playerView.rankedResults");
     expect(playerSource).toContain("playerView.characterLog");
     expect(playerSource).toContain("loadScenarioMyParticipant");
+    expect(playerSource).toContain("loadScenarioParticipants");
     expect(playerSource).toContain("mergePlayerVisibleResults");
     expect(source).toContain("isSamePlayerVisibleRankedResult");
     expect(playerSource).toContain("dismissedAssignedRollIds");
     expect(playerSource).toContain("dismissedRankedResultIds");
     expect(source).toContain("getScenarioParticipantFallbackEncounterParticipants");
     expect(source).toContain("resolveEncounterParticipantByRollParticipantId");
+  });
+
+  it("supports read-only GM inspection of the player-facing Skill rolls screen", () => {
+    const playerSource = readPlayerScreenSource();
+
+    expect(playerSource).toContain("inspectionParticipantId");
+    expect(playerSource).toContain("readOnlyInspection");
+    expect(playerSource).toContain("controlledScenarioParticipantId: inspectedParticipantId");
+    expect(playerSource).toContain("GM player-view inspection is read-only.");
+    expect(playerSource).toContain("disabled={!canUsePlayerActions || Boolean(roll.result)}");
+    expect(playerSource).toContain("showWorkspaceHeader");
+    expect(playerSource).toContain("Skill rolls{selectedPlayerFacingName");
   });
 
   it("preserves opposed result matching and player submitted roll identity", () => {
@@ -149,7 +162,7 @@ describe("RoleplayEncounterScreens", () => {
     const rankedSource = readFunctionSource(
       sectionsSource,
       "RankedRollResultsSection",
-      "function formatDifficulty"
+      "function formatDifficulty",
     );
 
     expect(source).toContain('entry.mode !== "opposed"');
@@ -163,7 +176,7 @@ describe("RoleplayEncounterScreens", () => {
     expect(source).toContain("serverRankedRollResults");
     expect(source).toContain("dedupeRankedRoleplayEntries");
     expect(rankedSource).toContain("entry.numericSubtotal == null");
-    expect(rankedSource).not.toContain("entry.fumble ? \"FUMBLE\"");
+    expect(rankedSource).not.toContain('entry.fumble ? "FUMBLE"');
     expect(rankedSource).not.toContain("entry.success");
   });
 

--- a/apps/web/src/features/roleplay/RoleplayEncounterScreens.tsx
+++ b/apps/web/src/features/roleplay/RoleplayEncounterScreens.tsx
@@ -44,6 +44,7 @@ import {
   loadEncounterById,
   loadScenarioById,
   loadScenarioMyParticipant,
+  loadScenarioParticipants,
   submitPlayerRoleplayRollOnServer,
 } from "@/lib/api/localServiceClient";
 import { useSessionUser } from "@/lib/auth/SessionUserContext";
@@ -106,7 +107,10 @@ interface PlayerRoleplayingEncounterScreenProps {
   campaignId: string;
   embedded?: boolean;
   encounterId: string;
+  inspectionParticipantId?: string | null;
+  readOnlyInspection?: boolean;
   scenarioId: string;
+  showWorkspaceHeader?: boolean;
   surface?: "encounter" | "full" | "skill-rolls";
 }
 
@@ -124,7 +128,7 @@ function getScenarioParticipantForEncounterParticipant(input: {
 }): ScenarioParticipant | undefined {
   return input.encounterParticipant?.scenarioParticipantId
     ? input.scenarioParticipants.find(
-        (participant) => participant.id === input.encounterParticipant?.scenarioParticipantId
+        (participant) => participant.id === input.encounterParticipant?.scenarioParticipantId,
       )
     : undefined;
 }
@@ -157,13 +161,12 @@ function readSkillOptions(input: {
 }): SkillOption[] {
   const scenarioParticipant = input.encounterParticipant?.scenarioParticipantId
     ? input.scenarioParticipants.find(
-        (participant) => participant.id === input.encounterParticipant?.scenarioParticipantId
+        (participant) => participant.id === input.encounterParticipant?.scenarioParticipantId,
       )
     : undefined;
   const sheetSummary = scenarioParticipant?.snapshot.sheetSummary;
-  const draftView = isRecord(sheetSummary) && isRecord(sheetSummary.draftView)
-    ? sheetSummary.draftView
-    : undefined;
+  const draftView =
+    isRecord(sheetSummary) && isRecord(sheetSummary.draftView) ? sheetSummary.draftView : undefined;
   const draftSkills = Array.isArray(draftView?.skills) ? draftView.skills : [];
   const skillsById = new Map(input.content?.skills.map((skill) => [skill.id, skill.name]) ?? []);
 
@@ -194,7 +197,9 @@ function readSystemSkillOptions(input: {
   scenarioParticipants: ScenarioParticipant[];
 }): SkillOption[] {
   const categoryDefinitions = getPlayerFacingSkillBucketDefinitions();
-  const categoryLabelById = new Map(categoryDefinitions.map((category) => [category.id, category.label]));
+  const categoryLabelById = new Map(
+    categoryDefinitions.map((category) => [category.id, category.label]),
+  );
 
   if (!input.content?.skills.length) {
     return readSkillOptions(input).map((skill) => ({
@@ -207,7 +212,7 @@ function readSystemSkillOptions(input: {
     .filter(
       (skill) =>
         (skill.category === "ordinary" || skill.category === "secondary") &&
-        !skill.specializationOfSkillId
+        !skill.specializationOfSkillId,
     )
     .map((skill) => {
       const categoryId = getPlayerFacingSkillBucket(skill);
@@ -227,7 +232,7 @@ function readSystemSkillOptions(input: {
         value: profile.rollBaseValue,
         warning: profile.warning
           ? profile.warning ===
-              "Skill not known: using linked stat average with -3 default modifier. GM may adjust or forbid."
+            "Skill not known: using linked stat average with -3 default modifier. GM may adjust or forbid."
             ? "Skill not known (-3 default). GM may adjust or forbid."
             : profile.warning
           : undefined,
@@ -305,13 +310,11 @@ function applyUnknownSkillDefaultOtherMod(input: {
     return String(input.selectedSkill.profile.unknownSkillPenalty);
   }
 
-  return input.currentValue === "-3"
-    ? "0"
-    : input.currentValue;
+  return input.currentValue === "-3" ? "0" : input.currentValue;
 }
 
 function buildRoleplayCalculationPreview(
-  input: Parameters<typeof buildDomainRoleplayCalculationPreview>[0]
+  input: Parameters<typeof buildDomainRoleplayCalculationPreview>[0],
 ): ReturnType<typeof buildDomainRoleplayCalculationPreview> {
   const otherMod = normalizeRoleplayOtherMod(input.otherMod);
   const modifierPipeline =
@@ -349,7 +352,7 @@ function buildPlayerRollResult(input?: {
 
 function buildActionLogRollResult(
   input?: RoleplayActionLogEntry,
-  side: "actor" | "opponent" = "actor"
+  side: "actor" | "opponent" = "actor",
 ): RoleplayOpenEndedD20Roll | undefined {
   if (!input) {
     return undefined;
@@ -366,7 +369,9 @@ function buildActionLogRollResult(
   return buildPlayerRollResult(input);
 }
 
-function buildActionLogSupportRollResult(input?: RoleplayActionLogEntry): RoleplayOpenEndedD20Roll | undefined {
+function buildActionLogSupportRollResult(
+  input?: RoleplayActionLogEntry,
+): RoleplayOpenEndedD20Roll | undefined {
   return buildPlayerRollResult({
     dieResult: input?.supportDieResult,
     openEndedD10s: input?.supportOpenEndedD10s ?? [],
@@ -406,7 +411,8 @@ function findRoleplayResultForSide(input: {
 
       if (input.side === "opponent" && !entry.side) {
         return (
-          (entry.opponentParticipantId === input.participantId && entry.opponentSkillId === input.skillId) ||
+          (entry.opponentParticipantId === input.participantId &&
+            entry.opponentSkillId === input.skillId) ||
           (entry.participantId === input.participantId && entry.skillId === input.skillId)
         );
       }
@@ -458,21 +464,27 @@ type PlayerVisibleRankedResult = {
   total: number;
 };
 
-function hasSamePlayerRankedStackIdentity(left: PlayerVisibleRankedResult, right: PlayerVisibleRankedResult): boolean {
+function hasSamePlayerRankedStackIdentity(
+  left: PlayerVisibleRankedResult,
+  right: PlayerVisibleRankedResult,
+): boolean {
   return Boolean(
     left.rollSetId &&
-      right.rollSetId &&
-      left.rollSetId === right.rollSetId &&
-      left.participantId &&
-      right.participantId &&
-      left.participantId === right.participantId &&
-      left.skillId &&
-      right.skillId &&
-      left.skillId === right.skillId
+    right.rollSetId &&
+    left.rollSetId === right.rollSetId &&
+    left.participantId &&
+    right.participantId &&
+    left.participantId === right.participantId &&
+    left.skillId &&
+    right.skillId &&
+    left.skillId === right.skillId,
   );
 }
 
-function isSamePlayerVisibleRankedResult(left: PlayerVisibleRankedResult, right: PlayerVisibleRankedResult): boolean {
+function isSamePlayerVisibleRankedResult(
+  left: PlayerVisibleRankedResult,
+  right: PlayerVisibleRankedResult,
+): boolean {
   if (left.pendingRollId && right.pendingRollId) {
     return left.pendingRollId === right.pendingRollId;
   }
@@ -489,14 +501,22 @@ function isSamePlayerVisibleRankedResult(left: PlayerVisibleRankedResult, right:
 }
 
 function rankPlayerVisibleResults(entries: PlayerVisibleRankedResult[]) {
-  return [...entries].sort((left, right) => right.total - left.total || left.participantName.localeCompare(right.participantName));
+  return [...entries].sort(
+    (left, right) =>
+      right.total - left.total || left.participantName.localeCompare(right.participantName),
+  );
 }
 
-function mergePlayerVisibleResults(left: PlayerVisibleRankedResult[], right: PlayerVisibleRankedResult[]) {
+function mergePlayerVisibleResults(
+  left: PlayerVisibleRankedResult[],
+  right: PlayerVisibleRankedResult[],
+) {
   const merged: PlayerVisibleRankedResult[] = [];
 
   for (const entry of [...left, ...right]) {
-    const existingIndex = merged.findIndex((existing) => isSamePlayerVisibleRankedResult(existing, entry));
+    const existingIndex = merged.findIndex((existing) =>
+      isSamePlayerVisibleRankedResult(existing, entry),
+    );
 
     if (existingIndex >= 0) {
       merged[existingIndex] = entry;
@@ -509,10 +529,12 @@ function mergePlayerVisibleResults(left: PlayerVisibleRankedResult[], right: Pla
 }
 
 function getRankedRoleplayEntryKey(entry: RoleplayActionLogEntry): string {
-  return entry.pendingRollId ??
+  return (
+    entry.pendingRollId ??
     (entry.rollSetId && entry.participantId && entry.skillId
       ? `${entry.rollSetId}:${entry.participantId}:${entry.skillId}`
-      : entry.id);
+      : entry.id)
+  );
 }
 
 function dedupeRankedRoleplayEntries(entries: RoleplayActionLogEntry[]): RoleplayActionLogEntry[] {
@@ -526,7 +548,7 @@ function dedupeRankedRoleplayEntries(entries: RoleplayActionLogEntry[]): Rolepla
 }
 
 function findLatestNonOpposedRollStackId(
-  roleplayState: ReturnType<typeof normalizeRoleplayState>
+  roleplayState: ReturnType<typeof normalizeRoleplayState>,
 ): string | undefined {
   if (roleplayState.currentRankedRollStackId) {
     return roleplayState.currentRankedRollStackId;
@@ -541,12 +563,18 @@ function findLatestNonOpposedRollStackId(
   }
 
   for (const entry of roleplayState.actionLog) {
-    if (entry.type === "gm_skill_roll" && entry.mode !== "opposed" && !entry.side && entry.rollSetId) {
+    if (
+      entry.type === "gm_skill_roll" &&
+      entry.mode !== "opposed" &&
+      !entry.side &&
+      entry.rollSetId
+    ) {
       candidates.push({ rollSetId: entry.rollSetId, timestamp: entry.createdAt });
     }
   }
 
-  return candidates.sort((left, right) => right.timestamp.localeCompare(left.timestamp))[0]?.rollSetId;
+  return candidates.sort((left, right) => right.timestamp.localeCompare(left.timestamp))[0]
+    ?.rollSetId;
 }
 
 export function GmRoleplayingEncounterScreen({
@@ -564,11 +592,11 @@ export function GmRoleplayingEncounterScreen({
   const roleplayState = normalizeRoleplayState(encounter);
   const roster = useMemo(
     () => orderRoleplayEncounterParticipants(encounter.participants),
-    [encounter.participants]
+    [encounter.participants],
   );
   const [gmMessageDraft, setGmMessageDraft] = useState(roleplayState.gmMessage);
   const [currentGmRollStackId, setCurrentGmRollStackId] = useState(
-    () => findLatestNonOpposedRollStackId(roleplayState) ?? makeRoleplayRollSetId()
+    () => findLatestNonOpposedRollStackId(roleplayState) ?? makeRoleplayRollSetId(),
   );
   const initialSkillId = useMemo(
     () =>
@@ -577,12 +605,18 @@ export function GmRoleplayingEncounterScreen({
         encounterParticipant: roster[0],
         scenarioParticipants,
       })[0]?.id ?? "",
-    [content, roster, scenarioParticipants]
+    [content, roster, scenarioParticipants],
   );
   const [rollDrafts, setRollDrafts] = useState<RoleplayRollDraft[]>([
-    makeRollDraft({ participantId: roster[0]?.id, rollSetId: currentGmRollStackId, skillId: initialSkillId }),
+    makeRollDraft({
+      participantId: roster[0]?.id,
+      rollSetId: currentGmRollStackId,
+      skillId: initialSkillId,
+    }),
   ]);
-  const [currentRankedRollResults, setCurrentRankedRollResults] = useState<RoleplayActionLogEntry[]>([]);
+  const [currentRankedRollResults, setCurrentRankedRollResults] = useState<
+    RoleplayActionLogEntry[]
+  >([]);
   const [gmMessageDirty, setGmMessageDirty] = useState(false);
 
   useEffect(() => {
@@ -594,8 +628,7 @@ export function GmRoleplayingEncounterScreen({
   useEffect(() => {
     setRollDrafts((currentDrafts) =>
       currentDrafts.map((draft) => {
-        const participant =
-          roster.find((row) => row.id === draft.participantId) ?? roster[0];
+        const participant = roster.find((row) => row.id === draft.participantId) ?? roster[0];
         const skillOptions = readSystemSkillOptions({
           content,
           encounterParticipant: participant,
@@ -609,8 +642,7 @@ export function GmRoleplayingEncounterScreen({
           draft.supportSkillCategoryId === "all"
             ? skillOptions
             : skillOptions.filter((skill) => skill.categoryId === draft.supportSkillCategoryId);
-        const opponent =
-          roster.find((row) => row.id === draft.opponentParticipantId) ?? undefined;
+        const opponent = roster.find((row) => row.id === draft.opponentParticipantId) ?? undefined;
         const opponentSkillOptions = readSystemSkillOptions({
           content,
           encounterParticipant: opponent,
@@ -619,15 +651,18 @@ export function GmRoleplayingEncounterScreen({
         const filteredOpponentSkillOptions =
           draft.opponentSkillCategoryId === "all"
             ? opponentSkillOptions
-            : opponentSkillOptions.filter((skill) => skill.categoryId === draft.opponentSkillCategoryId);
+            : opponentSkillOptions.filter(
+                (skill) => skill.categoryId === draft.opponentSkillCategoryId,
+              );
         const opponentSupportSkillOptions =
           draft.opponentSupportSkillCategoryId === "all"
             ? opponentSkillOptions
-            : opponentSkillOptions.filter((skill) => skill.categoryId === draft.opponentSupportSkillCategoryId);
-        const nextSkillId =
-          filteredSkillOptions.some((skill) => skill.id === draft.skillId)
-            ? draft.skillId
-            : filteredSkillOptions[0]?.id ?? skillOptions[0]?.id ?? "";
+            : opponentSkillOptions.filter(
+                (skill) => skill.categoryId === draft.opponentSupportSkillCategoryId,
+              );
+        const nextSkillId = filteredSkillOptions.some((skill) => skill.id === draft.skillId)
+          ? draft.skillId
+          : (filteredSkillOptions[0]?.id ?? skillOptions[0]?.id ?? "");
         const nextSelectedSkill = skillOptions.find((skill) => skill.id === nextSkillId);
         const nextOpponentSkillId =
           !draft.opponentBlockOpen || draft.opponentSkillId === ""
@@ -635,7 +670,9 @@ export function GmRoleplayingEncounterScreen({
             : filteredOpponentSkillOptions.some((skill) => skill.id === draft.opponentSkillId)
               ? draft.opponentSkillId
               : "";
-        const nextSelectedOpponentSkill = opponentSkillOptions.find((skill) => skill.id === nextOpponentSkillId);
+        const nextSelectedOpponentSkill = opponentSkillOptions.find(
+          (skill) => skill.id === nextOpponentSkillId,
+        );
 
         return {
           ...draft,
@@ -658,11 +695,12 @@ export function GmRoleplayingEncounterScreen({
           participantId: participant?.id ?? "",
           skillId: nextSkillId,
           supportSkillId:
-            draft.supportSkillId === "" || supportSkillOptions.some((skill) => skill.id === draft.supportSkillId)
+            draft.supportSkillId === "" ||
+            supportSkillOptions.some((skill) => skill.id === draft.supportSkillId)
               ? draft.supportSkillId
               : "",
         };
-      })
+      }),
     );
   }, [content, roster, scenarioParticipants]);
 
@@ -676,7 +714,7 @@ export function GmRoleplayingEncounterScreen({
         message: gmMessageDraft,
         session: encounter,
       }),
-      "Updated roleplaying encounter GM message."
+      "Updated roleplaying encounter GM message.",
     );
     setGmMessageDirty(false);
   }
@@ -691,7 +729,7 @@ export function GmRoleplayingEncounterScreen({
         session: encounter,
         ...input,
       }),
-      "Updated roleplaying visibility."
+      "Updated roleplaying visibility.",
     );
   }
 
@@ -702,7 +740,7 @@ export function GmRoleplayingEncounterScreen({
         session: encounter,
         viewerParticipantId,
       }),
-      "Updated roleplaying visibility row."
+      "Updated roleplaying visibility row.",
     );
   }
 
@@ -716,13 +754,13 @@ export function GmRoleplayingEncounterScreen({
         participantId: input.participantId,
         session: encounter,
       }),
-      "Updated roleplaying participant description."
+      "Updated roleplaying participant description.",
     );
   }
 
   function updateRollDraft(draftId: string, patch: Partial<RoleplayRollDraft>) {
     setRollDrafts((currentDrafts) =>
-      currentDrafts.map((draft) => (draft.id === draftId ? { ...draft, ...patch } : draft))
+      currentDrafts.map((draft) => (draft.id === draftId ? { ...draft, ...patch } : draft)),
     );
   }
 
@@ -752,7 +790,7 @@ export function GmRoleplayingEncounterScreen({
           skillCategoryId: "all",
           skillId: nextSkillId,
         };
-      })
+      }),
     );
   }
 
@@ -772,18 +810,20 @@ export function GmRoleplayingEncounterScreen({
         rollSetId: nextRollStackId,
         session: encounter,
       }),
-      "Cleared roleplaying ranked roll stack."
+      "Cleared roleplaying ranked roll stack.",
     );
   }
 
   function rankVisibleRollResults(entries: RoleplayActionLogEntry[]): RoleplayActionLogEntry[] {
-    return entries.filter((entry) => entry.mode !== "opposed").sort(
-      (left, right) =>
-        Number(Boolean(left.fumble)) - Number(Boolean(right.fumble)) ||
-        (right.numericSubtotal ?? Number.NEGATIVE_INFINITY) -
-          (left.numericSubtotal ?? Number.NEGATIVE_INFINITY) ||
-        right.createdAt.localeCompare(left.createdAt)
-    );
+    return entries
+      .filter((entry) => entry.mode !== "opposed")
+      .sort(
+        (left, right) =>
+          Number(Boolean(left.fumble)) - Number(Boolean(right.fumble)) ||
+          (right.numericSubtotal ?? Number.NEGATIVE_INFINITY) -
+            (left.numericSubtotal ?? Number.NEGATIVE_INFINITY) ||
+          right.createdAt.localeCompare(left.createdAt),
+      );
   }
 
   function replaceDraftRankedRollResults(draftId: string, entries: RoleplayActionLogEntry[]) {
@@ -792,7 +832,7 @@ export function GmRoleplayingEncounterScreen({
       rankVisibleRollResults([
         ...entries,
         ...currentEntries.filter((entry) => !entry.id.startsWith(draftPrefix)),
-      ])
+      ]),
     );
   }
 
@@ -855,7 +895,8 @@ export function GmRoleplayingEncounterScreen({
       draft.skillCategoryId === "all"
         ? allSkillOptions
         : allSkillOptions.filter((skill) => skill.categoryId === draft.skillCategoryId);
-    const selectedSkill = skillOptions.find((skill) => skill.id === draft.skillId) ?? skillOptions[0];
+    const selectedSkill =
+      skillOptions.find((skill) => skill.id === draft.skillId) ?? skillOptions[0];
     const supportSkillOptions =
       draft.supportSkillCategoryId === "all"
         ? allSkillOptions
@@ -864,8 +905,7 @@ export function GmRoleplayingEncounterScreen({
       draft.supportSkillId === ""
         ? undefined
         : supportSkillOptions.find((skill) => skill.id === draft.supportSkillId);
-    const opponent =
-      roster.find((row) => row.id === draft.opponentParticipantId) ?? undefined;
+    const opponent = roster.find((row) => row.id === draft.opponentParticipantId) ?? undefined;
     const allOpponentSkillOptions = readSystemSkillOptions({
       content,
       encounterParticipant: opponent,
@@ -874,15 +914,18 @@ export function GmRoleplayingEncounterScreen({
     const opponentSkillOptions =
       draft.opponentSkillCategoryId === "all"
         ? allOpponentSkillOptions
-        : allOpponentSkillOptions.filter((skill) => skill.categoryId === draft.opponentSkillCategoryId);
-    const selectedOpponentSkill =
-      draft.opponentBlockOpen
-        ? opponentSkillOptions.find((skill) => skill.id === draft.opponentSkillId)
-        : undefined;
+        : allOpponentSkillOptions.filter(
+            (skill) => skill.categoryId === draft.opponentSkillCategoryId,
+          );
+    const selectedOpponentSkill = draft.opponentBlockOpen
+      ? opponentSkillOptions.find((skill) => skill.id === draft.opponentSkillId)
+      : undefined;
     const opponentSupportSkillOptions =
       draft.opponentSupportSkillCategoryId === "all"
         ? allOpponentSkillOptions
-        : allOpponentSkillOptions.filter((skill) => skill.categoryId === draft.opponentSupportSkillCategoryId);
+        : allOpponentSkillOptions.filter(
+            (skill) => skill.categoryId === draft.opponentSupportSkillCategoryId,
+          );
     const selectedOpponentSupportSkill =
       draft.opponentSupportSkillId === ""
         ? undefined
@@ -939,10 +982,11 @@ export function GmRoleplayingEncounterScreen({
     const matchingPendingRoll = matchingPendingRollCandidates.sort(
       (left, right) =>
         scorePendingRoll(right) - scorePendingRoll(left) ||
-        right.assignedAt.localeCompare(left.assignedAt)
+        right.assignedAt.localeCompare(left.assignedAt),
     )[0];
     const activeOpposedRollSetId = isOpposed ? draft.rollSetId : matchingPendingRoll?.rollSetId;
-    const activeRollSetId = activeOpposedRollSetId ?? matchingPendingRoll?.rollSetId ?? draft.rollSetId;
+    const activeRollSetId =
+      activeOpposedRollSetId ?? matchingPendingRoll?.rollSetId ?? draft.rollSetId;
     const matchingOpponentPendingRoll =
       activeOpposedRollSetId && opponent && selectedOpponentSkill
         ? roleplayState.pendingSkillRolls.find((roll) => {
@@ -1054,7 +1098,10 @@ export function GmRoleplayingEncounterScreen({
     };
   }
 
-  async function handleAssignSkillRoll(draft: RoleplayRollDraft, side: "actor" | "opponent" = "actor") {
+  async function handleAssignSkillRoll(
+    draft: RoleplayRollDraft,
+    side: "actor" | "opponent" = "actor",
+  ) {
     const {
       isOpposed,
       activeOpposedRollSetId,
@@ -1069,7 +1116,11 @@ export function GmRoleplayingEncounterScreen({
       selectedSupportSkill,
     } = getRollDraftContext(draft);
 
-    if (!participant || !selectedSkill || (side === "opponent" && (!opponent || !selectedOpponentSkill))) {
+    if (
+      !participant ||
+      !selectedSkill ||
+      (side === "opponent" && (!opponent || !selectedOpponentSkill))
+    ) {
       return;
     }
 
@@ -1090,9 +1141,7 @@ export function GmRoleplayingEncounterScreen({
           roll.skillId === selectedSkill.id
         );
       });
-    const duplicateOpponentAssignment =
-      assigningOpponent &&
-      Boolean(matchingOpponentPendingRoll);
+    const duplicateOpponentAssignment = assigningOpponent && Boolean(matchingOpponentPendingRoll);
 
     if (duplicateActorAssignment || duplicateOpponentAssignment) {
       return;
@@ -1100,17 +1149,24 @@ export function GmRoleplayingEncounterScreen({
 
     await persist(
       assignRoleplaySkillRoll({
-        difficulty: assigningOpponent || isOpposed || draft.difficulty === "none" ? undefined : draft.difficulty,
+        difficulty:
+          assigningOpponent || isOpposed || draft.difficulty === "none"
+            ? undefined
+            : draft.difficulty,
         mode: assigningOpponent || isOpposed ? "opposed" : "difficulty",
         otherMod: assigningOpponent ? opponentOtherMod : otherMod,
         opponentParticipantId: !assigningOpponent && isOpposed ? opponent?.id : undefined,
         opponentParticipantName: !assigningOpponent && isOpposed ? opponent?.label : undefined,
         opponentSilent: !assigningOpponent && isOpposed ? draft.opponentSilent : undefined,
         opponentSkillId: !assigningOpponent && isOpposed ? selectedOpponentSkill?.id : undefined,
-        opponentSkillLabel: !assigningOpponent && isOpposed ? selectedOpponentSkill?.label : undefined,
-        opponentSkillValue: !assigningOpponent && isOpposed ? selectedOpponentSkill?.value : undefined,
-        opponentSupportSkillId: !assigningOpponent && isOpposed ? selectedOpponentSupportSkill?.id : undefined,
-        opponentSupportSkillLabel: !assigningOpponent && isOpposed ? selectedOpponentSupportSkill?.label : undefined,
+        opponentSkillLabel:
+          !assigningOpponent && isOpposed ? selectedOpponentSkill?.label : undefined,
+        opponentSkillValue:
+          !assigningOpponent && isOpposed ? selectedOpponentSkill?.value : undefined,
+        opponentSupportSkillId:
+          !assigningOpponent && isOpposed ? selectedOpponentSupportSkill?.id : undefined,
+        opponentSupportSkillLabel:
+          !assigningOpponent && isOpposed ? selectedOpponentSupportSkill?.label : undefined,
         participantId: assigningOpponent ? opponent.id : participant.id,
         participantName: assigningOpponent ? opponent.label : participant.label,
         rollSetId: assigningOpponent || isOpposed ? activeOpposedRollSetId : draft.rollSetId,
@@ -1120,18 +1176,27 @@ export function GmRoleplayingEncounterScreen({
         skillId: assigningOpponent ? selectedOpponentSkill.id : selectedSkill.id,
         skillLabel: assigningOpponent ? selectedOpponentSkill.label : selectedSkill.label,
         skillValue: assigningOpponent ? selectedOpponentSkill.value : selectedSkill.value,
-        supportSkillId: assigningOpponent ? selectedOpponentSupportSkill?.id : selectedSupportSkill?.id,
-        supportSkillLabel: assigningOpponent ? selectedOpponentSupportSkill?.label : selectedSupportSkill?.label,
-        supportSkillValue: assigningOpponent ? selectedOpponentSupportSkill?.value : selectedSupportSkill?.value,
+        supportSkillId: assigningOpponent
+          ? selectedOpponentSupportSkill?.id
+          : selectedSupportSkill?.id,
+        supportSkillLabel: assigningOpponent
+          ? selectedOpponentSupportSkill?.label
+          : selectedSupportSkill?.label,
+        supportSkillValue: assigningOpponent
+          ? selectedOpponentSupportSkill?.value
+          : selectedSupportSkill?.value,
         useDbMod: assigningOpponent ? draft.opponentUseDbMod : draft.useDbMod,
         useGenMod: assigningOpponent ? draft.opponentUseGenMod : draft.useGenMod,
         useObSkillMod: assigningOpponent ? draft.opponentUseObSkillMod : draft.useObSkillMod,
       }),
-      "Assigned roleplaying skill roll."
+      "Assigned roleplaying skill roll.",
     );
   }
 
-  async function handleGmRoll(draft: RoleplayRollDraft, side: "actor" | "opponent" | "both" = "actor") {
+  async function handleGmRoll(
+    draft: RoleplayRollDraft,
+    side: "actor" | "opponent" | "both" = "actor",
+  ) {
     const {
       isOpposed,
       activeRollSetId,
@@ -1161,9 +1226,7 @@ export function GmRoleplayingEncounterScreen({
     const roll = shouldRollActor ? rollOpenEndedRoleplayD20() : draft.actorRoll;
     const opponentRoll = shouldRollOpponent ? rollOpenEndedRoleplayD20() : draft.opponentRoll;
     const actorSupportRoll =
-      shouldRollActor && selectedSupportSkill
-        ? rollOpenEndedRoleplayD20()
-        : draft.actorSupportRoll;
+      shouldRollActor && selectedSupportSkill ? rollOpenEndedRoleplayD20() : draft.actorSupportRoll;
     const opponentSupportRoll =
       shouldRollOpponent && selectedOpponentSupportSkill
         ? rollOpenEndedRoleplayD20()
@@ -1183,19 +1246,18 @@ export function GmRoleplayingEncounterScreen({
       opponentRoll,
       opponentSupportRoll,
     });
-    const preview =
-      roll
-        ? buildRoleplayCalculationPreview({
-            difficulty: isOpposed || draft.difficulty === "none" ? undefined : draft.difficulty,
-            otherMod,
-            roll,
-            skillLabel: selectedSkill.label,
-            skillValue: selectedSkill.value,
-            useDbMod: draft.useDbMod,
-            useGenMod: draft.useGenMod,
-            useObSkillMod: draft.useObSkillMod,
-          })
-        : undefined;
+    const preview = roll
+      ? buildRoleplayCalculationPreview({
+          difficulty: isOpposed || draft.difficulty === "none" ? undefined : draft.difficulty,
+          otherMod,
+          roll,
+          skillLabel: selectedSkill.label,
+          skillValue: selectedSkill.value,
+          useDbMod: draft.useDbMod,
+          useGenMod: draft.useGenMod,
+          useObSkillMod: draft.useObSkillMod,
+        })
+      : undefined;
     const opponentPreview =
       opponentRoll && selectedOpponentSkill
         ? buildRoleplayCalculationPreview({
@@ -1234,12 +1296,22 @@ export function GmRoleplayingEncounterScreen({
           })
         : undefined;
 
-    if (side === "opponent" && opponent && selectedOpponentSkill && opponentRoll && opponentPreview) {
+    if (
+      side === "opponent" &&
+      opponent &&
+      selectedOpponentSkill &&
+      opponentRoll &&
+      opponentPreview
+    ) {
       await persist(
         recordRoleplayGmSkillRoll({
           calculationText: [
-            opponentSupportPreview ? `support ${opponentSupportPreview.calculationText}` : undefined,
-            selectedOpponentSupportSkill && !opponentSupportPreview ? `Support: ${selectedOpponentSupportSkill.label}` : undefined,
+            opponentSupportPreview
+              ? `support ${opponentSupportPreview.calculationText}`
+              : undefined,
+            selectedOpponentSupportSkill && !opponentSupportPreview
+              ? `Support: ${selectedOpponentSupportSkill.label}`
+              : undefined,
             opponentPreview.calculationText,
           ]
             .filter(Boolean)
@@ -1276,12 +1348,22 @@ export function GmRoleplayingEncounterScreen({
           useGenMod: draft.opponentUseGenMod,
           useObSkillMod: draft.opponentUseObSkillMod,
         }),
-        "Recorded GM roleplaying skill roll."
+        "Recorded GM roleplaying skill roll.",
       );
-    } else if (side === "both" && opponent && selectedOpponentSkill && roll && opponentRoll && preview && opponentPreview) {
+    } else if (
+      side === "both" &&
+      opponent &&
+      selectedOpponentSkill &&
+      roll &&
+      opponentRoll &&
+      preview &&
+      opponentPreview
+    ) {
       const calculationText = [
         supportPreview ? `actor support ${supportPreview.calculationText}` : undefined,
-        opponentSupportPreview ? `opponent support ${opponentSupportPreview.calculationText}` : undefined,
+        opponentSupportPreview
+          ? `opponent support ${opponentSupportPreview.calculationText}`
+          : undefined,
         `Actor: ${preview.calculationText} · VERSUS · Opponent: ${opponentPreview.calculationText} · ${opposedResult?.summary ?? "Opposed result pending."}`,
       ]
         .filter(Boolean)
@@ -1336,14 +1418,16 @@ export function GmRoleplayingEncounterScreen({
           useGenMod: draft.useGenMod,
           useObSkillMod: draft.useObSkillMod,
         }),
-        "Recorded GM roleplaying skill roll."
+        "Recorded GM roleplaying skill roll.",
       );
     } else if (roll && preview) {
       await persist(
         recordRoleplayGmSkillRoll({
           calculationText: [
             supportPreview ? `support ${supportPreview.calculationText}` : undefined,
-            selectedSupportSkill && !supportPreview ? `Support: ${selectedSupportSkill.label}` : undefined,
+            selectedSupportSkill && !supportPreview
+              ? `Support: ${selectedSupportSkill.label}`
+              : undefined,
             preview.calculationText,
           ]
             .filter(Boolean)
@@ -1382,7 +1466,7 @@ export function GmRoleplayingEncounterScreen({
           useGenMod: draft.useGenMod,
           useObSkillMod: draft.useObSkillMod,
         }),
-        "Recorded GM roleplaying skill roll."
+        "Recorded GM roleplaying skill roll.",
       );
     }
 
@@ -1414,10 +1498,10 @@ export function GmRoleplayingEncounterScreen({
       !entry.side &&
       !entry.silent &&
       entry.rollSetId === currentGmRollStackId &&
-      entry.numericSubtotal != null
+      entry.numericSubtotal != null,
   );
   const rankedRollResults = rankVisibleRollResults(
-    dedupeRankedRoleplayEntries([...currentRankedRollResults, ...serverRankedRollResults])
+    dedupeRankedRoleplayEntries([...currentRankedRollResults, ...serverRankedRollResults]),
   );
   const showEncounterContext = surface !== "skill-rolls";
   const showSkillRollTools = surface !== "encounter";
@@ -1473,7 +1557,14 @@ export function GmRoleplayingEncounterScreen({
       {showSkillRollTools ? (
         <>
           <section style={panelStyle}>
-            <div style={{ alignItems: "center", display: "flex", justifyContent: "space-between", gap: "0.75rem" }}>
+            <div
+              style={{
+                alignItems: "center",
+                display: "flex",
+                justifyContent: "space-between",
+                gap: "0.75rem",
+              }}
+            >
               <h2 style={{ margin: 0 }}>Skill roll assignment</h2>
               <button onClick={() => void resetRollDrafts()} type="button">
                 Clear
@@ -1525,8 +1616,9 @@ export function GmRoleplayingEncounterScreen({
               </button>
             </div>
             <div style={{ color: "#5e5a50" }}>
-              GM Roll uses the roleplay open-ended d20 table for non-opposed skill rolls.
-              Gen, OB/Skill, and DB flags remain visible placeholder modifiers until numeric sources are defined.
+              GM Roll uses the roleplay open-ended d20 table for non-opposed skill rolls. Gen,
+              OB/Skill, and DB flags remain visible placeholder modifiers until numeric sources are
+              defined.
             </div>
           </section>
 
@@ -1543,7 +1635,10 @@ export function PlayerRoleplayingEncounterScreen({
   campaignId,
   embedded = false,
   encounterId,
+  inspectionParticipantId,
+  readOnlyInspection = false,
   scenarioId,
+  showWorkspaceHeader = true,
   surface = "full",
 }: PlayerRoleplayingEncounterScreenProps) {
   const [campaign, setCampaign] = useState<Campaign | null>(null);
@@ -1553,40 +1648,51 @@ export function PlayerRoleplayingEncounterScreen({
   const [scenario, setScenario] = useState<Scenario | null>(null);
   const [scenarioParticipants, setScenarioParticipants] = useState<ScenarioParticipant[]>([]);
   const [loading, setLoading] = useState(true);
-  const [dismissedAssignedRollIds, setDismissedAssignedRollIds] = useState<Set<string>>(() => new Set());
-  const [dismissedRankedResultIds, setDismissedRankedResultIds] = useState<Set<string>>(() => new Set());
+  const [dismissedAssignedRollIds, setDismissedAssignedRollIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [dismissedRankedResultIds, setDismissedRankedResultIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [localRankedResults, setLocalRankedResults] = useState<PlayerVisibleRankedResult[]>([]);
   const [playerLocalRollDraft, setPlayerLocalRollDraft] = useState<PlayerLocalRollDraft>(() =>
-    makePlayerLocalRollDraft()
+    makePlayerLocalRollDraft(),
   );
   const [playerLocalRollRoundId, setPlayerLocalRollRoundId] = useState(
-    () => `player-local-roll-set-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    () => `player-local-roll-set-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
   );
   const { currentUser } = useSessionUser();
+  const isGameMaster = Boolean(
+    currentUser?.roles.includes("game_master") || currentUser?.roles.includes("admin"),
+  );
+  const inspectedParticipantId =
+    readOnlyInspection && isGameMaster ? inspectionParticipantId : undefined;
   const situationRef = useRef<HTMLDivElement>(null);
 
-  const fetchRoleplayEncounter = useCallback(
-    async () => {
-      const [nextEncounter, nextScenario, nextCampaign, nextParticipants, nextContent] = await Promise.all([
+  const fetchRoleplayEncounter = useCallback(async () => {
+    const [nextEncounter, nextScenario, nextCampaign, nextParticipants, nextContent] =
+      await Promise.all([
         loadEncounterById(encounterId),
         loadScenarioById(scenarioId),
         loadCampaignById(campaignId).catch(() => null),
         currentUser
-          ? loadScenarioMyParticipant(scenarioId).then((participant) => (participant ? [participant] : []))
+          ? inspectedParticipantId
+            ? loadScenarioParticipants(scenarioId)
+            : loadScenarioMyParticipant(scenarioId).then((participant) =>
+                participant ? [participant] : [],
+              )
           : Promise.resolve([]),
         loadCanonicalContent(),
       ]);
 
-      return {
-        nextCampaign,
-        nextContent,
-        nextEncounter,
-        nextParticipants,
-        nextScenario,
-      };
-    },
-    [campaignId, currentUser, encounterId, scenarioId]
-  );
+    return {
+      nextCampaign,
+      nextContent,
+      nextEncounter,
+      nextParticipants,
+      nextScenario,
+    };
+  }, [campaignId, currentUser, encounterId, inspectedParticipantId, scenarioId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1661,7 +1767,7 @@ export function PlayerRoleplayingEncounterScreen({
     }
 
     setLocalRankedResults((currentResults) =>
-      currentResults.filter((entry) => entry.rollSetId === activeStackId)
+      currentResults.filter((entry) => entry.rollSetId === activeStackId),
     );
   }, [encounter?.roleplayState?.currentRankedRollStackId]);
 
@@ -1674,6 +1780,7 @@ export function PlayerRoleplayingEncounterScreen({
   }
 
   const playerView = buildPlayerGeneralEncounterView({
+    controlledScenarioParticipantId: inspectedParticipantId ?? undefined,
     currentUserId: currentUser?.id,
     encounter,
     scenarioParticipants,
@@ -1714,20 +1821,30 @@ export function PlayerRoleplayingEncounterScreen({
   }
 
   const visibleAssignedRolls = playerView.assignedRolls.filter(
-    (roll) => !dismissedAssignedRollIds.has(roll.id)
+    (roll) => !dismissedAssignedRollIds.has(roll.id),
   );
   const readModelRankedResults = playerView.rankedResults.filter(
-    (entry) => !dismissedRankedResultIds.has(entry.id)
+    (entry) => !dismissedRankedResultIds.has(entry.id),
   );
   const activeRankedStackId = playerView.currentRollRoundId;
   const localVisibleRankedResults = activeRankedStackId
     ? localRankedResults.filter((entry) => entry.rollSetId === activeRankedStackId)
     : localRankedResults;
-  const visibleRankedResults = mergePlayerVisibleResults(localVisibleRankedResults, readModelRankedResults);
+  const visibleRankedResults = mergePlayerVisibleResults(
+    localVisibleRankedResults,
+    readModelRankedResults,
+  );
   const unresolvedAssignedRolls = visibleAssignedRolls.filter((roll) => !roll.result);
   const controlledParticipant = effectivePlayerEncounterParticipants.find(
-    (participant) => participant.id === playerView.controlledParticipantIds[0]
+    (participant) => participant.id === playerView.controlledParticipantIds[0],
   );
+  const selectedPlayerFacingName =
+    controlledParticipant?.label ??
+    (inspectedParticipantId
+      ? scenarioParticipants.find((participant) => participant.id === inspectedParticipantId)
+          ?.snapshot.displayName
+      : undefined);
+  const canUsePlayerActions = !readOnlyInspection;
   const localAllSkillOptions = readSystemSkillOptions({
     content,
     encounterParticipant: controlledParticipant,
@@ -1736,13 +1853,18 @@ export function PlayerRoleplayingEncounterScreen({
   const localSkillOptions =
     playerLocalRollDraft.skillCategoryId === "all"
       ? localAllSkillOptions
-      : localAllSkillOptions.filter((skill) => skill.categoryId === playerLocalRollDraft.skillCategoryId);
+      : localAllSkillOptions.filter(
+          (skill) => skill.categoryId === playerLocalRollDraft.skillCategoryId,
+        );
   const localSelectedSkill =
-    localSkillOptions.find((skill) => skill.id === playerLocalRollDraft.skillId) ?? localSkillOptions[0];
+    localSkillOptions.find((skill) => skill.id === playerLocalRollDraft.skillId) ??
+    localSkillOptions[0];
   const localSupportSkillOptions =
     playerLocalRollDraft.supportSkillCategoryId === "all"
       ? localAllSkillOptions
-      : localAllSkillOptions.filter((skill) => skill.categoryId === playerLocalRollDraft.supportSkillCategoryId);
+      : localAllSkillOptions.filter(
+          (skill) => skill.categoryId === playerLocalRollDraft.supportSkillCategoryId,
+        );
   const localSelectedSupportSkill =
     playerLocalRollDraft.supportSkillId === ""
       ? undefined
@@ -1780,6 +1902,10 @@ export function PlayerRoleplayingEncounterScreen({
     : undefined;
 
   function handleClearAssignedRolls() {
+    if (readOnlyInspection) {
+      return;
+    }
+
     if (unresolvedAssignedRolls.length > 0) {
       return;
     }
@@ -1804,10 +1930,16 @@ export function PlayerRoleplayingEncounterScreen({
     });
     setLocalRankedResults([]);
     setPlayerLocalRollDraft(makePlayerLocalRollDraft({ skillId: localAllSkillOptions[0]?.id }));
-    setPlayerLocalRollRoundId(`player-local-roll-set-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    setPlayerLocalRollRoundId(
+      `player-local-roll-set-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    );
   }
 
   async function handlePlayerRoll(rollId: string) {
+    if (readOnlyInspection) {
+      return;
+    }
+
     const roleplayState = normalizeRoleplayState(encounter as EncounterSession);
     const pendingRoll = roleplayState.pendingSkillRolls.find((roll) => roll.id === rollId);
 
@@ -1851,28 +1983,42 @@ export function PlayerRoleplayingEncounterScreen({
           {
             id: `player-roll-${pendingRoll.id}-${roll.rollD20}-${roll.dieResult}`,
             participantId: participant.id,
-            participantName: playerView.assignedRolls.find((entry) => entry.id === pendingRoll.id)?.participantName ?? participant.label,
+            participantName:
+              playerView.assignedRolls.find((entry) => entry.id === pendingRoll.id)
+                ?.participantName ?? participant.label,
             pendingRollId: pendingRoll.id,
             rollSetId: pendingRoll.rollSetId,
             skillId: pendingRoll.skillId,
             skillLabel: pendingRoll.skillLabel,
             total: preview.numericSubtotal ?? preview.finalTotal ?? 0,
           },
-        ])
+        ]),
       );
     }
-    setFeedback(`Rolled ${pendingRoll.skillLabel}: total ${preview.numericSubtotal ?? "unresolved"}.`);
+    setFeedback(
+      `Rolled ${pendingRoll.skillLabel}: total ${preview.numericSubtotal ?? "unresolved"}.`,
+    );
   }
 
   async function handleLocalPlayerRoll() {
-    if (!encounter || !controlledParticipant || !localSelectedSkill || playerLocalRollDraft.opponentParticipantId) {
+    if (readOnlyInspection) {
+      return;
+    }
+
+    if (
+      !encounter ||
+      !controlledParticipant ||
+      !localSelectedSkill ||
+      playerLocalRollDraft.opponentParticipantId
+    ) {
       return;
     }
 
     const roll = rollOpenEndedRoleplayD20();
     const supportRoll = localSelectedSupportSkill ? rollOpenEndedRoleplayD20() : undefined;
     const preview = buildRoleplayCalculationPreview({
-      difficulty: playerLocalRollDraft.difficulty === "none" ? undefined : playerLocalRollDraft.difficulty,
+      difficulty:
+        playerLocalRollDraft.difficulty === "none" ? undefined : playerLocalRollDraft.difficulty,
       otherMod: localOtherMod,
       roll,
       skillLabel: localSelectedSkill.label,
@@ -1898,9 +2044,11 @@ export function PlayerRoleplayingEncounterScreen({
           skillLabel: localSelectedSkill.label,
           total: preview.numericSubtotal ?? preview.finalTotal ?? 0,
         },
-      ])
+      ]),
     );
-    setFeedback(`Rolled ${localSelectedSkill.label}: total ${preview.numericSubtotal ?? "unresolved"}.`);
+    setFeedback(
+      `Rolled ${localSelectedSkill.label}: total ${preview.numericSubtotal ?? "unresolved"}.`,
+    );
   }
   return (
     <section style={{ display: "grid", gap: "1rem", maxWidth: 980 }}>
@@ -1914,6 +2062,14 @@ export function PlayerRoleplayingEncounterScreen({
         <Link href={buildCampaignWorkspaceHref({ campaignId, scenarioId, tab: "scenario" })}>
           Back to scenario
         </Link>
+      ) : null}
+      {showWorkspaceHeader && showSkillRollTools ? (
+        <section style={panelStyle}>
+          <h2 style={{ margin: 0 }}>
+            Skill rolls{selectedPlayerFacingName ? ` — ${selectedPlayerFacingName}` : ""}
+          </h2>
+          {readOnlyInspection ? <div>GM player-view inspection is read-only.</div> : null}
+        </section>
       ) : null}
       {feedback ? <section style={panelStyle}>{feedback}</section> : null}
       {showEncounterContext ? (
@@ -1987,88 +2143,282 @@ export function PlayerRoleplayingEncounterScreen({
 
       {showSkillRollTools ? (
         <>
-      <section style={panelStyle}>
-        <div style={{ alignItems: "center", display: "flex", justifyContent: "space-between", gap: "0.75rem" }}>
-          <h2 style={{ margin: 0 }}>Skill roll grid</h2>
-          <button disabled={unresolvedAssignedRolls.length > 0} onClick={handleClearAssignedRolls} type="button">
-            Clear
-          </button>
-        </div>
-        {visibleAssignedRolls.length > 0 ? (
-          <div style={{ display: "grid", gap: "0.75rem" }}>
-            {visibleAssignedRolls.map((roll, index) => {
-              const contentSkill = content?.skills.find((skill) => skill.id === roll.skillId);
-              const assignedParticipant = resolveEncounterParticipantByRollParticipantId({
-                participantId: roll.participantId,
-                participants: effectivePlayerEncounterParticipants,
-              });
-              const assignedSkillProfile =
-                contentSkill && assignedParticipant
-                  ? getSkillRollProfile({
-                      content,
-                      encounterParticipant: assignedParticipant,
-                      scenarioParticipants,
-                      skill: contentSkill,
-                    })
-                  : undefined;
-              const assignedSupportSkill = content?.skills.find((skill) => skill.id === roll.supportSkillId);
-              const assignedSupportSkillProfile =
-                assignedSupportSkill && assignedParticipant
-                  ? getSkillRollProfile({
-                      content,
-                      encounterParticipant: assignedParticipant,
-                      scenarioParticipants,
-                      skill: assignedSupportSkill,
-                    })
-                  : undefined;
-              const categoryLabel = contentSkill
-                ? getPlayerFacingSkillBucketDefinitions().find(
-                    (category) => category.id === getPlayerFacingSkillBucket(contentSkill)
-                  )?.label ?? "Assigned"
-                : "Assigned";
-              const resultRoll = buildPlayerRollResult(roll.result);
-              const supportResultRoll = buildPlayerRollResult(roll.supportResult);
-              const mainPreview = buildRoleplayCalculationPreview({
-                difficulty: roll.mode === "difficulty" ? roll.difficulty : undefined,
-                otherMod: roll.otherMod,
-                roll: resultRoll,
-                skillLabel: roll.skillLabel,
-                skillValue: roll.skillValue,
-                useDbMod: roll.useDbMod,
-                useGenMod: roll.useGenMod,
-                useObSkillMod: roll.useObSkillMod,
-              });
-              const supportPreview = roll.supportSkillLabel
-                ? buildRoleplayCalculationPreview({
-                    roll: supportResultRoll,
-                    skillLabel: roll.supportSkillLabel,
-                    skillValue: assignedSupportSkillProfile?.rollBaseValue ?? roll.supportSkillValue,
-                  })
-                : undefined;
+          <section style={panelStyle}>
+            <div
+              style={{
+                alignItems: "center",
+                display: "flex",
+                justifyContent: "space-between",
+                gap: "0.75rem",
+              }}
+            >
+              <h2 style={{ margin: 0 }}>Skill roll grid</h2>
+              <button
+                disabled={readOnlyInspection || unresolvedAssignedRolls.length > 0}
+                onClick={handleClearAssignedRolls}
+                type="button"
+              >
+                Clear
+              </button>
+            </div>
+            {visibleAssignedRolls.length > 0 ? (
+              <div style={{ display: "grid", gap: "0.75rem" }}>
+                {visibleAssignedRolls.map((roll, index) => {
+                  const contentSkill = content?.skills.find((skill) => skill.id === roll.skillId);
+                  const assignedParticipant = resolveEncounterParticipantByRollParticipantId({
+                    participantId: roll.participantId,
+                    participants: effectivePlayerEncounterParticipants,
+                  });
+                  const assignedSkillProfile =
+                    contentSkill && assignedParticipant
+                      ? getSkillRollProfile({
+                          content,
+                          encounterParticipant: assignedParticipant,
+                          scenarioParticipants,
+                          skill: contentSkill,
+                        })
+                      : undefined;
+                  const assignedSupportSkill = content?.skills.find(
+                    (skill) => skill.id === roll.supportSkillId,
+                  );
+                  const assignedSupportSkillProfile =
+                    assignedSupportSkill && assignedParticipant
+                      ? getSkillRollProfile({
+                          content,
+                          encounterParticipant: assignedParticipant,
+                          scenarioParticipants,
+                          skill: assignedSupportSkill,
+                        })
+                      : undefined;
+                  const categoryLabel = contentSkill
+                    ? (getPlayerFacingSkillBucketDefinitions().find(
+                        (category) => category.id === getPlayerFacingSkillBucket(contentSkill),
+                      )?.label ?? "Assigned")
+                    : "Assigned";
+                  const resultRoll = buildPlayerRollResult(roll.result);
+                  const supportResultRoll = buildPlayerRollResult(roll.supportResult);
+                  const mainPreview = buildRoleplayCalculationPreview({
+                    difficulty: roll.mode === "difficulty" ? roll.difficulty : undefined,
+                    otherMod: roll.otherMod,
+                    roll: resultRoll,
+                    skillLabel: roll.skillLabel,
+                    skillValue: roll.skillValue,
+                    useDbMod: roll.useDbMod,
+                    useGenMod: roll.useGenMod,
+                    useObSkillMod: roll.useObSkillMod,
+                  });
+                  const supportPreview = roll.supportSkillLabel
+                    ? buildRoleplayCalculationPreview({
+                        roll: supportResultRoll,
+                        skillLabel: roll.supportSkillLabel,
+                        skillValue:
+                          assignedSupportSkillProfile?.rollBaseValue ?? roll.supportSkillValue,
+                      })
+                    : undefined;
 
-              return (
-                <div key={roll.id} style={rollBlockShellStyle}>
-                  <strong>Assigned roll {index + 1} · {roll.participantName}</strong>
+                  return (
+                    <div key={roll.id} style={rollBlockShellStyle}>
+                      <strong>
+                        Assigned roll {index + 1} · {roll.participantName}
+                      </strong>
+                      <section style={rollEditorStyle}>
+                        <div style={rollControlsStackStyle}>
+                          <section style={rollControlsStyle}>
+                            <div style={rollControlRowStyle}>
+                              <span>Use:</span>
+                              <label>
+                                <input checked={roll.useGenMod} disabled readOnly type="checkbox" />{" "}
+                                Gen
+                              </label>
+                              <label>
+                                <input
+                                  checked={roll.useObSkillMod}
+                                  disabled
+                                  readOnly
+                                  type="checkbox"
+                                />{" "}
+                                OB/Skill
+                              </label>
+                              <label>
+                                <input checked={roll.useDbMod} disabled readOnly type="checkbox" />{" "}
+                                DB
+                              </label>
+                              <label style={compactControlStyle}>
+                                <span>Other mod</span>
+                                <input
+                                  readOnly
+                                  style={{ ...compactInputStyle, width: "4.5rem" }}
+                                  value={roll.otherMod}
+                                />
+                              </label>
+                            </div>
+                            <div style={rollFieldRowStyle}>
+                              <div style={playerRollSkillColumnsStyle}>
+                                <label style={compactControlStyle}>
+                                  <span>Category</span>
+                                  <select disabled style={compactInputStyle} value={categoryLabel}>
+                                    <option value={categoryLabel}>{categoryLabel}</option>
+                                  </select>
+                                </label>
+                                <label style={compactControlStyle}>
+                                  <span>Skill</span>
+                                  <select
+                                    disabled
+                                    style={compactSkillInputStyle}
+                                    value={roll.skillId}
+                                  >
+                                    <option value={roll.skillId}>
+                                      {roll.skillLabel} ({roll.skillValue ?? 0})
+                                    </option>
+                                  </select>
+                                </label>
+                                <label style={compactControlStyle}>
+                                  <span>Support category</span>
+                                  <select disabled style={compactInputStyle} value="assigned">
+                                    <option value="assigned">
+                                      {roll.supportSkillLabel ? "Assigned" : "None"}
+                                    </option>
+                                  </select>
+                                </label>
+                                <label style={compactControlStyle}>
+                                  <span>Support</span>
+                                  <select
+                                    disabled
+                                    style={compactSkillInputStyle}
+                                    value={roll.supportSkillLabel ?? ""}
+                                  >
+                                    <option value={roll.supportSkillLabel ?? ""}>
+                                      {roll.supportSkillLabel ?? "No support skill"}
+                                    </option>
+                                  </select>
+                                </label>
+                              </div>
+                            </div>
+                            <div style={rollFieldRowStyle}>
+                              <label style={compactControlStyle}>
+                                <span>Level</span>
+                                <select
+                                  disabled
+                                  style={compactInputStyle}
+                                  value={roll.difficultyLabel}
+                                >
+                                  <option value={roll.difficultyLabel}>
+                                    {roll.difficultyLabel}
+                                  </option>
+                                </select>
+                              </label>
+                              <label style={compactControlStyle}>
+                                <span>Opponent</span>
+                                <input
+                                  readOnly
+                                  style={compactInputStyle}
+                                  value={
+                                    roll.mode === "opposed"
+                                      ? (roll.opponentLabel ?? "Opposed")
+                                      : "No opponent"
+                                  }
+                                />
+                              </label>
+                              <button
+                                disabled={!canUsePlayerActions || Boolean(roll.result)}
+                                onClick={() => void handlePlayerRoll(roll.id)}
+                                type="button"
+                              >
+                                {roll.supportSkillLabel ? "Roll both 1d20s" : "Roll 1d20"}
+                              </button>
+                            </div>
+                            {assignedSkillProfile && !assignedSkillProfile.known ? (
+                              <div style={{ color: "#8a5a00", fontSize: "0.85rem" }}>
+                                Skill not known (-3 default).
+                              </div>
+                            ) : null}
+                            {assignedSupportSkillProfile && !assignedSupportSkillProfile.known ? (
+                              <div style={{ color: "#8a5a00", fontSize: "0.85rem" }}>
+                                {assignedSupportSkillProfile.skillName}: Skill not known (-3
+                                default).
+                              </div>
+                            ) : null}
+                          </section>
+                        </div>
+                        <RoleplayRollCalculationPanel
+                          actorDifficulty={roll.mode === "difficulty" ? roll.difficulty : undefined}
+                          actorLabel={`Actor — ${roll.participantName}`}
+                          actorMainPreview={mainPreview}
+                          actorPendingLabels={mainPreview.pendingModifierLabels}
+                          actorSupportPreview={supportPreview}
+                          cleanPendingText
+                          comparison={roll.comparison}
+                          opponentOpen={false}
+                          showPendingLabels={false}
+                        />
+                      </section>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : (
+              <div style={{ display: "grid", gap: "0.75rem" }}>
+                <div>No skill rolls assigned.</div>
+                <div style={rollBlockShellStyle}>
+                  <strong>Local roll 1</strong>
                   <section style={rollEditorStyle}>
                     <div style={rollControlsStackStyle}>
                       <section style={rollControlsStyle}>
                         <div style={rollControlRowStyle}>
                           <span>Use:</span>
                           <label>
-                            <input checked={roll.useGenMod} disabled readOnly type="checkbox" /> Gen
+                            <input
+                              checked={playerLocalRollDraft.useGenMod}
+                              onChange={(event) =>
+                                setPlayerLocalRollDraft((currentDraft) => ({
+                                  ...currentDraft,
+                                  useGenMod: event.target.checked,
+                                }))
+                              }
+                              type="checkbox"
+                            />{" "}
+                            Gen
                           </label>
                           <label>
-                            <input checked={roll.useObSkillMod} disabled readOnly type="checkbox" /> OB/Skill
+                            <input
+                              checked={playerLocalRollDraft.useObSkillMod}
+                              onChange={(event) =>
+                                setPlayerLocalRollDraft((currentDraft) => ({
+                                  ...currentDraft,
+                                  useObSkillMod: event.target.checked,
+                                }))
+                              }
+                              type="checkbox"
+                            />{" "}
+                            OB/Skill
                           </label>
                           <label>
-                            <input checked={roll.useDbMod} disabled readOnly type="checkbox" /> DB
+                            <input
+                              checked={playerLocalRollDraft.useDbMod}
+                              onChange={(event) =>
+                                setPlayerLocalRollDraft((currentDraft) => ({
+                                  ...currentDraft,
+                                  useDbMod: event.target.checked,
+                                }))
+                              }
+                              type="checkbox"
+                            />{" "}
+                            DB
                           </label>
                           <label style={compactControlStyle}>
                             <span>Other mod</span>
                             <input
-                              readOnly
+                              onChange={(event) =>
+                                setPlayerLocalRollDraft((currentDraft) => ({
+                                  ...currentDraft,
+                                  otherModInput: event.target.value,
+                                  otherModTouched: true,
+                                  roll: undefined,
+                                }))
+                              }
                               style={{ ...compactInputStyle, width: "4.5rem" }}
-                              value={roll.otherMod}
+                              type="number"
+                              value={localOtherModInput}
                             />
                           </label>
                         </div>
@@ -2076,30 +2426,126 @@ export function PlayerRoleplayingEncounterScreen({
                           <div style={playerRollSkillColumnsStyle}>
                             <label style={compactControlStyle}>
                               <span>Category</span>
-                              <select disabled style={compactInputStyle} value={categoryLabel}>
-                                <option value={categoryLabel}>{categoryLabel}</option>
+                              <select
+                                onChange={(event) => {
+                                  const nextCategoryId = event.target
+                                    .value as PlayerLocalRollDraft["skillCategoryId"];
+                                  const nextSkillOptions =
+                                    nextCategoryId === "all"
+                                      ? localAllSkillOptions
+                                      : localAllSkillOptions.filter(
+                                          (skill) => skill.categoryId === nextCategoryId,
+                                        );
+
+                                  setPlayerLocalRollDraft((currentDraft) => ({
+                                    ...currentDraft,
+                                    otherModInput: applyUnknownSkillDefaultOtherMod({
+                                      currentValue: currentDraft.otherModInput,
+                                      selectedSkill: nextSkillOptions[0],
+                                      touched: currentDraft.otherModTouched,
+                                    }),
+                                    roll: undefined,
+                                    skillCategoryId: nextCategoryId,
+                                    skillId: nextSkillOptions[0]?.id ?? "",
+                                  }));
+                                }}
+                                style={compactInputStyle}
+                                value={playerLocalRollDraft.skillCategoryId}
+                              >
+                                <option value="all">All categories</option>
+                                {getPlayerFacingSkillBucketDefinitions()
+                                  .filter((category) =>
+                                    localAllSkillOptions.some(
+                                      (skill) => skill.categoryId === category.id,
+                                    ),
+                                  )
+                                  .map((category) => (
+                                    <option key={category.id} value={category.id}>
+                                      {category.label}
+                                    </option>
+                                  ))}
                               </select>
                             </label>
                             <label style={compactControlStyle}>
                               <span>Skill</span>
-                              <select disabled style={compactSkillInputStyle} value={roll.skillId}>
-                                <option value={roll.skillId}>
-                                  {roll.skillLabel} ({roll.skillValue ?? 0})
-                                </option>
+                              <select
+                                disabled={localSkillOptions.length === 0}
+                                onChange={(event) =>
+                                  setPlayerLocalRollDraft((currentDraft) => ({
+                                    ...currentDraft,
+                                    otherModInput: applyUnknownSkillDefaultOtherMod({
+                                      currentValue: currentDraft.otherModInput,
+                                      selectedSkill: localSkillOptions.find(
+                                        (skill) => skill.id === event.target.value,
+                                      ),
+                                      touched: currentDraft.otherModTouched,
+                                    }),
+                                    roll: undefined,
+                                    skillId: event.target.value,
+                                  }))
+                                }
+                                style={compactSkillInputStyle}
+                                value={localSelectedSkill?.id ?? ""}
+                              >
+                                {localSkillOptions.length > 0 ? (
+                                  localSkillOptions.map((skill) => (
+                                    <option key={skill.id} value={skill.id}>
+                                      {skill.label} ({skill.value ?? 0})
+                                    </option>
+                                  ))
+                                ) : (
+                                  <option value="">No skills available</option>
+                                )}
                               </select>
                             </label>
                             <label style={compactControlStyle}>
                               <span>Support category</span>
-                              <select disabled style={compactInputStyle} value="assigned">
-                                <option value="assigned">{roll.supportSkillLabel ? "Assigned" : "None"}</option>
+                              <select
+                                onChange={(event) =>
+                                  setPlayerLocalRollDraft((currentDraft) => ({
+                                    ...currentDraft,
+                                    roll: undefined,
+                                    supportSkillCategoryId: event.target
+                                      .value as PlayerLocalRollDraft["supportSkillCategoryId"],
+                                    supportSkillId: "",
+                                  }))
+                                }
+                                style={compactInputStyle}
+                                value={playerLocalRollDraft.supportSkillCategoryId}
+                              >
+                                <option value="all">All categories</option>
+                                {getPlayerFacingSkillBucketDefinitions()
+                                  .filter((category) =>
+                                    localAllSkillOptions.some(
+                                      (skill) => skill.categoryId === category.id,
+                                    ),
+                                  )
+                                  .map((category) => (
+                                    <option key={category.id} value={category.id}>
+                                      {category.label}
+                                    </option>
+                                  ))}
                               </select>
                             </label>
                             <label style={compactControlStyle}>
                               <span>Support</span>
-                              <select disabled style={compactSkillInputStyle} value={roll.supportSkillLabel ?? ""}>
-                                <option value={roll.supportSkillLabel ?? ""}>
-                                  {roll.supportSkillLabel ?? "No support skill"}
-                                </option>
+                              <select
+                                onChange={(event) =>
+                                  setPlayerLocalRollDraft((currentDraft) => ({
+                                    ...currentDraft,
+                                    roll: undefined,
+                                    supportSkillId: event.target.value,
+                                  }))
+                                }
+                                style={compactSkillInputStyle}
+                                value={localSelectedSupportSkill?.id ?? ""}
+                              >
+                                <option value="">No support skill</option>
+                                {localSupportSkillOptions.map((skill) => (
+                                  <option key={skill.id} value={skill.id}>
+                                    {skill.label} ({skill.value ?? 0})
+                                  </option>
+                                ))}
                               </select>
                             </label>
                           </div>
@@ -2107,336 +2553,124 @@ export function PlayerRoleplayingEncounterScreen({
                         <div style={rollFieldRowStyle}>
                           <label style={compactControlStyle}>
                             <span>Level</span>
-                            <select disabled style={compactInputStyle} value={roll.difficultyLabel}>
-                              <option value={roll.difficultyLabel}>{roll.difficultyLabel}</option>
+                            <select
+                              onChange={(event) =>
+                                setPlayerLocalRollDraft((currentDraft) => ({
+                                  ...currentDraft,
+                                  difficulty: event.target
+                                    .value as PlayerLocalRollDraft["difficulty"],
+                                  opponentParticipantId:
+                                    event.target.value === "none"
+                                      ? currentDraft.opponentParticipantId
+                                      : "",
+                                  roll: undefined,
+                                }))
+                              }
+                              style={compactInputStyle}
+                              value={playerLocalRollDraft.difficulty}
+                            >
+                              <option value="none">No level</option>
+                              {roleplayDifficultyOptions.map((option) => (
+                                <option key={option.id} value={option.id}>
+                                  {option.label}
+                                </option>
+                              ))}
                             </select>
                           </label>
                           <label style={compactControlStyle}>
                             <span>Opponent</span>
-                            <input
-                              readOnly
+                            <select
+                              onChange={(event) =>
+                                setPlayerLocalRollDraft((currentDraft) => ({
+                                  ...currentDraft,
+                                  difficulty: event.target.value ? "none" : currentDraft.difficulty,
+                                  opponentParticipantId: event.target.value,
+                                  roll: undefined,
+                                }))
+                              }
                               style={compactInputStyle}
-                              value={roll.mode === "opposed" ? roll.opponentLabel ?? "Opposed" : "No opponent"}
-                            />
+                              value={playerLocalRollDraft.opponentParticipantId}
+                            >
+                              <option value="">No opponent</option>
+                              {playerView.visibleParticipants.map((participant) => (
+                                <option key={participant.id} value={participant.id}>
+                                  {participant.name}
+                                </option>
+                              ))}
+                            </select>
                           </label>
-                          <button disabled={Boolean(roll.result)} onClick={() => void handlePlayerRoll(roll.id)} type="button">
-                            {roll.supportSkillLabel ? "Roll both 1d20s" : "Roll 1d20"}
+                          <button
+                            disabled={
+                              !canUsePlayerActions ||
+                              !controlledParticipant ||
+                              !localSelectedSkill ||
+                              Boolean(playerLocalRollDraft.opponentParticipantId)
+                            }
+                            onClick={() => void handleLocalPlayerRoll()}
+                            type="button"
+                          >
+                            {localSelectedSupportSkill ? "Roll both 1d20s" : "Roll 1d20"}
                           </button>
                         </div>
-                        {assignedSkillProfile && !assignedSkillProfile.known ? (
-                          <div style={{ color: "#8a5a00", fontSize: "0.85rem" }}>
-                            Skill not known (-3 default).
-                          </div>
-                        ) : null}
-                        {assignedSupportSkillProfile && !assignedSupportSkillProfile.known ? (
-                          <div style={{ color: "#8a5a00", fontSize: "0.85rem" }}>
-                            {assignedSupportSkillProfile.skillName}: Skill not known (-3 default).
-                          </div>
-                        ) : null}
+                        {[localSelectedSkill, localSelectedSupportSkill]
+                          .filter((skill): skill is SkillOption =>
+                            Boolean(skill?.profile && !skill.profile.known),
+                          )
+                          .map((skill) => (
+                            <div key={skill.id} style={{ color: "#8a5a00", fontSize: "0.85rem" }}>
+                              {skill.label}: Skill not known (-3 default).
+                            </div>
+                          ))}
                       </section>
                     </div>
                     <RoleplayRollCalculationPanel
-                      actorDifficulty={roll.mode === "difficulty" ? roll.difficulty : undefined}
-                      actorLabel={`Actor — ${roll.participantName}`}
-                      actorMainPreview={mainPreview}
-                      actorPendingLabels={mainPreview.pendingModifierLabels}
-                      actorSupportPreview={supportPreview}
+                      actorDifficulty={
+                        playerLocalRollDraft.difficulty === "none" ||
+                        playerLocalRollDraft.opponentParticipantId
+                          ? undefined
+                          : playerLocalRollDraft.difficulty
+                      }
+                      actorMainPreview={localPreview}
+                      actorSupportPreview={localSupportPreview}
                       cleanPendingText
-                      comparison={roll.comparison}
                       opponentOpen={false}
                       showPendingLabels={false}
                     />
                   </section>
                 </div>
-              );
-            })}
-          </div>
-        ) : (
-          <div style={{ display: "grid", gap: "0.75rem" }}>
-            <div>No skill rolls assigned.</div>
-            <div style={rollBlockShellStyle}>
-              <strong>Local roll 1</strong>
-              <section style={rollEditorStyle}>
-                <div style={rollControlsStackStyle}>
-                  <section style={rollControlsStyle}>
-                    <div style={rollControlRowStyle}>
-                      <span>Use:</span>
-                      <label>
-                        <input
-                          checked={playerLocalRollDraft.useGenMod}
-                          onChange={(event) =>
-                            setPlayerLocalRollDraft((currentDraft) => ({
-                              ...currentDraft,
-                              useGenMod: event.target.checked,
-                            }))
-                          }
-                          type="checkbox"
-                        /> Gen
-                      </label>
-                      <label>
-                        <input
-                          checked={playerLocalRollDraft.useObSkillMod}
-                          onChange={(event) =>
-                            setPlayerLocalRollDraft((currentDraft) => ({
-                              ...currentDraft,
-                              useObSkillMod: event.target.checked,
-                            }))
-                          }
-                          type="checkbox"
-                        /> OB/Skill
-                      </label>
-                      <label>
-                        <input
-                          checked={playerLocalRollDraft.useDbMod}
-                          onChange={(event) =>
-                            setPlayerLocalRollDraft((currentDraft) => ({
-                              ...currentDraft,
-                              useDbMod: event.target.checked,
-                            }))
-                          }
-                          type="checkbox"
-                        /> DB
-                      </label>
-                      <label style={compactControlStyle}>
-                        <span>Other mod</span>
-                        <input
-                          onChange={(event) =>
-                            setPlayerLocalRollDraft((currentDraft) => ({
-                              ...currentDraft,
-                              otherModInput: event.target.value,
-                              otherModTouched: true,
-                              roll: undefined,
-                            }))
-                          }
-                          style={{ ...compactInputStyle, width: "4.5rem" }}
-                          type="number"
-                          value={localOtherModInput}
-                        />
-                      </label>
-                    </div>
-                    <div style={rollFieldRowStyle}>
-                      <div style={playerRollSkillColumnsStyle}>
-                        <label style={compactControlStyle}>
-                          <span>Category</span>
-                          <select
-                            onChange={(event) => {
-                              const nextCategoryId = event.target.value as PlayerLocalRollDraft["skillCategoryId"];
-                              const nextSkillOptions =
-                                nextCategoryId === "all"
-                                  ? localAllSkillOptions
-                                  : localAllSkillOptions.filter((skill) => skill.categoryId === nextCategoryId);
+              </div>
+            )}
+          </section>
 
-                              setPlayerLocalRollDraft((currentDraft) => ({
-                                ...currentDraft,
-                                otherModInput: applyUnknownSkillDefaultOtherMod({
-                                  currentValue: currentDraft.otherModInput,
-                                  selectedSkill: nextSkillOptions[0],
-                                  touched: currentDraft.otherModTouched,
-                                }),
-                                roll: undefined,
-                                skillCategoryId: nextCategoryId,
-                                skillId: nextSkillOptions[0]?.id ?? "",
-                              }));
-                            }}
-                            style={compactInputStyle}
-                            value={playerLocalRollDraft.skillCategoryId}
-                          >
-                            <option value="all">All categories</option>
-                            {getPlayerFacingSkillBucketDefinitions()
-                              .filter((category) => localAllSkillOptions.some((skill) => skill.categoryId === category.id))
-                              .map((category) => (
-                                <option key={category.id} value={category.id}>
-                                  {category.label}
-                                </option>
-                              ))}
-                          </select>
-                        </label>
-                        <label style={compactControlStyle}>
-                          <span>Skill</span>
-                          <select
-                            disabled={localSkillOptions.length === 0}
-                            onChange={(event) =>
-                              setPlayerLocalRollDraft((currentDraft) => ({
-                                ...currentDraft,
-                                otherModInput: applyUnknownSkillDefaultOtherMod({
-                                  currentValue: currentDraft.otherModInput,
-                                  selectedSkill: localSkillOptions.find((skill) => skill.id === event.target.value),
-                                  touched: currentDraft.otherModTouched,
-                                }),
-                                roll: undefined,
-                                skillId: event.target.value,
-                              }))
-                            }
-                            style={compactSkillInputStyle}
-                            value={localSelectedSkill?.id ?? ""}
-                          >
-                            {localSkillOptions.length > 0 ? (
-                              localSkillOptions.map((skill) => (
-                                <option key={skill.id} value={skill.id}>
-                                  {skill.label} ({skill.value ?? 0})
-                                </option>
-                              ))
-                            ) : (
-                              <option value="">No skills available</option>
-                            )}
-                          </select>
-                        </label>
-                        <label style={compactControlStyle}>
-                          <span>Support category</span>
-                          <select
-                            onChange={(event) =>
-                              setPlayerLocalRollDraft((currentDraft) => ({
-                                ...currentDraft,
-                                roll: undefined,
-                                supportSkillCategoryId: event.target.value as PlayerLocalRollDraft["supportSkillCategoryId"],
-                                supportSkillId: "",
-                              }))
-                            }
-                            style={compactInputStyle}
-                            value={playerLocalRollDraft.supportSkillCategoryId}
-                          >
-                            <option value="all">All categories</option>
-                            {getPlayerFacingSkillBucketDefinitions()
-                              .filter((category) => localAllSkillOptions.some((skill) => skill.categoryId === category.id))
-                              .map((category) => (
-                                <option key={category.id} value={category.id}>
-                                  {category.label}
-                                </option>
-                              ))}
-                          </select>
-                        </label>
-                        <label style={compactControlStyle}>
-                          <span>Support</span>
-                          <select
-                            onChange={(event) =>
-                              setPlayerLocalRollDraft((currentDraft) => ({
-                                ...currentDraft,
-                                roll: undefined,
-                                supportSkillId: event.target.value,
-                              }))
-                            }
-                            style={compactSkillInputStyle}
-                            value={localSelectedSupportSkill?.id ?? ""}
-                          >
-                            <option value="">No support skill</option>
-                            {localSupportSkillOptions.map((skill) => (
-                              <option key={skill.id} value={skill.id}>
-                                {skill.label} ({skill.value ?? 0})
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                      </div>
-                    </div>
-                    <div style={rollFieldRowStyle}>
-                      <label style={compactControlStyle}>
-                        <span>Level</span>
-                        <select
-                          onChange={(event) =>
-                            setPlayerLocalRollDraft((currentDraft) => ({
-                              ...currentDraft,
-                              difficulty: event.target.value as PlayerLocalRollDraft["difficulty"],
-                              opponentParticipantId: event.target.value === "none" ? currentDraft.opponentParticipantId : "",
-                              roll: undefined,
-                            }))
-                          }
-                          style={compactInputStyle}
-                          value={playerLocalRollDraft.difficulty}
-                        >
-                          <option value="none">No level</option>
-                          {roleplayDifficultyOptions.map((option) => (
-                            <option key={option.id} value={option.id}>
-                              {option.label}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                      <label style={compactControlStyle}>
-                        <span>Opponent</span>
-                        <select
-                          onChange={(event) =>
-                            setPlayerLocalRollDraft((currentDraft) => ({
-                              ...currentDraft,
-                              difficulty: event.target.value ? "none" : currentDraft.difficulty,
-                              opponentParticipantId: event.target.value,
-                              roll: undefined,
-                            }))
-                          }
-                          style={compactInputStyle}
-                          value={playerLocalRollDraft.opponentParticipantId}
-                        >
-                          <option value="">No opponent</option>
-                          {playerView.visibleParticipants.map((participant) => (
-                            <option key={participant.id} value={participant.id}>
-                              {participant.name}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                      <button
-                        disabled={!controlledParticipant || !localSelectedSkill || Boolean(playerLocalRollDraft.opponentParticipantId)}
-                        onClick={() => void handleLocalPlayerRoll()}
-                        type="button"
-                      >
-                        {localSelectedSupportSkill ? "Roll both 1d20s" : "Roll 1d20"}
-                      </button>
-                    </div>
-                    {[localSelectedSkill, localSelectedSupportSkill]
-                      .filter((skill): skill is SkillOption => Boolean(skill?.profile && !skill.profile.known))
-                      .map((skill) => (
-                        <div key={skill.id} style={{ color: "#8a5a00", fontSize: "0.85rem" }}>
-                          {skill.label}: Skill not known (-3 default).
-                        </div>
-                      ))}
-                  </section>
-                </div>
-                <RoleplayRollCalculationPanel
-                  actorDifficulty={
-                    playerLocalRollDraft.difficulty === "none" || playerLocalRollDraft.opponentParticipantId
-                      ? undefined
-                      : playerLocalRollDraft.difficulty
-                  }
-                  actorMainPreview={localPreview}
-                  actorSupportPreview={localSupportPreview}
-                  cleanPendingText
-                  opponentOpen={false}
-                  showPendingLabels={false}
-                />
-              </section>
-            </div>
-          </div>
-        )}
-      </section>
+          <section style={panelStyle}>
+            <h2 style={{ margin: 0 }}>Ranked roll results</h2>
+            {visibleRankedResults.length > 0 ? (
+              <ol style={{ margin: 0, paddingLeft: "1.5rem" }}>
+                {visibleRankedResults.map((entry) => (
+                  <li key={entry.id}>
+                    {entry.participantName} · {entry.skillLabel} · total {entry.total}
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <div>No player-visible ranked results yet.</div>
+            )}
+          </section>
 
-      <section style={panelStyle}>
-        <h2 style={{ margin: 0 }}>Ranked roll results</h2>
-        {visibleRankedResults.length > 0 ? (
-          <ol style={{ margin: 0, paddingLeft: "1.5rem" }}>
-            {visibleRankedResults.map((entry) => (
-              <li key={entry.id}>
-                {entry.participantName} · {entry.skillLabel} · total {entry.total}
-              </li>
-            ))}
-          </ol>
-        ) : (
-          <div>No player-visible ranked results yet.</div>
-        )}
-      </section>
-
-      <section style={panelStyle}>
-        <h2 style={{ margin: 0 }}>Character log</h2>
-        {playerView.characterLog.length > 0 ? (
-          <ul style={{ display: "grid", gap: "0.35rem", margin: 0, paddingLeft: "1.25rem" }}>
-            {playerView.characterLog.map((entry) => (
-              <li key={entry.id}>
-                {formatShortDateTime(entry.timestamp)} · {entry.detail}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <div>No character log entries yet.</div>
-        )}
-      </section>
+          <section style={panelStyle}>
+            <h2 style={{ margin: 0 }}>Character log</h2>
+            {playerView.characterLog.length > 0 ? (
+              <ul style={{ display: "grid", gap: "0.35rem", margin: 0, paddingLeft: "1.25rem" }}>
+                {playerView.characterLog.map((entry) => (
+                  <li key={entry.id}>
+                    {formatShortDateTime(entry.timestamp)} · {entry.detail}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div>No character log entries yet.</div>
+            )}
+          </section>
         </>
       ) : null}
     </section>

--- a/apps/web/src/features/roleplay/RoleplayEncounterScreens.tsx
+++ b/apps/web/src/features/roleplay/RoleplayEncounterScreens.tsx
@@ -112,6 +112,7 @@ interface PlayerRoleplayingEncounterScreenProps {
   scenarioId: string;
   showWorkspaceHeader?: boolean;
   surface?: "encounter" | "full" | "skill-rolls";
+  workspaceScreenName?: string;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -1640,6 +1641,7 @@ export function PlayerRoleplayingEncounterScreen({
   scenarioId,
   showWorkspaceHeader = true,
   surface = "full",
+  workspaceScreenName = "Skill rolls",
 }: PlayerRoleplayingEncounterScreenProps) {
   const [campaign, setCampaign] = useState<Campaign | null>(null);
   const [content, setContent] = useState<Awaited<ReturnType<typeof loadCanonicalContent>>>();
@@ -2066,7 +2068,8 @@ export function PlayerRoleplayingEncounterScreen({
       {showWorkspaceHeader && showSkillRollTools ? (
         <section style={panelStyle}>
           <h2 style={{ margin: 0 }}>
-            Skill rolls{selectedPlayerFacingName ? ` — ${selectedPlayerFacingName}` : ""}
+            {workspaceScreenName}
+            {selectedPlayerFacingName ? ` — ${selectedPlayerFacingName}` : ""}
           </h2>
           {readOnlyInspection ? <div>GM player-view inspection is read-only.</div> : null}
         </section>

--- a/apps/web/src/features/roleplay/RoleplayEncounterScreens.tsx
+++ b/apps/web/src/features/roleplay/RoleplayEncounterScreens.tsx
@@ -99,6 +99,7 @@ interface GmRoleplayingEncounterScreenProps {
   scenario?: Scenario | null;
   scenarioId?: string;
   scenarioParticipants: ScenarioParticipant[];
+  surface?: "encounter" | "full" | "skill-rolls";
 }
 
 interface PlayerRoleplayingEncounterScreenProps {
@@ -106,6 +107,7 @@ interface PlayerRoleplayingEncounterScreenProps {
   embedded?: boolean;
   encounterId: string;
   scenarioId: string;
+  surface?: "encounter" | "full" | "skill-rolls";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -557,6 +559,7 @@ export function GmRoleplayingEncounterScreen({
   scenario,
   scenarioId,
   scenarioParticipants,
+  surface = "full",
 }: GmRoleplayingEncounterScreenProps) {
   const roleplayState = normalizeRoleplayState(encounter);
   const roster = useMemo(
@@ -1416,6 +1419,9 @@ export function GmRoleplayingEncounterScreen({
   const rankedRollResults = rankVisibleRollResults(
     dedupeRankedRoleplayEntries([...currentRankedRollResults, ...serverRankedRollResults])
   );
+  const showEncounterContext = surface !== "skill-rolls";
+  const showSkillRollTools = surface !== "encounter";
+  const rememberedTab = surface === "skill-rolls" ? "skill-rolls" : "encounter";
 
   return (
     <section style={{ display: "grid", gap: "1rem", maxWidth: 1120 }}>
@@ -1424,7 +1430,7 @@ export function GmRoleplayingEncounterScreen({
           campaignId={campaignId}
           encounterId={encounter.id}
           scenarioId={scenarioId}
-          tab="gm-encounter"
+          tab={rememberedTab}
         />
       ) : null}
       {!embedded && campaignId && scenarioId ? (
@@ -1432,95 +1438,103 @@ export function GmRoleplayingEncounterScreen({
           Back to scenario
         </Link>
       ) : null}
-      <RoleplayTopInfo
-        campaignName={campaignName}
-        encounter={encounter}
-        scenarioName={scenario?.name}
-      />
+      {showEncounterContext ? (
+        <>
+          <RoleplayTopInfo
+            campaignName={campaignName}
+            encounter={encounter}
+            scenarioName={scenario?.name}
+          />
 
-      <GmMessageSection
-        gmMessageDraft={gmMessageDraft}
-        onChange={(message) => {
-          setGmMessageDirty(true);
-          setGmMessageDraft(message);
-        }}
-        onSave={handleSaveGmMessage}
-      />
+          <GmMessageSection
+            gmMessageDraft={gmMessageDraft}
+            onChange={(message) => {
+              setGmMessageDirty(true);
+              setGmMessageDraft(message);
+            }}
+            onSave={handleSaveGmMessage}
+          />
 
-      <VisibilityGridSection
-        onSelectAllVisibility={handleSelectAllVisibility}
-        onVisibilityChange={handleVisibilityChange}
-        roster={roster}
-        state={roleplayState}
-      />
+          <VisibilityGridSection
+            onSelectAllVisibility={handleSelectAllVisibility}
+            onVisibilityChange={handleVisibilityChange}
+            roster={roster}
+            state={roleplayState}
+          />
 
-      <ParticipantDescriptionsSection
-        onSave={handleDescriptionSave}
-        roster={roster}
-        state={roleplayState}
-      />
+          <ParticipantDescriptionsSection
+            onSave={handleDescriptionSave}
+            roster={roster}
+            state={roleplayState}
+          />
+        </>
+      ) : null}
 
-      <section style={panelStyle}>
-        <div style={{ alignItems: "center", display: "flex", justifyContent: "space-between", gap: "0.75rem" }}>
-          <h2 style={{ margin: 0 }}>Skill roll assignment</h2>
-          <button onClick={() => void resetRollDrafts()} type="button">
-            Clear
-          </button>
-        </div>
-        <div style={{ display: "grid", gap: "0.75rem" }}>
-          {rollDrafts.map((draft, index) => {
-            const context = getRollDraftContext(draft);
-            const comparison =
-              context.preview && context.opponentPreview
-                ? compareRoleplayOpposedRolls({
-                    actorLabel: context.participant?.label ?? "Actor",
-                    actorPreview: context.preview,
-                    opponentLabel: context.opponent?.label ?? "Opponent",
-                    opponentPreview: context.opponentPreview,
-                  }).summary
-                : undefined;
+      {showSkillRollTools ? (
+        <>
+          <section style={panelStyle}>
+            <div style={{ alignItems: "center", display: "flex", justifyContent: "space-between", gap: "0.75rem" }}>
+              <h2 style={{ margin: 0 }}>Skill roll assignment</h2>
+              <button onClick={() => void resetRollDrafts()} type="button">
+                Clear
+              </button>
+            </div>
+            <div style={{ display: "grid", gap: "0.75rem" }}>
+              {rollDrafts.map((draft, index) => {
+                const context = getRollDraftContext(draft);
+                const comparison =
+                  context.preview && context.opponentPreview
+                    ? compareRoleplayOpposedRolls({
+                        actorLabel: context.participant?.label ?? "Actor",
+                        actorPreview: context.preview,
+                        opponentLabel: context.opponent?.label ?? "Opponent",
+                        opponentPreview: context.opponentPreview,
+                      }).summary
+                    : undefined;
 
-            return (
-              <RoleplayRollBlock
-                applyUnknownSkillDefaultOtherMod={applyUnknownSkillDefaultOtherMod}
-                comparison={comparison}
-                context={context}
-                draft={draft}
-                index={index}
-                key={draft.id}
-                onActorParticipantChange={handleActorParticipantChange}
-                onAssignSkillRoll={handleAssignSkillRoll}
-                onGmRoll={handleGmRoll}
-                onUpdateRollDraft={updateRollDraft}
-                roster={roster}
-              />
-            );
-          })}
-          <button
-            onClick={() =>
-              setRollDrafts((currentDrafts) => [
-                ...currentDrafts,
-                makeRollDraft({
-                  participantId: roster[0]?.id,
-                  rollSetId: currentGmRollStackId,
-                  skillId: initialSkillId,
-                }),
-              ])
-            }
-            type="button"
-          >
-            Add roll
-          </button>
-        </div>
-        <div style={{ color: "#5e5a50" }}>
-          GM Roll uses the roleplay open-ended d20 table for non-opposed skill rolls.
-          Gen, OB/Skill, and DB flags remain visible placeholder modifiers until numeric sources are defined.
-        </div>
-      </section>
+                return (
+                  <RoleplayRollBlock
+                    applyUnknownSkillDefaultOtherMod={applyUnknownSkillDefaultOtherMod}
+                    comparison={comparison}
+                    context={context}
+                    draft={draft}
+                    index={index}
+                    key={draft.id}
+                    onActorParticipantChange={handleActorParticipantChange}
+                    onAssignSkillRoll={handleAssignSkillRoll}
+                    onGmRoll={handleGmRoll}
+                    onUpdateRollDraft={updateRollDraft}
+                    roster={roster}
+                  />
+                );
+              })}
+              <button
+                onClick={() =>
+                  setRollDrafts((currentDrafts) => [
+                    ...currentDrafts,
+                    makeRollDraft({
+                      participantId: roster[0]?.id,
+                      rollSetId: currentGmRollStackId,
+                      skillId: initialSkillId,
+                    }),
+                  ])
+                }
+                type="button"
+              >
+                Add roll
+              </button>
+            </div>
+            <div style={{ color: "#5e5a50" }}>
+              GM Roll uses the roleplay open-ended d20 table for non-opposed skill rolls.
+              Gen, OB/Skill, and DB flags remain visible placeholder modifiers until numeric sources are defined.
+            </div>
+          </section>
 
-      <RankedRollResultsSection entries={rankedRollResults} roster={roster} />
+          <RankedRollResultsSection entries={rankedRollResults} roster={roster} />
 
-      <RoleplayActionLogSection entries={roleplayState.actionLog} />
+          <RoleplayActionLogSection entries={roleplayState.actionLog} />
+        </>
+      ) : null}
     </section>
   );
 }
@@ -1530,6 +1544,7 @@ export function PlayerRoleplayingEncounterScreen({
   embedded = false,
   encounterId,
   scenarioId,
+  surface = "full",
 }: PlayerRoleplayingEncounterScreenProps) {
   const [campaign, setCampaign] = useState<Campaign | null>(null);
   const [content, setContent] = useState<Awaited<ReturnType<typeof loadCanonicalContent>>>();
@@ -1667,6 +1682,9 @@ export function PlayerRoleplayingEncounterScreen({
     encounter,
     scenarioParticipants,
   });
+  const showEncounterContext = surface !== "skill-rolls";
+  const showSkillRollTools = surface !== "encounter";
+  const rememberedTab = surface === "skill-rolls" ? "skill-rolls" : "encounter";
 
   if (currentUser && playerView.controlledParticipantIds.length === 0) {
     return (
@@ -1675,7 +1693,7 @@ export function PlayerRoleplayingEncounterScreen({
           campaignId={campaignId}
           encounterId={encounterId}
           scenarioId={scenarioId}
-          tab="player-encounter"
+          tab={rememberedTab}
         />
         {!embedded ? (
           <Link href={buildCampaignWorkspaceHref({ campaignId, scenarioId, tab: "scenario" })}>
@@ -1884,86 +1902,91 @@ export function PlayerRoleplayingEncounterScreen({
     );
     setFeedback(`Rolled ${localSelectedSkill.label}: total ${preview.numericSubtotal ?? "unresolved"}.`);
   }
-
   return (
     <section style={{ display: "grid", gap: "1rem", maxWidth: 980 }}>
       <RememberedCampaignWorkspaceEffect
         campaignId={campaignId}
         encounterId={encounterId}
         scenarioId={scenarioId}
-        tab="player-encounter"
+        tab={rememberedTab}
       />
       {!embedded ? (
         <Link href={buildCampaignWorkspaceHref({ campaignId, scenarioId, tab: "scenario" })}>
           Back to scenario
         </Link>
       ) : null}
-      <PlayerEncounterTopInfo
-        campaignName={campaign?.name}
-        encounter={encounter}
-        scenarioName={scenario?.name}
-      />
       {feedback ? <section style={panelStyle}>{feedback}</section> : null}
-      {playerView.gmMessage ? (
-        <section style={panelStyle}>
-          <h2 style={{ margin: 0 }}>Situation</h2>
-          <div
-            aria-readonly="true"
-            ref={situationRef}
-            role="textbox"
-            style={{
-              ...playerReadOnlyPanelStyle,
-              maxHeight: "16rem",
-              minHeight: "8rem",
-              overflowY: "auto",
-            }}
-          >
-            {playerView.gmMessage}
-          </div>
-        </section>
+      {showEncounterContext ? (
+        <>
+          <PlayerEncounterTopInfo
+            campaignName={campaign?.name}
+            encounter={encounter}
+            scenarioName={scenario?.name}
+          />
+          {playerView.gmMessage ? (
+            <section style={panelStyle}>
+              <h2 style={{ margin: 0 }}>Situation</h2>
+              <div
+                aria-readonly="true"
+                ref={situationRef}
+                role="textbox"
+                style={{
+                  ...playerReadOnlyPanelStyle,
+                  maxHeight: "16rem",
+                  minHeight: "8rem",
+                  overflowY: "auto",
+                }}
+              >
+                {playerView.gmMessage}
+              </div>
+            </section>
+          ) : null}
+
+          <section style={panelStyle}>
+            <h2 style={{ margin: 0 }}>PCs and NPCs</h2>
+            {currentUser ? (
+              playerView.visibleParticipants.length > 0 ? (
+                <div style={{ maxHeight: "30rem", overflow: "auto" }}>
+                  <table style={{ borderCollapse: "collapse", minWidth: 720, width: "100%" }}>
+                    <colgroup>
+                      <col style={{ width: "22%" }} />
+                      <col style={{ width: "22%" }} />
+                      <col style={{ width: "56%" }} />
+                    </colgroup>
+                    <thead>
+                      <tr style={{ borderBottom: "1px solid #d9ddd8", textAlign: "left" }}>
+                        <th style={{ padding: "0.5rem 0.75rem 0.5rem 0" }}>Short description</th>
+                        <th style={{ padding: "0.5rem 0.75rem" }}>Name</th>
+                        <th style={{ padding: "0.5rem 0.75rem" }}>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {playerView.visibleParticipants.map((participant) => (
+                        <tr key={participant.id} style={{ borderBottom: "1px solid #eee8dc" }}>
+                          <td style={{ padding: "0.6rem 0.75rem 0.6rem 0" }}>
+                            {participant.shortDescription || "—"}
+                          </td>
+                          <td style={{ padding: "0.6rem 0.75rem" }}>{participant.name}</td>
+                          <td style={{ padding: "0.6rem 0.75rem" }}>
+                            {participant.description || "—"}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              ) : (
+                <div>No other visible participants.</div>
+              )
+            ) : (
+              <div>Sign in to view player-visible encounter participants.</div>
+            )}
+          </section>
+        </>
       ) : null}
 
-      <section style={panelStyle}>
-        <h2 style={{ margin: 0 }}>PCs and NPCs</h2>
-        {currentUser ? (
-          playerView.visibleParticipants.length > 0 ? (
-            <div style={{ maxHeight: "30rem", overflow: "auto" }}>
-              <table style={{ borderCollapse: "collapse", minWidth: 720, width: "100%" }}>
-                <colgroup>
-                  <col style={{ width: "22%" }} />
-                  <col style={{ width: "22%" }} />
-                  <col style={{ width: "56%" }} />
-                </colgroup>
-                <thead>
-                  <tr style={{ borderBottom: "1px solid #d9ddd8", textAlign: "left" }}>
-                    <th style={{ padding: "0.5rem 0.75rem 0.5rem 0" }}>Short description</th>
-                    <th style={{ padding: "0.5rem 0.75rem" }}>Name</th>
-                    <th style={{ padding: "0.5rem 0.75rem" }}>Description</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {playerView.visibleParticipants.map((participant) => (
-                    <tr key={participant.id} style={{ borderBottom: "1px solid #eee8dc" }}>
-                      <td style={{ padding: "0.6rem 0.75rem 0.6rem 0" }}>
-                        {participant.shortDescription || "—"}
-                      </td>
-                      <td style={{ padding: "0.6rem 0.75rem" }}>{participant.name}</td>
-                      <td style={{ padding: "0.6rem 0.75rem" }}>
-                        {participant.description || "—"}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <div>No other visible participants.</div>
-          )
-        ) : (
-          <div>Sign in to view player-visible encounter participants.</div>
-        )}
-      </section>
-
+      {showSkillRollTools ? (
+        <>
       <section style={panelStyle}>
         <div style={{ alignItems: "center", display: "flex", justifyContent: "space-between", gap: "0.75rem" }}>
           <h2 style={{ margin: 0 }}>Skill roll grid</h2>
@@ -2414,6 +2437,8 @@ export function PlayerRoleplayingEncounterScreen({
           <div>No character log entries yet.</div>
         )}
       </section>
+        </>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/lib/campaigns/access.test.ts
+++ b/apps/web/src/lib/campaigns/access.test.ts
@@ -163,13 +163,13 @@ describe("campaign access", () => {
       rememberedEncounterId: "encounter-1",
       rememberedParticipantId: "participant-1",
       rememberedScenarioId: "scenario-1",
-      rememberedTab: "player-encounter",
+      rememberedTab: "encounter",
     });
 
     expect(destination).toEqual({
       clearRememberedCampaign: false,
       href:
-        "/campaigns/campaign-1?tab=player-encounter&scenarioId=scenario-1&encounterId=encounter-1&participantId=participant-1",
+        "/campaigns/campaign-1?tab=encounter&scenarioId=scenario-1&encounterId=encounter-1&participantId=participant-1",
     });
   });
 });

--- a/apps/web/src/lib/campaigns/access.ts
+++ b/apps/web/src/lib/campaigns/access.ts
@@ -97,11 +97,17 @@ export function resolveCampaignResumeDestination(input: {
         campaignId: rememberedCampaignId,
         encounterId: input.rememberedEncounterId,
         participantId:
-          input.rememberedTab === "player-encounter" ? input.rememberedParticipantId : undefined,
+          input.rememberedTab === "player-encounter" ||
+          input.rememberedTab === "encounter" ||
+          input.rememberedTab === "skill-rolls"
+            ? input.rememberedParticipantId
+            : undefined,
         scenarioId: input.rememberedScenarioId,
         tab:
           input.rememberedTab === "campaign" ||
           input.rememberedTab === "scenario" ||
+          input.rememberedTab === "encounter" ||
+          input.rememberedTab === "skill-rolls" ||
           input.rememberedTab === "gm-encounter" ||
           input.rememberedTab === "player-encounter"
             ? input.rememberedTab
@@ -115,4 +121,3 @@ export function resolveCampaignResumeDestination(input: {
     href: "/campaigns",
   };
 }
-

--- a/apps/web/src/lib/campaigns/playerGeneralEncounter.test.ts
+++ b/apps/web/src/lib/campaigns/playerGeneralEncounter.test.ts
@@ -31,7 +31,7 @@ function makeScenarioParticipant(input: {
 }
 
 function makeRoleplayActionLogEntry(
-  input: Partial<RoleplayActionLogEntry> & Pick<RoleplayActionLogEntry, "id" | "summary">
+  input: Partial<RoleplayActionLogEntry> & Pick<RoleplayActionLogEntry, "id" | "summary">,
 ): RoleplayActionLogEntry {
   const { id, summary, ...rest } = input;
   return {
@@ -55,7 +55,7 @@ function makeRoleplayActionLogEntry(
 
 function makePendingSkillRoll(
   input: Partial<RoleplayPendingSkillRoll> &
-    Pick<RoleplayPendingSkillRoll, "id" | "participantId" | "skillId" | "skillLabel">
+    Pick<RoleplayPendingSkillRoll, "id" | "participantId" | "skillId" | "skillLabel">,
 ): RoleplayPendingSkillRoll {
   const { id, participantId, skillId, skillLabel, ...rest } = input;
   return {
@@ -265,7 +265,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter: makeEncounter(),
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
         makeScenarioParticipant({ id: "npc-hidden", name: "Hidden spy" }),
       ],
@@ -274,15 +278,21 @@ describe("playerGeneralEncounter", () => {
     expect(view.gmMessage).toBe("The market is loud and tense.");
     expect(view.controlledParticipantIds).toEqual(["scenario-pc-1"]);
     expect(view.visibleParticipantIds).toEqual(["scenario-pc-1", "scenario-npc-visible"]);
-    expect(view.visibleParticipants.map((participant) => participant.name)).toEqual(["Street merchant"]);
-    expect(view.visibleParticipants.map((participant) => participant.name)).not.toContain("Disguised spy");
-    expect(view.visibleParticipants.map((participant) => participant.name)).not.toContain("Player hero");
+    expect(view.visibleParticipants.map((participant) => participant.name)).toEqual([
+      "Street merchant",
+    ]);
+    expect(view.visibleParticipants.map((participant) => participant.name)).not.toContain(
+      "Disguised spy",
+    );
+    expect(view.visibleParticipants.map((participant) => participant.name)).not.toContain(
+      "Player hero",
+    );
     expect(view.visibleParticipants.map((participant) => participant.shortDescription)).toContain(
-      "A nervous seller"
+      "A nervous seller",
     );
     expect(JSON.stringify(view.visibleParticipants)).not.toContain("GM-only");
     expect(view.visibleParticipants.map((participant) => participant.description)).toContain(
-      "A player-safe clue."
+      "A player-safe clue.",
     );
   });
 
@@ -312,7 +322,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter,
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
         makeScenarioParticipant({ id: "npc-hidden", name: "Hidden spy" }),
       ],
@@ -334,7 +348,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter: makeEncounter(),
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
       ],
     });
 
@@ -352,6 +370,29 @@ describe("playerGeneralEncounter", () => {
       skillValue: 16,
     });
     expect(JSON.stringify(view.assignedRolls)).not.toContain("silent-roll");
+  });
+
+  it("can build the same player-safe view for a GM-selected scenario participant", () => {
+    const view = buildPlayerGeneralEncounterView({
+      controlledScenarioParticipantId: "pc-1",
+      encounter: makeEncounter(),
+      scenarioParticipants: [
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
+        makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
+        makeScenarioParticipant({ id: "npc-hidden", name: "Hidden spy" }),
+      ],
+    });
+
+    expect(view.controlledParticipantIds).toEqual(["scenario-pc-1"]);
+    expect(view.visibleParticipants.map((participant) => participant.name)).toEqual([
+      "Street merchant",
+    ]);
+    expect(view.assignedRolls.map((roll) => roll.id)).toEqual(["visible-roll"]);
+    expect(JSON.stringify(view)).not.toContain("Disguised spy");
   });
 
   it("matches assigned rolls by scenario participant id when needed", () => {
@@ -380,7 +421,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter,
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
       ],
     });
 
@@ -462,7 +507,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter,
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
       ],
     });
@@ -550,7 +599,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter,
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-hidden", name: "Hidden spy" }),
       ],
     });
@@ -564,7 +617,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter: makeEncounter(),
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
         makeScenarioParticipant({ id: "npc-hidden", name: "Hidden spy" }),
       ],
@@ -678,7 +735,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter,
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
         makeScenarioParticipant({ id: "npc-visible-2", name: "Second visible NPC" }),
         makeScenarioParticipant({ id: "npc-hidden", name: "Hidden spy" }),
@@ -690,7 +751,9 @@ describe("playerGeneralEncounter", () => {
       "Player hero:25",
       "Street merchant:12",
     ]);
-    expect(view.rankedResults.filter((entry) => entry.participantName === "Player hero")).toHaveLength(1);
+    expect(
+      view.rankedResults.filter((entry) => entry.participantName === "Player hero"),
+    ).toHaveLength(1);
     expect(JSON.stringify(view.rankedResults)).not.toContain("Hidden spy");
   });
 
@@ -724,7 +787,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter,
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
       ],
     });
 
@@ -760,7 +827,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter,
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
       ],
     });
 
@@ -811,12 +882,19 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter,
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
       ],
     });
 
     expect(view.rankedResults.map((entry) => entry.id)).toEqual(["new-stack-result"]);
-    expect(view.characterLog.map((entry) => entry.id)).toEqual(["new-stack-result", "old-stack-result"]);
+    expect(view.characterLog.map((entry) => entry.id)).toEqual([
+      "new-stack-result",
+      "old-stack-result",
+    ]);
   });
 
   it("keeps distinct ranked rolls when assigned roll identities differ", () => {
@@ -864,7 +942,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter,
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
       ],
     });
 
@@ -915,7 +997,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter,
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
       ],
     });
@@ -928,7 +1014,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter: makeEncounter(),
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
       ],
     });
@@ -965,14 +1055,23 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter: makeEmptyParticipantEncounter(),
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
       ],
     });
 
     expect(view.controlledParticipantIds).toEqual(["scenario-fallback-pc-1"]);
-    expect(view.visibleParticipantIds).toEqual(["scenario-fallback-pc-1", "scenario-fallback-npc-visible"]);
-    expect(view.visibleParticipants.map((participant) => participant.name)).toEqual(["Visible NPC"]);
+    expect(view.visibleParticipantIds).toEqual([
+      "scenario-fallback-pc-1",
+      "scenario-fallback-npc-visible",
+    ]);
+    expect(view.visibleParticipants.map((participant) => participant.name)).toEqual([
+      "Visible NPC",
+    ]);
   });
 
   it("does not fall back to scenario participants after explicit encounter membership exists", () => {
@@ -980,7 +1079,11 @@ describe("playerGeneralEncounter", () => {
       currentUserId: "player-1",
       encounter: makeEncounter(),
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "not-in-encounter", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "not-in-encounter",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
       ],
     });
@@ -998,7 +1101,11 @@ describe("playerGeneralEncounter", () => {
         participantMembershipMode: "explicit",
       },
       scenarioParticipants: [
-        makeScenarioParticipant({ controlledByUserId: "player-1", id: "pc-1", name: "Player hero" }),
+        makeScenarioParticipant({
+          controlledByUserId: "player-1",
+          id: "pc-1",
+          name: "Player hero",
+        }),
         makeScenarioParticipant({ id: "npc-visible", name: "Visible NPC" }),
       ],
     });

--- a/apps/web/src/lib/campaigns/playerGeneralEncounter.ts
+++ b/apps/web/src/lib/campaigns/playerGeneralEncounter.ts
@@ -99,13 +99,14 @@ const difficultyLabels: Record<string, string> = {
 
 function getScenarioParticipantControllerId(
   encounterParticipant: EncounterParticipant,
-  scenarioParticipantsById: Map<string, ScenarioParticipant>
+  scenarioParticipantsById: Map<string, ScenarioParticipant>,
 ): string | undefined {
   if (!encounterParticipant.scenarioParticipantId) {
     return undefined;
   }
 
-  return scenarioParticipantsById.get(encounterParticipant.scenarioParticipantId)?.controlledByUserId;
+  return scenarioParticipantsById.get(encounterParticipant.scenarioParticipantId)
+    ?.controlledByUserId;
 }
 
 function getPlayerSafeParticipantName(input: {
@@ -170,11 +171,13 @@ function isParticipantVisibleToPlayer(input: {
   }
 
   for (const viewer of input.controlledParticipants) {
-    if (isVisibilityEnabled({
-      state: input.state,
-      target: input.participant,
-      viewer,
-    })) {
+    if (
+      isVisibilityEnabled({
+        state: input.state,
+        target: input.participant,
+        viewer,
+      })
+    ) {
       return true;
     }
 
@@ -229,25 +232,19 @@ function buildAssignedRoll(input: {
             entry.type === "gm_skill_roll" &&
             !entry.silent &&
             entry.rollSetId === input.pendingRoll.rollSetId &&
-            (
-              (
-                entry.side === "opponent" &&
-                entry.participantId === opponentParticipant.id &&
-                entry.numericSubtotal != null
-              ) ||
-              (
-                !entry.side &&
+            ((entry.side === "opponent" &&
+              entry.participantId === opponentParticipant.id &&
+              entry.numericSubtotal != null) ||
+              (!entry.side &&
                 !entry.opponentSilent &&
                 entry.opponentParticipantId === opponentParticipant.id &&
-                entry.opponentNumericSubtotal != null
-              )
-            )
+                entry.opponentNumericSubtotal != null)),
         )
       : undefined;
   const ownTotal = input.result?.numericSubtotal ?? input.result?.finalTotal;
   const opponentTotal =
     opponentResult?.side === "opponent"
-      ? opponentResult.numericSubtotal ?? opponentResult.finalTotal
+      ? (opponentResult.numericSubtotal ?? opponentResult.finalTotal)
       : opponentResult?.opponentNumericSubtotal;
   const comparison =
     ownTotal != null && opponentTotal != null && opponentName
@@ -262,7 +259,7 @@ function buildAssignedRoll(input: {
     comparison,
     difficulty: input.pendingRoll.difficulty,
     difficultyLabel: input.pendingRoll.difficulty
-      ? difficultyLabels[input.pendingRoll.difficulty] ?? input.pendingRoll.difficulty
+      ? (difficultyLabels[input.pendingRoll.difficulty] ?? input.pendingRoll.difficulty)
       : "No level",
     id: input.pendingRoll.id,
     mode: input.pendingRoll.mode,
@@ -285,7 +282,7 @@ function buildAssignedRoll(input: {
           openEndedD10s: input.result.openEndedD10s,
           rollD20: input.result.rollD20,
           total: input.result.numericSubtotal ?? input.result.finalTotal,
-      }
+        }
       : undefined,
     rollSetId: input.pendingRoll.rollSetId,
     skillId: input.pendingRoll.skillId,
@@ -294,16 +291,17 @@ function buildAssignedRoll(input: {
     supportSkillId: input.pendingRoll.supportSkillId,
     supportSkillLabel: input.pendingRoll.supportSkillLabel,
     supportSkillValue: input.pendingRoll.supportSkillValue,
-    supportResult: input.result?.supportDieResult != null && input.result.supportRollD20 != null
-      ? {
-          dieResult: input.result.supportDieResult,
-          fumble: false,
-          id: `${input.result.id}-support`,
-          openEndedD10s: input.result.supportOpenEndedD10s,
-          rollD20: input.result.supportRollD20,
-          total: input.result.supportNumericSubtotal,
-        }
-      : undefined,
+    supportResult:
+      input.result?.supportDieResult != null && input.result.supportRollD20 != null
+        ? {
+            dieResult: input.result.supportDieResult,
+            fumble: false,
+            id: `${input.result.id}-support`,
+            openEndedD10s: input.result.supportOpenEndedD10s,
+            rollD20: input.result.supportRollD20,
+            total: input.result.supportNumericSubtotal,
+          }
+        : undefined,
     useDbMod: input.pendingRoll.useDbMod,
     useGenMod: input.pendingRoll.useGenMod,
     useObSkillMod: input.pendingRoll.useObSkillMod,
@@ -322,7 +320,7 @@ function findVisibleResultForPendingRoll(input: {
         (entry.participantId === input.pendingRoll.participantId &&
           entry.skillId === input.pendingRoll.skillId &&
           (input.pendingRoll.rollSetId ? entry.rollSetId === input.pendingRoll.rollSetId : true) &&
-          (input.pendingRoll.side ? entry.side === input.pendingRoll.side : true)))
+          (input.pendingRoll.side ? entry.side === input.pendingRoll.side : true))),
   );
 
   return matchingEntries.sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0];
@@ -345,21 +343,27 @@ function isPlayerVisibleRankedResult(input: {
   );
 }
 
-function hasSameRankedStackIdentity(left: RoleplayActionLogEntry, right: RoleplayActionLogEntry): boolean {
+function hasSameRankedStackIdentity(
+  left: RoleplayActionLogEntry,
+  right: RoleplayActionLogEntry,
+): boolean {
   return Boolean(
     left.rollSetId &&
-      right.rollSetId &&
-      left.rollSetId === right.rollSetId &&
-      left.participantId &&
-      right.participantId &&
-      left.participantId === right.participantId &&
-      left.skillId &&
-      right.skillId &&
-      left.skillId === right.skillId
+    right.rollSetId &&
+    left.rollSetId === right.rollSetId &&
+    left.participantId &&
+    right.participantId &&
+    left.participantId === right.participantId &&
+    left.skillId &&
+    right.skillId &&
+    left.skillId === right.skillId,
   );
 }
 
-function isSamePlayerRankedEntry(left: RoleplayActionLogEntry, right: RoleplayActionLogEntry): boolean {
+function isSamePlayerRankedEntry(
+  left: RoleplayActionLogEntry,
+  right: RoleplayActionLogEntry,
+): boolean {
   if (left.pendingRollId && right.pendingRollId) {
     return left.pendingRollId === right.pendingRollId;
   }
@@ -397,18 +401,16 @@ function buildPlayerCharacterLog(input: {
   resolveParticipant: (participantId?: string | null) => EncounterParticipant | undefined;
 }): PlayerGeneralEncounterLogEntry[] {
   return input.entries
-    .filter(
-      (entry) => {
-        const participant = input.resolveParticipant(entry.participantId);
+    .filter((entry) => {
+      const participant = input.resolveParticipant(entry.participantId);
 
-        return (
-          entry.type === "gm_skill_roll" &&
-          !entry.silent &&
-          participant != null &&
-          input.controlledParticipantIds.has(participant.id)
-        );
-      }
-    )
+      return (
+        entry.type === "gm_skill_roll" &&
+        !entry.silent &&
+        participant != null &&
+        input.controlledParticipantIds.has(participant.id)
+      );
+    })
     .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
     .map((entry) => {
       const total = entry.numericSubtotal ?? entry.finalTotal;
@@ -439,6 +441,7 @@ function buildPlayerCharacterLog(input: {
 }
 
 export function buildPlayerGeneralEncounterView(input: {
+  controlledScenarioParticipantId?: string;
   currentUserId?: string;
   encounter: EncounterSession;
   scenarioParticipants: ScenarioParticipant[];
@@ -452,7 +455,7 @@ export function buildPlayerGeneralEncounterView(input: {
       ...state.actionLog
         .filter((entry) => (entry.mode === "opposed" || Boolean(entry.side)) && entry.rollSetId)
         .map((entry) => entry.rollSetId),
-    ].filter((rollSetId): rollSetId is string => Boolean(rollSetId))
+    ].filter((rollSetId): rollSetId is string => Boolean(rollSetId)),
   );
   const membership = resolveEncounterParticipantMembership({
     encounter: input.encounter,
@@ -461,9 +464,11 @@ export function buildPlayerGeneralEncounterView(input: {
   const effectiveEncounterParticipants = membership.participants;
   const usesFallbackParticipants = membership.source === "defaultFallback";
   const orderedParticipants = orderRoleplayEncounterParticipants(effectiveEncounterParticipants);
-  const encounterParticipantsById = new Map(orderedParticipants.map((participant) => [participant.id, participant]));
+  const encounterParticipantsById = new Map(
+    orderedParticipants.map((participant) => [participant.id, participant]),
+  );
   const scenarioParticipantsById = new Map(
-    input.scenarioParticipants.map((participant) => [participant.id, participant])
+    input.scenarioParticipants.map((participant) => [participant.id, participant]),
   );
   const resolveParticipant = (participantId?: string | null): EncounterParticipant | undefined => {
     return resolveEncounterParticipantByRollParticipantId({
@@ -471,17 +476,29 @@ export function buildPlayerGeneralEncounterView(input: {
       participants: orderedParticipants,
     });
   };
+  const inspectedScenarioParticipantIds = new Set(
+    input.controlledScenarioParticipantId ? [input.controlledScenarioParticipantId] : [],
+  );
   const controlledParticipantIds = new Set(
     orderedParticipants
-      .filter(
-        (participant) =>
+      .filter((participant) => {
+        if (
+          participant.scenarioParticipantId &&
+          inspectedScenarioParticipantIds.has(participant.scenarioParticipantId)
+        ) {
+          return true;
+        }
+
+        return (
           input.currentUserId &&
-          getScenarioParticipantControllerId(participant, scenarioParticipantsById) === input.currentUserId
-      )
-      .map((participant) => participant.id)
+          getScenarioParticipantControllerId(participant, scenarioParticipantsById) ===
+            input.currentUserId
+        );
+      })
+      .map((participant) => participant.id),
   );
   const controlledParticipants = orderedParticipants.filter((participant) =>
-    controlledParticipantIds.has(participant.id)
+    controlledParticipantIds.has(participant.id),
   );
   const visibleParticipantIds = new Set(
     orderedParticipants
@@ -491,14 +508,14 @@ export function buildPlayerGeneralEncounterView(input: {
           defaultVisibleWhenNoMatrix: usesFallbackParticipants,
           participant,
           state,
-        })
+        }),
       )
-      .map((participant) => participant.id)
+      .map((participant) => participant.id),
   );
   const visibleParticipants = orderedParticipants
     .filter(
       (participant) =>
-        visibleParticipantIds.has(participant.id) && !controlledParticipantIds.has(participant.id)
+        visibleParticipantIds.has(participant.id) && !controlledParticipantIds.has(participant.id),
     )
     .map((participant) => {
       const description = getParticipantDescription({
@@ -514,20 +531,18 @@ export function buildPlayerGeneralEncounterView(input: {
         shortDescription: description.shortDescription ?? "",
       };
     });
-  const visiblePendingRolls = state.pendingSkillRolls.filter(
-    (roll) => {
-      const participant = resolveParticipant(roll.participantId);
+  const visiblePendingRolls = state.pendingSkillRolls.filter((roll) => {
+    const participant = resolveParticipant(roll.participantId);
 
-      return (
-        !roll.silent &&
-        participant != null &&
-        controlledParticipantIds.has(participant.id) &&
-        visibleParticipantIds.has(participant.id)
-      );
-    }
-  );
+    return (
+      !roll.silent &&
+      participant != null &&
+      controlledParticipantIds.has(participant.id) &&
+      visibleParticipantIds.has(participant.id)
+    );
+  });
   const latestPendingRoll = [...visiblePendingRolls].sort((left, right) =>
-    right.assignedAt.localeCompare(left.assignedAt)
+    right.assignedAt.localeCompare(left.assignedAt),
   )[0];
   const latestPendingRollSetId = latestPendingRoll?.rollSetId;
   const assignedRolls = visiblePendingRolls
@@ -536,7 +551,7 @@ export function buildPlayerGeneralEncounterView(input: {
         ? roll.rollSetId === latestPendingRollSetId
         : latestPendingRoll
           ? roll.id === latestPendingRoll.id
-          : false
+          : false,
     )
     .map((pendingRoll) =>
       buildAssignedRoll({
@@ -549,7 +564,7 @@ export function buildPlayerGeneralEncounterView(input: {
         }),
         state,
         visibleParticipantIds,
-      })
+      }),
     );
   const visibleRankedEntries = state.actionLog.filter((entry) => {
     const participant = resolveParticipant(entry.participantId);
@@ -560,7 +575,7 @@ export function buildPlayerGeneralEncounterView(input: {
         entry,
         opposedRollSetIds,
         visibleParticipantIds: new Set(
-          visibleParticipantIds.has(participant.id) ? [entry.participantId ?? participant.id] : []
+          visibleParticipantIds.has(participant.id) ? [entry.participantId ?? participant.id] : [],
         ),
       })
     );
@@ -573,14 +588,14 @@ export function buildPlayerGeneralEncounterView(input: {
         ? entry.rollSetId === currentRollRoundId
         : currentRollRoundResultId
           ? entry.id === currentRollRoundResultId
-          : false
+          : false,
     )
     .sort(
       (left, right) =>
         Number(Boolean(left.fumble)) - Number(Boolean(right.fumble)) ||
         (right.numericSubtotal ?? Number.NEGATIVE_INFINITY) -
           (left.numericSubtotal ?? Number.NEGATIVE_INFINITY) ||
-        right.createdAt.localeCompare(left.createdAt)
+        right.createdAt.localeCompare(left.createdAt),
     )
     .map((entry) => {
       const participant = resolveParticipant(entry.participantId);

--- a/apps/web/src/lib/campaigns/workspace.test.ts
+++ b/apps/web/src/lib/campaigns/workspace.test.ts
@@ -19,6 +19,7 @@ function scenario(input: Pick<Scenario, "id" | "name">): Scenario {
 
 function encounter(input: {
   id: string;
+  kind?: EncounterSession["kind"];
   participantMembershipMode?: EncounterSession["participantMembershipMode"];
   scenarioId: string;
   status?: EncounterSession["status"];
@@ -33,7 +34,7 @@ function encounter(input: {
     currentTurnIndex: 0,
     declarationsLocked: false,
     id: input.id,
-    kind: "roleplay",
+    kind: input.kind ?? "roleplay",
     participantMembershipMode: input.participantMembershipMode,
     participants: input.scenarioParticipantId
       ? [
@@ -136,6 +137,116 @@ describe("campaign workspace", () => {
     });
 
     expect(state.activeScenarioId).toBeUndefined();
+    expect(state.activeTab).toBe("combat");
+  });
+
+  it("auto-selects the only combat encounter when a GM opens the Combat tab", () => {
+    const state = resolveCampaignWorkspaceState({
+      activeCampaignId: "camp-1",
+      canAccessGmEncounter: true,
+      encounters: [
+        encounter({
+          id: "roleplay-encounter",
+          kind: "roleplay",
+          scenarioId: "scn-1",
+          status: "active",
+        }),
+        encounter({
+          id: "combat-encounter",
+          kind: "combat",
+          scenarioId: "scn-1",
+          status: "planned",
+        }),
+      ],
+      requestedEncounterId: null,
+      requestedScenarioId: "scn-1",
+      requestedTab: "combat",
+      scenarios: [scenario({ id: "scn-1", name: "Session one" })],
+    });
+
+    expect(state.activeScenarioId).toBe("scn-1");
+    expect(state.activeEncounterId).toBe("combat-encounter");
+    expect(state.activeTab).toBe("combat");
+  });
+
+  it("keeps the GM Combat tab in selection mode when multiple combat encounters are available", () => {
+    const state = resolveCampaignWorkspaceState({
+      activeCampaignId: "camp-1",
+      canAccessGmEncounter: true,
+      encounters: [
+        encounter({
+          id: "combat-one",
+          kind: "combat",
+          scenarioId: "scn-1",
+          status: "active",
+        }),
+        encounter({
+          id: "combat-two",
+          kind: "combat",
+          scenarioId: "scn-1",
+          status: "planned",
+        }),
+      ],
+      requestedEncounterId: null,
+      requestedScenarioId: "scn-1",
+      requestedTab: "combat",
+      scenarios: [scenario({ id: "scn-1", name: "Session one" })],
+    });
+
+    expect(state.activeScenarioId).toBe("scn-1");
+    expect(state.activeEncounterId).toBeUndefined();
+    expect(state.activeTab).toBe("combat");
+  });
+
+  it("keeps an explicitly selected roleplaying encounter visible for GM Combat tab messaging", () => {
+    const state = resolveCampaignWorkspaceState({
+      activeCampaignId: "camp-1",
+      canAccessGmEncounter: true,
+      encounters: [
+        encounter({
+          id: "roleplay-encounter",
+          kind: "roleplay",
+          scenarioId: "scn-1",
+          status: "active",
+        }),
+        encounter({
+          id: "combat-encounter",
+          kind: "combat",
+          scenarioId: "scn-1",
+          status: "planned",
+        }),
+      ],
+      requestedEncounterId: "roleplay-encounter",
+      requestedScenarioId: "scn-1",
+      requestedTab: "combat",
+      scenarios: [scenario({ id: "scn-1", name: "Session one" })],
+    });
+
+    expect(state.activeScenarioId).toBe("scn-1");
+    expect(state.activeEncounterId).toBe("roleplay-encounter");
+    expect(state.activeTab).toBe("combat");
+  });
+
+  it("auto-selects the only scenario for a GM opening Combat tab without ids", () => {
+    const state = resolveCampaignWorkspaceState({
+      activeCampaignId: "camp-1",
+      canAccessGmEncounter: true,
+      encounters: [
+        encounter({
+          id: "combat-encounter",
+          kind: "combat",
+          scenarioId: "scn-1",
+          status: "active",
+        }),
+      ],
+      requestedEncounterId: null,
+      requestedScenarioId: null,
+      requestedTab: "combat",
+      scenarios: [scenario({ id: "scn-1", name: "Session one" })],
+    });
+
+    expect(state.activeScenarioId).toBe("scn-1");
+    expect(state.activeEncounterId).toBe("combat-encounter");
     expect(state.activeTab).toBe("combat");
   });
 

--- a/apps/web/src/lib/campaigns/workspace.test.ts
+++ b/apps/web/src/lib/campaigns/workspace.test.ts
@@ -78,21 +78,21 @@ function scenarioParticipant(input: {
 }
 
 describe("campaign workspace", () => {
-  it("keeps the intended left-to-right tab order and hides the GM tab for players", () => {
+  it("keeps the intended left-to-right shared workspace tab order", () => {
     expect(
       buildCampaignWorkspaceTabs({ canAccessGmEncounter: true }).map((tab) => tab.id)
     ).toEqual([
       "campaign",
       "scenario",
-      "gm-encounter",
-      "player-encounter",
+      "encounter",
+      "skill-rolls",
       "character",
       "combat",
     ]);
 
     expect(
       buildCampaignWorkspaceTabs({ canAccessGmEncounter: false }).map((tab) => tab.id)
-    ).toEqual(["campaign", "scenario", "player-encounter", "character", "combat"]);
+    ).toEqual(["campaign", "scenario", "encounter", "skill-rolls", "character", "combat"]);
   });
 
   it("opens the Character tab against the active scenario context", () => {
@@ -108,6 +108,28 @@ describe("campaign workspace", () => {
 
     expect(state.activeScenarioId).toBe("scn-1");
     expect(state.activeTab).toBe("character");
+  });
+
+  it("opens the Skill rolls tab against the selected encounter context", () => {
+    const state = resolveCampaignWorkspaceState({
+      activeCampaignId: "camp-1",
+      canAccessGmEncounter: true,
+      encounters: [
+        encounter({
+          id: "enc-1",
+          scenarioId: "scn-1",
+          status: "active",
+        }),
+      ],
+      requestedEncounterId: "enc-1",
+      requestedScenarioId: "scn-1",
+      requestedTab: "skill-rolls",
+      scenarios: [scenario({ id: "scn-1", name: "Session one" })],
+    });
+
+    expect(state.activeScenarioId).toBe("scn-1");
+    expect(state.activeEncounterId).toBe("enc-1");
+    expect(state.activeTab).toBe("skill-rolls");
   });
 
   it("opens the Combat tab against the active scenario context", () => {
@@ -140,7 +162,7 @@ describe("campaign workspace", () => {
     expect(state.activeTab).toBe("combat");
   });
 
-  it("auto-selects the only combat encounter when a GM opens the Combat tab", () => {
+  it("keeps the GM Combat tab in selection mode when multiple encounters are available", () => {
     const state = resolveCampaignWorkspaceState({
       activeCampaignId: "camp-1",
       canAccessGmEncounter: true,
@@ -165,7 +187,7 @@ describe("campaign workspace", () => {
     });
 
     expect(state.activeScenarioId).toBe("scn-1");
-    expect(state.activeEncounterId).toBe("combat-encounter");
+    expect(state.activeEncounterId).toBeUndefined();
     expect(state.activeTab).toBe("combat");
   });
 
@@ -363,7 +385,7 @@ describe("campaign workspace", () => {
 
     expect(state.activeScenarioId).toBe("scn-1");
     expect(state.activeEncounterId).toBe("enc-1");
-    expect(state.activeTab).toBe("player-encounter");
+    expect(state.activeTab).toBe("encounter");
   });
 
   it("restores a remembered player encounter when the encounter remains visible to the player", () => {
@@ -398,7 +420,7 @@ describe("campaign workspace", () => {
 
     expect(state.activeScenarioId).toBe("scn-1");
     expect(state.activeEncounterId).toBe("enc-1");
-    expect(state.activeTab).toBe("player-encounter");
+    expect(state.activeTab).toBe("encounter");
   });
 
   it("falls back to the scenario tab when the encounter is missing but the scenario is still valid", () => {
@@ -482,7 +504,7 @@ describe("campaign workspace", () => {
 
     expect(state.activeScenarioId).toBe("scn-1");
     expect(state.activeEncounterId).toBe("enc-active");
-    expect(state.activeTab).toBe("player-encounter");
+    expect(state.activeTab).toBe("encounter");
   });
 
   it("uses active scenario participants as the default player access list for empty encounters", () => {
@@ -513,7 +535,7 @@ describe("campaign workspace", () => {
 
     expect(state.activeScenarioId).toBe("scn-1");
     expect(state.activeEncounterId).toBe("enc-empty");
-    expect(state.activeTab).toBe("player-encounter");
+    expect(state.activeTab).toBe("encounter");
   });
 
   it("does not use inactive scenario participants for empty encounter player access", () => {
@@ -545,7 +567,7 @@ describe("campaign workspace", () => {
 
     expect(state.activeScenarioId).toBe("scn-1");
     expect(state.activeEncounterId).toBeUndefined();
-    expect(state.activeTab).toBe("player-encounter");
+    expect(state.activeTab).toBe("encounter");
   });
 
   it("does not fall back when explicit membership mode has an empty list", () => {
@@ -576,7 +598,7 @@ describe("campaign workspace", () => {
 
     expect(state.activeScenarioId).toBe("scn-1");
     expect(state.activeEncounterId).toBeUndefined();
-    expect(state.activeTab).toBe("player-encounter");
+    expect(state.activeTab).toBe("encounter");
   });
 
   it("keeps explicit encounter membership strict once participants are assigned", () => {
@@ -612,7 +634,7 @@ describe("campaign workspace", () => {
 
     expect(state.activeScenarioId).toBe("scn-1");
     expect(state.activeEncounterId).toBeUndefined();
-    expect(state.activeTab).toBe("player-encounter");
+    expect(state.activeTab).toBe("encounter");
   });
 
   it("invalidates remembered fallback access when explicit membership later excludes the player", () => {
@@ -666,7 +688,7 @@ describe("campaign workspace", () => {
 
     expect(fallbackState.activeEncounterId).toBe("enc-changing");
     expect(explicitState.activeEncounterId).toBeUndefined();
-    expect(explicitState.activeTab).toBe("player-encounter");
+    expect(explicitState.activeTab).toBe("encounter");
   });
 
   it("keeps the player encounter tab for a waiting state when no assigned encounter exists", () => {
@@ -697,6 +719,6 @@ describe("campaign workspace", () => {
 
     expect(state.activeScenarioId).toBe("scn-1");
     expect(state.activeEncounterId).toBeUndefined();
-    expect(state.activeTab).toBe("player-encounter");
+    expect(state.activeTab).toBe("encounter");
   });
 });

--- a/apps/web/src/lib/campaigns/workspace.test.ts
+++ b/apps/web/src/lib/campaigns/workspace.test.ts
@@ -86,13 +86,24 @@ describe("campaign workspace", () => {
       "scenario",
       "encounter",
       "skill-rolls",
+      "player-skill-rolls",
       "character",
       "combat",
+      "player-combat",
     ]);
 
     expect(
       buildCampaignWorkspaceTabs({ canAccessGmEncounter: false }).map((tab) => tab.id)
-    ).toEqual(["campaign", "scenario", "encounter", "skill-rolls", "character", "combat"]);
+    ).toEqual([
+      "campaign",
+      "scenario",
+      "encounter",
+      "skill-rolls",
+      "player-skill-rolls",
+      "character",
+      "combat",
+      "player-combat",
+    ]);
   });
 
   it("opens the Character tab against the active scenario context", () => {
@@ -132,6 +143,28 @@ describe("campaign workspace", () => {
     expect(state.activeTab).toBe("skill-rolls");
   });
 
+  it("opens the Player skill rolls tab against the selected encounter context", () => {
+    const state = resolveCampaignWorkspaceState({
+      activeCampaignId: "camp-1",
+      canAccessGmEncounter: true,
+      encounters: [
+        encounter({
+          id: "enc-1",
+          scenarioId: "scn-1",
+          status: "active",
+        }),
+      ],
+      requestedEncounterId: "enc-1",
+      requestedScenarioId: "scn-1",
+      requestedTab: "player-skill-rolls",
+      scenarios: [scenario({ id: "scn-1", name: "Session one" })],
+    });
+
+    expect(state.activeScenarioId).toBe("scn-1");
+    expect(state.activeEncounterId).toBe("enc-1");
+    expect(state.activeTab).toBe("player-skill-rolls");
+  });
+
   it("opens the Combat tab against the active scenario context", () => {
     const state = resolveCampaignWorkspaceState({
       activeCampaignId: "camp-1",
@@ -145,6 +178,21 @@ describe("campaign workspace", () => {
 
     expect(state.activeScenarioId).toBe("scn-1");
     expect(state.activeTab).toBe("combat");
+  });
+
+  it("opens the Player combat tab against the active scenario context", () => {
+    const state = resolveCampaignWorkspaceState({
+      activeCampaignId: "camp-1",
+      canAccessGmEncounter: false,
+      encounters: [],
+      requestedEncounterId: null,
+      requestedScenarioId: null,
+      requestedTab: "player-combat",
+      scenarios: [scenario({ id: "scn-1", name: "Session one" })],
+    });
+
+    expect(state.activeScenarioId).toBe("scn-1");
+    expect(state.activeTab).toBe("player-combat");
   });
 
   it("keeps the Combat tab open with a missing-context state when no scenario is selected", () => {

--- a/apps/web/src/lib/campaigns/workspace.ts
+++ b/apps/web/src/lib/campaigns/workspace.ts
@@ -9,8 +9,10 @@ export type CampaignWorkspaceTabId =
   | "gm-encounter"
   | "player-encounter"
   | "skill-rolls"
+  | "player-skill-rolls"
   | "character"
-  | "combat";
+  | "combat"
+  | "player-combat";
 
 export interface CampaignWorkspaceTab {
   id: CampaignWorkspaceTabId;
@@ -37,8 +39,10 @@ const orderedTabs: CampaignWorkspaceTab[] = [
   { id: "scenario", label: "Scenario" },
   { id: "encounter", label: "Encounter" },
   { id: "skill-rolls", label: "Skill rolls" },
+  { id: "player-skill-rolls", label: "Player skill rolls" },
   { id: "character", label: "Character" },
-  { id: "combat", label: "Combat" }
+  { id: "combat", label: "Combat" },
+  { id: "player-combat", label: "Player combat" }
 ];
 
 export function buildCampaignWorkspaceHref(input: CampaignWorkspaceHrefInput): string {
@@ -121,10 +125,18 @@ function resolveRequestedCampaignWorkspaceTab(input: {
         : input.canAccessGmEncounter
           ? fallbackTab
           : "skill-rolls";
+    case "player-skill-rolls":
+      return input.activeScenarioId && input.activeEncounterId
+        ? "player-skill-rolls"
+        : input.canAccessGmEncounter
+          ? fallbackTab
+          : "player-skill-rolls";
     case "character":
       return input.activeScenarioId ? "character" : fallbackTab;
     case "combat":
       return "combat";
+    case "player-combat":
+      return input.activeScenarioId ? "player-combat" : fallbackTab;
     default:
       return fallbackTab;
   }
@@ -253,8 +265,10 @@ export function resolveCampaignWorkspaceState(input: {
         requestedTab === "scenario" ||
         requestedTab === "character" ||
         requestedTab === "combat" ||
+        requestedTab === "player-combat" ||
         requestedTab === "encounter" ||
-        requestedTab === "skill-rolls"
+        requestedTab === "skill-rolls" ||
+        requestedTab === "player-skill-rolls"
       ) &&
       input.scenarios.length === 1
     ) {
@@ -263,13 +277,25 @@ export function resolveCampaignWorkspaceState(input: {
 
     if (
       !activeScenarioId &&
-      (requestedTab === "player-encounter" || requestedTab === "encounter" || requestedTab === "skill-rolls") &&
+      (
+        requestedTab === "player-encounter" ||
+        requestedTab === "encounter" ||
+        requestedTab === "skill-rolls" ||
+        requestedTab === "player-skill-rolls" ||
+        requestedTab === "player-combat"
+      ) &&
       input.scenarios.length === 1
     ) {
       activeScenarioId = input.scenarios[0]?.id;
     }
 
-    if (requestedTab === "player-encounter" || requestedTab === "encounter" || requestedTab === "skill-rolls") {
+    if (
+      requestedTab === "player-encounter" ||
+      requestedTab === "encounter" ||
+      requestedTab === "skill-rolls" ||
+      requestedTab === "player-skill-rolls" ||
+      requestedTab === "player-combat"
+    ) {
       const playerEncounter = resolvePlayerEncounterSelection({
         activeScenarioId,
         encounters: input.encounters,
@@ -285,7 +311,7 @@ export function resolveCampaignWorkspaceState(input: {
         activeEncounterId = undefined;
       }
     }
-  } else if (requestedTab === "combat") {
+  } else if (requestedTab === "combat" || requestedTab === "player-combat") {
     if (!activeScenarioId && input.scenarios.length === 1) {
       activeScenarioId = input.scenarios[0]?.id;
     }

--- a/apps/web/src/lib/campaigns/workspace.ts
+++ b/apps/web/src/lib/campaigns/workspace.ts
@@ -5,8 +5,10 @@ import { isUserAssignedToEffectiveEncounter } from "./encounterParticipantFallba
 export type CampaignWorkspaceTabId =
   | "campaign"
   | "scenario"
+  | "encounter"
   | "gm-encounter"
   | "player-encounter"
+  | "skill-rolls"
   | "character"
   | "combat";
 
@@ -33,8 +35,8 @@ export interface CampaignWorkspaceHrefInput {
 const orderedTabs: CampaignWorkspaceTab[] = [
   { id: "campaign", label: "Campaign" },
   { id: "scenario", label: "Scenario" },
-  { id: "gm-encounter", label: "GM Encounter" },
-  { id: "player-encounter", label: "Player Encounter" },
+  { id: "encounter", label: "Encounter" },
+  { id: "skill-rolls", label: "Skill rolls" },
   { id: "character", label: "Character" },
   { id: "combat", label: "Combat" }
 ];
@@ -65,18 +67,16 @@ export function buildCampaignWorkspaceHref(input: CampaignWorkspaceHrefInput): s
 export function buildCampaignWorkspaceTabs(input: {
   canAccessGmEncounter: boolean;
 }): CampaignWorkspaceTab[] {
-  return orderedTabs.filter(
-    (tab) => input.canAccessGmEncounter || tab.id !== "gm-encounter"
-  );
+  void input;
+  return orderedTabs;
 }
 
 function resolveFallbackCampaignWorkspaceTab(input: {
   activeEncounterId?: string;
   activeScenarioId?: string;
-  canAccessGmEncounter: boolean;
 }): CampaignWorkspaceTabId {
   if (input.activeEncounterId && input.activeScenarioId) {
-    return input.canAccessGmEncounter ? "gm-encounter" : "player-encounter";
+    return "encounter";
   }
 
   if (input.activeScenarioId) {
@@ -95,7 +95,6 @@ function resolveRequestedCampaignWorkspaceTab(input: {
   const fallbackTab = resolveFallbackCampaignWorkspaceTab({
     activeEncounterId: input.activeEncounterId,
     activeScenarioId: input.activeScenarioId,
-    canAccessGmEncounter: input.canAccessGmEncounter,
   });
 
   switch (input.requestedTab) {
@@ -103,18 +102,25 @@ function resolveRequestedCampaignWorkspaceTab(input: {
       return "campaign";
     case "scenario":
       return input.activeScenarioId || !input.canAccessGmEncounter ? "scenario" : "campaign";
-    case "gm-encounter":
+    case "encounter":
+    case "player-encounter":
       if (!input.activeScenarioId || !input.activeEncounterId) {
+        return input.canAccessGmEncounter ? fallbackTab : "encounter";
+      }
+
+      return "encounter";
+    case "gm-encounter":
+      if (!input.canAccessGmEncounter) {
         return fallbackTab;
       }
 
-      return input.canAccessGmEncounter ? "gm-encounter" : "player-encounter";
-    case "player-encounter":
-      if (!input.canAccessGmEncounter) {
-        return "player-encounter";
-      }
-
-      return input.activeScenarioId && input.activeEncounterId ? "player-encounter" : fallbackTab;
+      return input.activeScenarioId && input.activeEncounterId ? "encounter" : fallbackTab;
+    case "skill-rolls":
+      return input.activeScenarioId && input.activeEncounterId
+        ? "skill-rolls"
+        : input.canAccessGmEncounter
+          ? fallbackTab
+          : "skill-rolls";
     case "character":
       return input.activeScenarioId ? "character" : fallbackTab;
     case "combat":
@@ -194,17 +200,16 @@ function resolveGmCombatEncounterSelection(input: {
   encounters: EncounterSession[];
   requestedEncounterId?: string | null;
 }): EncounterSession | undefined {
-  const combatEncounters = input.encounters
+  const candidateEncounters = input.encounters
     .filter((encounter) => !input.activeScenarioId || encounter.scenarioId === input.activeScenarioId)
-    .filter((encounter) => encounter.kind === "combat")
     .filter((encounter) => encounter.status !== "archived");
 
   if (input.requestedEncounterId) {
-    return combatEncounters.find((encounter) => encounter.id === input.requestedEncounterId);
+    return candidateEncounters.find((encounter) => encounter.id === input.requestedEncounterId);
   }
 
-  if (combatEncounters.length === 1) {
-    return combatEncounters[0];
+  if (candidateEncounters.length === 1) {
+    return candidateEncounters[0];
   }
 
   return undefined;
@@ -244,17 +249,27 @@ export function resolveCampaignWorkspaceState(input: {
   if (!input.canAccessGmEncounter) {
     if (
       !activeScenarioId &&
-      (requestedTab === "scenario" || requestedTab === "character" || requestedTab === "combat") &&
+      (
+        requestedTab === "scenario" ||
+        requestedTab === "character" ||
+        requestedTab === "combat" ||
+        requestedTab === "encounter" ||
+        requestedTab === "skill-rolls"
+      ) &&
       input.scenarios.length === 1
     ) {
       activeScenarioId = input.scenarios[0]?.id;
     }
 
-    if (!activeScenarioId && requestedTab === "player-encounter" && input.scenarios.length === 1) {
+    if (
+      !activeScenarioId &&
+      (requestedTab === "player-encounter" || requestedTab === "encounter" || requestedTab === "skill-rolls") &&
+      input.scenarios.length === 1
+    ) {
       activeScenarioId = input.scenarios[0]?.id;
     }
 
-    if (requestedTab === "player-encounter") {
+    if (requestedTab === "player-encounter" || requestedTab === "encounter" || requestedTab === "skill-rolls") {
       const playerEncounter = resolvePlayerEncounterSelection({
         activeScenarioId,
         encounters: input.encounters,
@@ -283,14 +298,11 @@ export function resolveCampaignWorkspaceState(input: {
         )
       : undefined;
 
-    if (!explicitlyRequestedEncounter || explicitlyRequestedEncounter.kind === "combat") {
+    if (!explicitlyRequestedEncounter) {
       const combatEncounter = resolveGmCombatEncounterSelection({
         activeScenarioId,
         encounters: input.encounters,
-        requestedEncounterId:
-          explicitlyRequestedEncounter?.kind === "combat"
-            ? explicitlyRequestedEncounter.id
-            : undefined,
+        requestedEncounterId: undefined,
       });
 
       activeEncounterId = combatEncounter?.id;

--- a/apps/web/src/lib/campaigns/workspace.ts
+++ b/apps/web/src/lib/campaigns/workspace.ts
@@ -189,6 +189,27 @@ function resolvePlayerEncounterSelection(input: {
   )[0];
 }
 
+function resolveGmCombatEncounterSelection(input: {
+  activeScenarioId?: string;
+  encounters: EncounterSession[];
+  requestedEncounterId?: string | null;
+}): EncounterSession | undefined {
+  const combatEncounters = input.encounters
+    .filter((encounter) => !input.activeScenarioId || encounter.scenarioId === input.activeScenarioId)
+    .filter((encounter) => encounter.kind === "combat")
+    .filter((encounter) => encounter.status !== "archived");
+
+  if (input.requestedEncounterId) {
+    return combatEncounters.find((encounter) => encounter.id === input.requestedEncounterId);
+  }
+
+  if (combatEncounters.length === 1) {
+    return combatEncounters[0];
+  }
+
+  return undefined;
+}
+
 export function resolveCampaignWorkspaceState(input: {
   activeCampaignId: string;
   canAccessGmEncounter: boolean;
@@ -248,6 +269,32 @@ export function resolveCampaignWorkspaceState(input: {
       } else {
         activeEncounterId = undefined;
       }
+    }
+  } else if (requestedTab === "combat") {
+    if (!activeScenarioId && input.scenarios.length === 1) {
+      activeScenarioId = input.scenarios[0]?.id;
+    }
+
+    const explicitlyRequestedEncounter = input.requestedEncounterId
+      ? input.encounters.find(
+          (encounter) =>
+            encounter.id === input.requestedEncounterId &&
+            (!activeScenarioId || encounter.scenarioId === activeScenarioId)
+        )
+      : undefined;
+
+    if (!explicitlyRequestedEncounter || explicitlyRequestedEncounter.kind === "combat") {
+      const combatEncounter = resolveGmCombatEncounterSelection({
+        activeScenarioId,
+        encounters: input.encounters,
+        requestedEncounterId:
+          explicitlyRequestedEncounter?.kind === "combat"
+            ? explicitlyRequestedEncounter.id
+            : undefined,
+      });
+
+      activeEncounterId = combatEncounter?.id;
+      activeScenarioId = combatEncounter?.scenarioId ?? activeScenarioId;
     }
   }
 

--- a/docs/product/campaign-scenario-encounter-workflows.md
+++ b/docs/product/campaign-scenario-encounter-workflows.md
@@ -104,18 +104,24 @@ The current workspace tabs should read:
 - Scenario
 - Encounter
 - Skill rolls
+- Player skill rolls
 - Character
 - Combat
+- Player combat
 
-Skill rolls are the encounter roll tool. They own GM skill roll assignment, calculations, ranked roll results, the GM action log, player assigned roll cards, player-safe ranked results, and the character roll log.
+Skill rolls is the GM encounter roll manager. It owns GM skill roll assignment, calculations, ranked roll results, and the GM action log.
+
+Player skill rolls is the player-facing roll view. Players see their own assigned rolls, ranked results, and character roll log. GMs can open the same player-facing screen for a selected participant through the participant picker/shuffler; this inspection is read-only and is not player impersonation.
 
 Character is the encounter participant state/control tool. It owns the current character loadout and Physical state panel for the selected/controlled participant.
 
-Combat is the encounter round/action manager tool. It should be reachable for the selected encounter when the GM wants to use combat flow; roleplay and combat are not separate encounter universes.
+Combat is the GM encounter round/action manager tool. It should be reachable for the selected encounter when the GM wants to use combat flow; roleplay and combat are not separate encounter universes.
+
+Player combat is the player-facing combat/action view. Players see their own combat controls and context. GMs can inspect that same player-facing screen for a selected participant through the participant picker/shuffler; this is read-only unless a future GM-safe edit path is added.
 
 Combat Panel is part of the Encounter workflow. It is separate from Character control for now: Character control tracks the current character/loadout/physical state, while the Combat Panel is the scenario or encounter workspace for combat action context. Future damage tracking, round recording, and combat-effect automation should build on these workflows without rendering inactive placeholders.
 
-GM users may inspect player-facing Skill rolls and Combat views for a selected encounter participant. This inspection uses the same participant picker/shuffler pattern as Character control and does not require logging in as that player. Inspection is a role-safe aid for reviewing what the selected participant can see; player-facing behavior remains controlled by normal access and visibility rules.
+GM player-facing inspection is separate from GM tooling. Player skill rolls is not embedded inside the GM Skill rolls manager, and Player combat is not embedded inside the GM Combat Round Manager. Inspection uses the same participant picker/shuffler pattern as Character control and does not require logging in as that player. Inspection is a role-safe aid for reviewing what the selected participant can see; player-facing behavior remains controlled by normal access and visibility rules.
 
 Current design rules:
 
@@ -193,6 +199,8 @@ Scenario pages should focus on concrete scenario actors, accessible encounters, 
 
 Encounter pages should focus on the current moment of play, player-safe visibility, situation, and visible participants.
 
-Skill rolls pages should focus on assigned rolls, current ranked results, and concise roll logs.
+Skill rolls pages should focus on GM roll assignment and GM roll management.
+
+Player skill rolls pages should focus on assigned rolls, current ranked results, and concise player-safe roll logs.
 
 Player pages should always prefer safety over completeness. If the system cannot confidently show something without revealing GM-only information, it should show less.

--- a/docs/product/campaign-scenario-encounter-workflows.md
+++ b/docs/product/campaign-scenario-encounter-workflows.md
@@ -12,7 +12,7 @@ Campaign is the broad container for play. It manages the campaign roster, campai
 
 Scenario is a concrete story situation inside a campaign. It manages the actors who are currently part of that scenario and the scenario-level setup used by encounters.
 
-Encounter is a specific moment of play inside a scenario. It manages the actors who are present in that encounter, the current player-facing situation, and encounter-specific resolution such as roleplay rolls or combat.
+Encounter is a specific moment of play inside a scenario. It manages the actors who are present in that encounter, the current player-facing situation, access, membership, visibility, and participant descriptions. Skill rolls, Character, and Combat are tools used inside that shared encounter context rather than separate encounter universes.
 
 ## Campaign Workspace
 
@@ -61,7 +61,7 @@ Player responsibilities:
 - Review player-safe scenario information.
 - See active scenario participants that are safe for the player to know about.
 - See accessible encounters when the player has an assigned or default-eligible participant.
-- Open the Player Encounter when available.
+- Open the Encounter when available.
 
 Current design rules:
 
@@ -90,17 +90,28 @@ GM responsibilities:
 - Set the player-facing situation message.
 - Control encounter participant membership when needed.
 - Manage visibility between participants.
-- Assign and resolve roleplay rolls.
-- Run combat encounter tools when applicable.
-- Review action logs, hidden data, and GM-only roll information.
+- Maintain participant names, short descriptions, and detailed encounter descriptions.
 
 Player responsibilities:
 
 - Read the player-facing encounter title, context, and situation.
 - See only visible PCs/NPCs.
-- Resolve assigned non-silent rolls for the player's controlled participant.
-- Review player-safe ranked results and character log entries.
 - Receive clear empty states when not assigned or when no encounter is available.
+
+The current workspace tabs should read:
+
+- Campaign
+- Scenario
+- Encounter
+- Skill rolls
+- Character
+- Combat
+
+Skill rolls are the encounter roll tool. They own GM skill roll assignment, calculations, ranked roll results, the GM action log, player assigned roll cards, player-safe ranked results, and the character roll log.
+
+Character is the encounter participant state/control tool. It owns the current character loadout and Physical state panel for the selected/controlled participant.
+
+Combat is the encounter round/action manager tool. It should be reachable for the selected encounter when the GM wants to use combat flow; roleplay and combat are not separate encounter universes.
 
 Combat Panel is part of the Encounter workflow. It is separate from Character control for now: Character control tracks the current character/loadout/physical state, while the Combat Panel is the scenario or encounter workspace for combat action context. Future damage tracking, round recording, and combat-effect automation should build on these workflows without rendering inactive placeholders.
 
@@ -113,7 +124,7 @@ Current design rules:
 - If an encounter has never had explicit participant membership, the app may internally treat active concrete scenario participants as eligible for access.
 - Once explicit encounter membership is controlled, player access should follow explicit encounter membership only.
 
-Player Encounter pages should not show:
+Player-facing Encounter pages should not show:
 
 - GM-only notes.
 - GM action log.
@@ -178,6 +189,8 @@ Campaign pages should focus on campaign availability and navigation.
 
 Scenario pages should focus on concrete scenario actors, accessible encounters, and player-safe scenario context.
 
-Encounter pages should focus on the current moment of play, player-safe visibility, assigned rolls, current results, and concise logs.
+Encounter pages should focus on the current moment of play, player-safe visibility, situation, and visible participants.
+
+Skill rolls pages should focus on assigned rolls, current ranked results, and concise roll logs.
 
 Player pages should always prefer safety over completeness. If the system cannot confidently show something without revealing GM-only information, it should show less.

--- a/docs/product/campaign-scenario-encounter-workflows.md
+++ b/docs/product/campaign-scenario-encounter-workflows.md
@@ -115,6 +115,8 @@ Combat is the encounter round/action manager tool. It should be reachable for th
 
 Combat Panel is part of the Encounter workflow. It is separate from Character control for now: Character control tracks the current character/loadout/physical state, while the Combat Panel is the scenario or encounter workspace for combat action context. Future damage tracking, round recording, and combat-effect automation should build on these workflows without rendering inactive placeholders.
 
+GM users may inspect player-facing Skill rolls and Combat views for a selected encounter participant. This inspection uses the same participant picker/shuffler pattern as Character control and does not require logging in as that player. Inspection is a role-safe aid for reviewing what the selected participant can see; player-facing behavior remains controlled by normal access and visibility rules.
+
 Current design rules:
 
 - Encounter participants are actors in a specific encounter.

--- a/docs/testing-regression-matrix.md
+++ b/docs/testing-regression-matrix.md
@@ -88,7 +88,7 @@ invariants there, but avoid brittle tests that freeze current layout, section
 order, table order, or exact button placement:
 
 - GM Scenario screen
-- GM/Player Encounter screens
+- Encounter and Skill rolls workspace screens
 - Roleplay encounter roll UI
 - Combat encounter UI
 

--- a/packages/domain/src/encounter/combatRoundManager.test.ts
+++ b/packages/domain/src/encounter/combatRoundManager.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+
+import type { EncounterParticipant, EncounterSession } from "./session";
+
+import {
+  advanceCombatRoundStep,
+  buildCombatRoundInspector,
+  initializeCombatRoundState,
+  setCombatRoundActiveParticipant,
+  setCombatRoundParticipantInitiative,
+  sortCombatRoundParticipantsByInitiative,
+} from "./combatRoundManager";
+import { encounterSessionSchema } from "./session";
+
+function participant(input: { id: string; initiative?: number; label: string }): EncounterParticipant {
+  return {
+    declaration: {
+      actionType: "none",
+      defenseFocus: "none",
+      defensePosture: "none",
+      targetLocation: "any",
+    },
+    facing: "north",
+    id: input.id,
+    initiative: input.initiative ?? 0,
+    label: input.label,
+    order: 0,
+    orientation: "neutral",
+    participantType: "scenario",
+    position: { x: 0, y: 0, zone: "center" },
+    scenarioParticipantId: `scenario-${input.id}`,
+  };
+}
+
+function encounter(input: Partial<EncounterSession> = {}): EncounterSession {
+  return encounterSessionSchema.parse({
+    actionLog: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    currentRound: 3,
+    currentTurnIndex: 0,
+    declarationsLocked: false,
+    id: "encounter-1",
+    kind: "combat",
+    participants: [
+      participant({ id: "gladiator", label: "The Gladiator" }),
+      participant({ id: "guard", label: "City guard" }),
+    ],
+    scenarioId: "scenario-1",
+    status: "active",
+    title: "A doubtful success",
+    turnOrderMode: "manual",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...input,
+  });
+}
+
+describe("combat round manager", () => {
+  it("initializes round state from encounter participants", () => {
+    const state = initializeCombatRoundState({ encounter: encounter() });
+
+    expect(state.roundNumber).toBe(3);
+    expect(state.currentStep).toBe("select_actions");
+    expect(state.selectedParticipantId).toBe("gladiator");
+    expect(state.participants.map((entry) => entry.participantId)).toEqual([
+      "gladiator",
+      "guard",
+    ]);
+    expect(state.participants[0]?.stepStatuses.select_actions).toBe("pending");
+    expect(state.participants[0]?.stepStatuses.round_summary).toBe("pending");
+  });
+
+  it("advances steps in order and resets after round summary", () => {
+    const state = initializeCombatRoundState({ encounter: encounter() });
+    const reviewState = advanceCombatRoundStep(state);
+
+    expect(reviewState.currentStep).toBe("review_action_modifiers");
+    expect(reviewState.selectedStep).toBe("review_action_modifiers");
+    expect(reviewState.participants[0]?.stepStatuses.select_actions).toBe("complete");
+
+    const roundSummaryState = [
+      "review_action_modifiers",
+      "initiative_phase_1",
+      "phase_1_actions",
+      "review_phase_2_actions",
+      "review_phase_2_modifiers",
+      "initiative_phase_2",
+      "phase_2_actions",
+    ].reduce((current) => advanceCombatRoundStep(current), reviewState);
+    const nextRoundState = advanceCombatRoundStep(roundSummaryState);
+
+    expect(roundSummaryState.currentStep).toBe("round_summary");
+    expect(nextRoundState.currentStep).toBe("select_actions");
+    expect(nextRoundState.roundNumber).toBe(4);
+    expect(nextRoundState.participants[0]?.stepStatuses.select_actions).toBe("pending");
+  });
+
+  it("sets the active participant marker", () => {
+    const state = initializeCombatRoundState({ encounter: encounter() });
+    const nextState = setCombatRoundActiveParticipant(state, "guard");
+
+    expect(nextState.activeParticipantId).toBe("guard");
+    expect(nextState.selectedParticipantId).toBe("guard");
+  });
+
+  it("sorts participants by phase initiative values when available", () => {
+    const state = initializeCombatRoundState({ encounter: encounter() });
+    const withGuardInitiative = setCombatRoundParticipantInitiative({
+      initiative: 12,
+      participantId: "guard",
+      phase: "phase1",
+      state,
+    });
+    const withGladiatorInitiative = setCombatRoundParticipantInitiative({
+      initiative: 18,
+      participantId: "gladiator",
+      phase: "phase1",
+      state: withGuardInitiative,
+    });
+
+    expect(
+      sortCombatRoundParticipantsByInitiative({
+        phase: "phase1",
+        state: withGladiatorInitiative,
+      }).map((entry) => entry.participantId),
+    ).toEqual(["gladiator", "guard"]);
+  });
+
+  it("builds inspector data for the selected participant and step", () => {
+    const state = initializeCombatRoundState({ encounter: encounter() });
+    const nextState = advanceCombatRoundStep(state);
+    const inspector = buildCombatRoundInspector({
+      participantId: "gladiator",
+      state: nextState,
+      step: "select_actions",
+    });
+
+    expect(inspector.participant?.label).toBe("The Gladiator");
+    expect(inspector.step).toBe("select_actions");
+    expect(inspector.status).toBe("complete");
+  });
+
+  it("does not alter combat effects or action log when advancing round steps", () => {
+    const session = encounter({
+      actionLog: [
+        {
+          attackRoll: { baseOb: 10, defenseTarget: 5, hit: true, margin: 5, roll: 50, total: 60 },
+          attackerParticipantId: "gladiator",
+          declaration: {
+            actionType: "attack",
+            defenseFocus: "none",
+            defensePosture: "none",
+            targetLocation: "any",
+          },
+          defenderParticipantId: "guard",
+          defense: {
+            dbApplied: false,
+            dbValue: 0,
+            defending: false,
+            parryAttempted: false,
+            parryBase: 0,
+            parrySucceeded: false,
+          },
+          encounterId: "encounter-1",
+          id: "attack-1",
+          order: 0,
+          outcome: "hit",
+          resolvedAt: "2026-01-01T00:00:00.000Z",
+          roundNumber: 3,
+        },
+      ],
+    });
+    const state = initializeCombatRoundState({ encounter: session });
+    const nextState = advanceCombatRoundStep(state);
+    const nextSession = encounterSessionSchema.parse({
+      ...session,
+      combatRoundState: nextState,
+    });
+
+    expect(nextSession.actionLog).toEqual(session.actionLog);
+    expect(nextSession.combatRoundState?.currentStep).toBe("review_action_modifiers");
+  });
+});

--- a/packages/domain/src/encounter/combatRoundManager.test.ts
+++ b/packages/domain/src/encounter/combatRoundManager.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import type { EncounterParticipant, EncounterSession } from "./session";
 
 import {
+  COMBAT_ROUND_STEP_ABBREVIATIONS,
+  COMBAT_ROUND_STEPS,
   advanceCombatRoundStep,
   buildCombatRoundInspector,
   initializeCombatRoundState,
@@ -12,7 +14,11 @@ import {
 } from "./combatRoundManager";
 import { encounterSessionSchema } from "./session";
 
-function participant(input: { id: string; initiative?: number; label: string }): EncounterParticipant {
+function participant(input: {
+  id: string;
+  initiative?: number;
+  label: string;
+}): EncounterParticipant {
   return {
     declaration: {
       actionType: "none",
@@ -55,16 +61,28 @@ function encounter(input: Partial<EncounterSession> = {}): EncounterSession {
 }
 
 describe("combat round manager", () => {
+  it("defines the compact round timeline steps in order", () => {
+    expect(COMBAT_ROUND_STEPS.map((step) => COMBAT_ROUND_STEP_ABBREVIATIONS[step])).toEqual([
+      "DE",
+      "M1",
+      "i1",
+      "P1",
+      "D1",
+      "M2",
+      "i2",
+      "P2",
+      "D2",
+      "SU",
+    ]);
+  });
+
   it("initializes round state from encounter participants", () => {
     const state = initializeCombatRoundState({ encounter: encounter() });
 
     expect(state.roundNumber).toBe(3);
     expect(state.currentStep).toBe("select_actions");
     expect(state.selectedParticipantId).toBe("gladiator");
-    expect(state.participants.map((entry) => entry.participantId)).toEqual([
-      "gladiator",
-      "guard",
-    ]);
+    expect(state.participants.map((entry) => entry.participantId)).toEqual(["gladiator", "guard"]);
     expect(state.participants[0]?.stepStatuses.select_actions).toBe("pending");
     expect(state.participants[0]?.stepStatuses.round_summary).toBe("pending");
   });
@@ -85,6 +103,7 @@ describe("combat round manager", () => {
       "review_phase_2_modifiers",
       "initiative_phase_2",
       "phase_2_actions",
+      "review_phase_2_damage",
     ].reduce((current) => advanceCombatRoundStep(current), reviewState);
     const nextRoundState = advanceCombatRoundStep(roundSummaryState);
 

--- a/packages/domain/src/encounter/combatRoundManager.ts
+++ b/packages/domain/src/encounter/combatRoundManager.ts
@@ -1,0 +1,250 @@
+import { z } from "zod";
+
+import type { EncounterParticipant, EncounterSession } from "./session";
+
+const idSchema = z.string().min(1);
+
+export const combatRoundStepSchema = z.enum([
+  "select_actions",
+  "review_action_modifiers",
+  "initiative_phase_1",
+  "phase_1_actions",
+  "review_phase_2_actions",
+  "review_phase_2_modifiers",
+  "initiative_phase_2",
+  "phase_2_actions",
+  "round_summary",
+]);
+
+export const COMBAT_ROUND_STEPS = combatRoundStepSchema.options;
+
+export const combatRoundStepStatusSchema = z.enum([
+  "pending",
+  "ready",
+  "complete",
+  "skipped",
+]);
+
+export const combatRoundInitiativesSchema = z.object({
+  phase1: z.number().int().optional(),
+  phase2: z.number().int().optional(),
+});
+
+const combatRoundStepStatusesSchema = z.record(
+  combatRoundStepSchema,
+  combatRoundStepStatusSchema,
+);
+
+export const combatRoundParticipantStateSchema = z.object({
+  initiatives: combatRoundInitiativesSchema.default({}),
+  label: z.string().min(1),
+  participantId: idSchema,
+  stepStatuses: combatRoundStepStatusesSchema.default(
+    Object.fromEntries(COMBAT_ROUND_STEPS.map((step) => [step, "pending"])),
+  ),
+});
+
+export const combatRoundStateSchema = z.object({
+  activeParticipantId: idSchema.optional(),
+  currentStep: combatRoundStepSchema.default("select_actions"),
+  participants: z.array(combatRoundParticipantStateSchema).default([]),
+  roundNumber: z.number().int().positive().default(1),
+  selectedParticipantId: idSchema.optional(),
+  selectedStep: combatRoundStepSchema.optional(),
+});
+
+export type CombatRoundStep = z.infer<typeof combatRoundStepSchema>;
+export type CombatRoundStepStatus = z.infer<typeof combatRoundStepStatusSchema>;
+export type CombatRoundInitiatives = z.infer<typeof combatRoundInitiativesSchema>;
+export type CombatRoundParticipantState = z.infer<typeof combatRoundParticipantStateSchema>;
+export type CombatRoundState = z.infer<typeof combatRoundStateSchema>;
+
+function buildDefaultStepStatuses(): Record<CombatRoundStep, CombatRoundStepStatus> {
+  return Object.fromEntries(COMBAT_ROUND_STEPS.map((step) => [step, "pending"])) as Record<
+    CombatRoundStep,
+    CombatRoundStepStatus
+  >;
+}
+
+function mergeStepStatuses(
+  existing?: Partial<Record<CombatRoundStep, CombatRoundStepStatus>>,
+): Record<CombatRoundStep, CombatRoundStepStatus> {
+  return {
+    ...buildDefaultStepStatuses(),
+    ...existing,
+  };
+}
+
+function participantStateFromEncounterParticipant(input: {
+  existing?: CombatRoundParticipantState;
+  participant: EncounterParticipant;
+}): CombatRoundParticipantState {
+  return {
+    initiatives: input.existing?.initiatives ?? {},
+    label: input.participant.label,
+    participantId: input.participant.id,
+    stepStatuses: mergeStepStatuses(input.existing?.stepStatuses),
+  };
+}
+
+export function initializeCombatRoundState(input: {
+  encounter: Pick<EncounterSession, "combatRoundState" | "currentRound" | "participants">;
+}): CombatRoundState {
+  const existing = input.encounter.combatRoundState
+    ? combatRoundStateSchema.parse(input.encounter.combatRoundState)
+    : undefined;
+  const existingByParticipantId = new Map(
+    existing?.participants.map((participant) => [participant.participantId, participant]) ?? [],
+  );
+  const participants = input.encounter.participants.map((participant) =>
+    participantStateFromEncounterParticipant({
+      existing: existingByParticipantId.get(participant.id),
+      participant,
+    }),
+  );
+  const participantIds = new Set(participants.map((participant) => participant.participantId));
+  const selectedParticipantId =
+    existing?.selectedParticipantId && participantIds.has(existing.selectedParticipantId)
+      ? existing.selectedParticipantId
+      : participants[0]?.participantId;
+  const activeParticipantId =
+    existing?.activeParticipantId && participantIds.has(existing.activeParticipantId)
+      ? existing.activeParticipantId
+      : undefined;
+
+  return {
+    activeParticipantId,
+    currentStep: existing?.currentStep ?? "select_actions",
+    participants,
+    roundNumber: existing?.roundNumber ?? input.encounter.currentRound,
+    selectedParticipantId,
+    selectedStep: existing?.selectedStep ?? existing?.currentStep ?? "select_actions",
+  };
+}
+
+export function getNextCombatRoundStep(step: CombatRoundStep): CombatRoundStep {
+  const currentIndex = COMBAT_ROUND_STEPS.indexOf(step);
+
+  return COMBAT_ROUND_STEPS[currentIndex + 1] ?? "select_actions";
+}
+
+export function advanceCombatRoundStep(state: CombatRoundState): CombatRoundState {
+  const normalized = combatRoundStateSchema.parse(state);
+  const nextStep = getNextCombatRoundStep(normalized.currentStep);
+  const startsNextRound = normalized.currentStep === "round_summary";
+
+  return {
+    ...normalized,
+    activeParticipantId: startsNextRound ? undefined : normalized.activeParticipantId,
+    currentStep: nextStep,
+    participants: normalized.participants.map((participant) => ({
+      ...participant,
+      stepStatuses: startsNextRound
+        ? buildDefaultStepStatuses()
+        : {
+            ...participant.stepStatuses,
+            [normalized.currentStep]: "complete",
+          },
+    })),
+    roundNumber: startsNextRound ? normalized.roundNumber + 1 : normalized.roundNumber,
+    selectedStep: nextStep,
+  };
+}
+
+export function setCombatRoundActiveParticipant(
+  state: CombatRoundState,
+  participantId?: string,
+): CombatRoundState {
+  const normalized = combatRoundStateSchema.parse(state);
+  const hasParticipant = normalized.participants.some(
+    (participant) => participant.participantId === participantId,
+  );
+
+  return {
+    ...normalized,
+    activeParticipantId: hasParticipant ? participantId : undefined,
+    selectedParticipantId: hasParticipant ? participantId : normalized.selectedParticipantId,
+  };
+}
+
+export function setCombatRoundSelection(input: {
+  participantId?: string;
+  state: CombatRoundState;
+  step?: CombatRoundStep;
+}): CombatRoundState {
+  const normalized = combatRoundStateSchema.parse(input.state);
+  const hasParticipant = normalized.participants.some(
+    (participant) => participant.participantId === input.participantId,
+  );
+
+  return {
+    ...normalized,
+    selectedParticipantId: hasParticipant ? input.participantId : normalized.selectedParticipantId,
+    selectedStep: input.step ?? normalized.selectedStep,
+  };
+}
+
+export function setCombatRoundParticipantInitiative(input: {
+  initiative?: number;
+  participantId: string;
+  phase: "phase1" | "phase2";
+  state: CombatRoundState;
+}): CombatRoundState {
+  const normalized = combatRoundStateSchema.parse(input.state);
+
+  return {
+    ...normalized,
+    participants: normalized.participants.map((participant) =>
+      participant.participantId === input.participantId
+        ? {
+            ...participant,
+            initiatives: {
+              ...participant.initiatives,
+              [input.phase]: input.initiative,
+            },
+          }
+        : participant,
+    ),
+  };
+}
+
+export function sortCombatRoundParticipantsByInitiative(input: {
+  phase: "phase1" | "phase2";
+  state: CombatRoundState;
+}): CombatRoundParticipantState[] {
+  const normalized = combatRoundStateSchema.parse(input.state);
+
+  return [...normalized.participants].sort((left, right) => {
+    const leftInitiative = left.initiatives[input.phase];
+    const rightInitiative = right.initiatives[input.phase];
+
+    if (leftInitiative !== undefined || rightInitiative !== undefined) {
+      return (rightInitiative ?? Number.NEGATIVE_INFINITY) - (leftInitiative ?? Number.NEGATIVE_INFINITY);
+    }
+
+    return left.label.localeCompare(right.label);
+  });
+}
+
+export function buildCombatRoundInspector(input: {
+  participantId?: string;
+  state: CombatRoundState;
+  step?: CombatRoundStep;
+}): {
+  participant?: CombatRoundParticipantState;
+  status?: CombatRoundStepStatus;
+  step: CombatRoundStep;
+} {
+  const normalized = combatRoundStateSchema.parse(input.state);
+  const step = input.step ?? normalized.selectedStep ?? normalized.currentStep;
+  const participant =
+    normalized.participants.find((entry) => entry.participantId === input.participantId) ??
+    normalized.participants.find((entry) => entry.participantId === normalized.selectedParticipantId) ??
+    normalized.participants[0];
+
+  return {
+    participant,
+    status: participant?.stepStatuses[step],
+    step,
+  };
+}

--- a/packages/domain/src/encounter/combatRoundManager.ts
+++ b/packages/domain/src/encounter/combatRoundManager.ts
@@ -13,27 +13,47 @@ export const combatRoundStepSchema = z.enum([
   "review_phase_2_modifiers",
   "initiative_phase_2",
   "phase_2_actions",
+  "review_phase_2_damage",
   "round_summary",
 ]);
 
 export const COMBAT_ROUND_STEPS = combatRoundStepSchema.options;
+export type CombatRoundStep = z.infer<typeof combatRoundStepSchema>;
 
-export const combatRoundStepStatusSchema = z.enum([
-  "pending",
-  "ready",
-  "complete",
-  "skipped",
-]);
+export const COMBAT_ROUND_STEP_ABBREVIATIONS = {
+  initiative_phase_1: "i1",
+  initiative_phase_2: "i2",
+  phase_1_actions: "P1",
+  phase_2_actions: "P2",
+  review_action_modifiers: "M1",
+  review_phase_2_actions: "D1",
+  review_phase_2_damage: "D2",
+  review_phase_2_modifiers: "M2",
+  round_summary: "SU",
+  select_actions: "DE",
+} satisfies Record<CombatRoundStep, string>;
+
+export const COMBAT_ROUND_STEP_LABELS = {
+  initiative_phase_1: "Initiative phase 1",
+  initiative_phase_2: "Initiative phase 2",
+  phase_1_actions: "Phase 1 actions",
+  phase_2_actions: "Phase 2 actions",
+  review_action_modifiers: "Review phase 1 modifiers",
+  review_phase_2_actions: "Phase 1 damage/effects review",
+  review_phase_2_damage: "Phase 2 damage/effects review",
+  review_phase_2_modifiers: "Review/modify phase 2 actions/modifiers",
+  round_summary: "Summary/update",
+  select_actions: "Declaration",
+} satisfies Record<CombatRoundStep, string>;
+
+export const combatRoundStepStatusSchema = z.enum(["pending", "ready", "complete", "skipped"]);
 
 export const combatRoundInitiativesSchema = z.object({
   phase1: z.number().int().optional(),
   phase2: z.number().int().optional(),
 });
 
-const combatRoundStepStatusesSchema = z.record(
-  combatRoundStepSchema,
-  combatRoundStepStatusSchema,
-);
+const combatRoundStepStatusesSchema = z.record(combatRoundStepSchema, combatRoundStepStatusSchema);
 
 export const combatRoundParticipantStateSchema = z.object({
   initiatives: combatRoundInitiativesSchema.default({}),
@@ -53,7 +73,6 @@ export const combatRoundStateSchema = z.object({
   selectedStep: combatRoundStepSchema.optional(),
 });
 
-export type CombatRoundStep = z.infer<typeof combatRoundStepSchema>;
 export type CombatRoundStepStatus = z.infer<typeof combatRoundStepStatusSchema>;
 export type CombatRoundInitiatives = z.infer<typeof combatRoundInitiativesSchema>;
 export type CombatRoundParticipantState = z.infer<typeof combatRoundParticipantStateSchema>;
@@ -219,7 +238,9 @@ export function sortCombatRoundParticipantsByInitiative(input: {
     const rightInitiative = right.initiatives[input.phase];
 
     if (leftInitiative !== undefined || rightInitiative !== undefined) {
-      return (rightInitiative ?? Number.NEGATIVE_INFINITY) - (leftInitiative ?? Number.NEGATIVE_INFINITY);
+      return (
+        (rightInitiative ?? Number.NEGATIVE_INFINITY) - (leftInitiative ?? Number.NEGATIVE_INFINITY)
+      );
     }
 
     return left.label.localeCompare(right.label);
@@ -239,7 +260,9 @@ export function buildCombatRoundInspector(input: {
   const step = input.step ?? normalized.selectedStep ?? normalized.currentStep;
   const participant =
     normalized.participants.find((entry) => entry.participantId === input.participantId) ??
-    normalized.participants.find((entry) => entry.participantId === normalized.selectedParticipantId) ??
+    normalized.participants.find(
+      (entry) => entry.participantId === normalized.selectedParticipantId,
+    ) ??
     normalized.participants[0];
 
   return {

--- a/packages/domain/src/encounter/session.ts
+++ b/packages/domain/src/encounter/session.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import type { ScenarioParticipant } from "../campaign/scenario";
+import { combatRoundStateSchema } from "./combatRoundManager";
 
 const idSchema = z.string().min(1);
 
@@ -302,6 +303,7 @@ export const encounterParticipantSchema = z.object({
 export const encounterSessionSchema = z.object({
   actionLog: z.array(encounterAttackResolutionSchema).default([]),
   campaignId: idSchema.optional(),
+  combatRoundState: combatRoundStateSchema.optional(),
   createdAt: z.string().min(1),
   currentRound: z.number().int().positive().default(1),
   currentTurnIndex: z.number().int().nonnegative().default(0),

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -9,6 +9,7 @@ export * from "./campaign/scenario";
 export * from "./combat/context";
 export * from "./content/skills";
 export * from "./docs/glantriTerms";
+export * from "./encounter/combatRoundManager";
 export * from "./encounter/combatEffects";
 export * from "./encounter/session";
 export * from "./encounter/roleplay";


### PR DESCRIPTION
## Summary

This PR continues the Campaign → Scenario → Encounter play workflow and introduces the first integrated live-play surfaces:

- unified encounter workspace tabs
- player-safe encounter and skill-roll flow
- Character control tab with physical state and combat effects
- restored Combat tab
- first GM Combat Round Manager skeleton
- GM inspection tabs for player-facing Skill rolls and Combat

The main architectural shift is that **Encounter is now one shared scene/context**, while **Skill rolls**, **Character**, **Combat**, and player-facing inspection screens are tools on that same encounter rather than separate “roleplay vs combat encounter” worlds.

## Workspace model

The Campaign workspace now uses the tab model:

- Campaign
- Scenario
- Encounter
- Skill rolls
- Player skill rolls
- Character
- Combat
- Player combat

### Encounter

The shared encounter surface.

- GM sees situation, visibility, and participant descriptions.
- Player sees situation and visible PCs/NPCs.
- Encounter access, participant membership, and visibility are resolved centrally.

### Skill rolls

The GM skill-roll manager.

- GM can assign and resolve skill rolls.
- Player-facing roll tools were moved out into their own tab.

### Player skill rolls

The player-facing roll screen.

- Players see their own assigned/free roll view.
- GM can inspect this same player-facing view with a participant selector/shuffler.
- GM inspection is read-only; it does not impersonate the player.

### Character

The live character-control/state screen.

- Player sees their controlled character.
- GM can inspect participants with selector + Previous/Next.
- Includes equipment/loadout, physical state, combat effects, and combat state panel.

### Combat

The GM combat orchestration surface.

- Contains the Combat Round Manager.
- No longer requires a separate combat-kind encounter just to open the tool.

### Player combat

The player-facing combat screen.

- Player sees own combat/action context.
- GM can inspect the same player-facing combat screen with participant selector/shuffler.
- GM inspection is read-only.

## Player Encounter / visibility / access fixes

This PR fixes several player access and visibility issues found during manual testing:

- Player can access live scenarios when their character is rostered and assigned.
- Explicit encounter membership now matches by the correct participant identity.
- Player-safe encounter API projection now preserves only the visibility rows/descriptions the player is allowed to use.
- Player Encounter no longer enters successfully while showing no visible participants when the GM visibility grid says otherwise.
- Legacy `gm-encounter` / `player-encounter` URL paths remain compatible as aliases.

## Skill roll flow

Adds and stabilizes player/GM roleplay skill rolls:

- GM can assign rolls to player-controlled participants.
- Player can submit assigned non-silent rolls through a player-safe endpoint.
- GM receives player-submitted results.
- Known skills use Character Sheet total skill level.
- Unknown skills use linked stat average with default raw `Other mod = -3`.
- Roleplay modifiers flow through the workbook percentage modifier pipeline.
- Support rolls display/log separate support dice, but do not yet modify the main result.
- Opposed assigned rolls preserve roll-set identity and actor/opponent side.
- Opposed comparisons resolve correctly.
- Opposed rolls are excluded from ranked results.
- Non-opposed roll stacks keep a shared stack id.
- GM Clear resets the current ranked roll stack for all players.
- Player Clear clears only that player’s local display.

## Campaign / Scenario workflow

Cleanup and bug fixes:

- Campaigns are not self-join.
- Character “Join scenario” uses campaign roster + live scenario eligibility.
- Player Campaign/Scenario pages show story-facing/actionable information only.
- Removed player-facing internal concepts such as scenario kind, combat status, fallback participant counts, and explicit/default membership wording.
- Removed Scenario Kind and Combat columns/selectors from campaign-level scenario UI.
- Campaign roster removal now works through the Member checkbox.
- Bodyless `DELETE` requests no longer send `content-type: application/json`, which was causing Fastify to reject requests before route handling.
- Roster removal uses source-key deletion and does not delete the underlying character/template/entity.

## Character control / Physical state

Adds the live Character control page in the Campaign workspace.

The Character tab includes:

- equipment/loadout controls
- Physical state panel
- Combat State Panel

Physical state now contains:

- Hitpoints and damage
- Combat effects by sum
- Combat effects

Hitpoint changes:

- Physical state uses calculated/max HP, not the raw Health stat roll.
- Location hitpoints use the updated location weights:
  - 4/11 for head/limbs
  - 6/11 for chest/back and abdomen/lower back

Combat State Panel changes:

- `Hitpoints` label renamed to `Max HP`
- added `Distraction lvl`

## Manual Combat Effects tracking

Adds the first manual combat-effects model and GM workflow.

Model:

- `CombatEffectEvent` = what happened / origin
- `CombatEffect` = ongoing effect/state row
- One event can create multiple linked effect rows through `sourceEventId`

Stored on existing scenario participant state JSON; no migration.

Combat effect UI:

- GM can manually create and delete combat effects.
- Player view is read-only.
- Effects display compact event numbers such as `E1`, `E2`.
- Multiple rows from the same event share the same event number.
- Type and Group are separated:
  - Type