### PR TITLE
Feature/player general encounter screen

### DIFF
--- a/apps/api/src/routes/scenarios.test.ts
+++ b/apps/api/src/routes/scenarios.test.ts
@@ -1069,6 +1069,111 @@ describe("scenarios route contract", () => {
     });
   });
 
+  it("allows a GM to submit a selected participant's player-facing assigned roleplay roll", async () => {
+    mocks.requireAuthenticatedUser.mockResolvedValue(mocks.adminUser);
+    const encounter = {
+      actionLog: [],
+      campaignId: "campaign-1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      currentRound: 1,
+      currentTurnIndex: 0,
+      declarationsLocked: false,
+      id: "encounter-1",
+      kind: "roleplay",
+      participants: [
+        {
+          id: "scenario-participant-1",
+          label: "Absent hero",
+          participantType: "scenario",
+          scenarioParticipantId: "participant-1",
+        },
+      ],
+      roleplayState: {
+        actionLog: [],
+        pendingSkillRolls: [
+          {
+            assignedAt: "2026-01-01T00:00:00.000Z",
+            difficulty: "medium",
+            id: "roll-1",
+            mode: "difficulty",
+            otherMod: 0,
+            participantId: "scenario-participant-1",
+            rollSetId: "roll-set-1",
+            silent: false,
+            skillId: "perception",
+            skillLabel: "Perception",
+            skillValue: 10,
+            useDbMod: false,
+            useGenMod: false,
+            useObSkillMod: false,
+          },
+        ],
+      },
+      scenarioId: "scenario-1",
+      status: "active",
+      title: "Courtyard",
+      turnOrderMode: "manual",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    mocks.encounterService.getEncounterById.mockResolvedValue(encounter);
+    mocks.encounterService.updateEncounter.mockImplementation(
+      async (input: { session: unknown }) => input.session,
+    );
+    mocks.scenarioService.getScenarioById.mockResolvedValue({
+      campaignId: "campaign-1",
+      id: "scenario-1",
+      kind: "combat",
+      name: "Bridge Ambush",
+      status: "live",
+    });
+    mocks.campaignService.getCampaignById.mockResolvedValue({
+      gmUserId: "gm-1",
+      id: "campaign-1",
+      name: "Border Trouble",
+      status: "active",
+    });
+    mocks.scenarioService.listScenarioParticipants.mockResolvedValue([
+      {
+        controlledByUserId: "other-player",
+        id: "participant-1",
+        isActive: true,
+        role: "player_character",
+        scenarioId: "scenario-1",
+        snapshot: {
+          displayName: "Absent hero",
+        },
+        sourceType: "character",
+      },
+    ]);
+    const app = await buildScenarioTestApp();
+
+    const response = await app.inject({
+      method: "POST",
+      payload: {
+        pendingRollId: "roll-1",
+        roll: {
+          dieResult: 12,
+          openEndedD10s: [],
+          rollD20: 12,
+        },
+      },
+      url: "/encounters/encounter-1/player-roll",
+    });
+
+    await app.close();
+
+    expect(response.statusCode).toBe(200);
+    const updatedEncounter = mocks.encounterService.updateEncounter.mock.calls[0]?.[0]?.session;
+    expect(updatedEncounter.roleplayState.actionLog[0]).toMatchObject({
+      pendingRollId: "roll-1",
+      participantId: "scenario-participant-1",
+      rollD20: 12,
+      silent: false,
+      skillId: "perception",
+      type: "gm_skill_roll",
+    });
+  });
+
   it("preserves roll set and actor side when a player submits an assigned opposed roll", async () => {
     const encounter = {
       actionLog: [],

--- a/apps/api/src/routes/scenarios/encounterRoutes.ts
+++ b/apps/api/src/routes/scenarios/encounterRoutes.ts
@@ -400,7 +400,10 @@ export const encounterRoutes: FastifyPluginAsync = async (app) => {
         });
       }
 
+      const gmAuthorizedOperation = access.mode === "gm";
+
       if (
+        !gmAuthorizedOperation &&
         !isUserAssignedToEncounterMembership({
           encounter,
           scenarioParticipants,
@@ -423,7 +426,7 @@ export const encounterRoutes: FastifyPluginAsync = async (app) => {
       if (
         !participant ||
         !scenarioParticipant ||
-        scenarioParticipant.controlledByUserId !== user.id ||
+        (!gmAuthorizedOperation && scenarioParticipant.controlledByUserId !== user.id) ||
         !scenarioParticipant.isActive
       ) {
         return reply.code(403).send({

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
@@ -79,6 +79,7 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("Select an encounter to open the Combat Round Manager.");
     expect(source).toContain("Create or open an encounter on Scenario tab");
     expect(source).toContain("onEncounterUpdated");
+    expect(source).toContain("scenarioParticipants={scenarioParticipants}");
     expect(source).toContain("ScenarioPlayerCombatPageContent");
     expect(source).toContain('workspaceTab="combat"');
     expect(source).toContain("Select a scenario to open the combat panel.");

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.test.ts
@@ -54,14 +54,13 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("currentRoundNumber={activeScenario?.liveState?.roundNumber}");
   });
 
-  it("keeps GM Skill rolls focused on GM tools and routes player inspection separately", () => {
+  it("keeps GM Skill rolls focused on GM tools and routes player operation separately", () => {
     const source = readSource();
 
     expect(source).toContain('workspaceState.activeTab === "skill-rolls"');
     expect(source).toContain('workspaceState.activeTab === "player-skill-rolls"');
     expect(source).toContain('screenName="Player skill rolls"');
     expect(source).toContain("inspectionParticipantId={selectedGmInspectableCandidate.id}");
-    expect(source).toContain("readOnlyInspection");
     expect(source).toContain("showWorkspaceHeader={false}");
     expect(source).toContain(
       'selectInspectableParticipant({ participantId, tab: "player-skill-rolls" })',
@@ -96,10 +95,9 @@ describe("CampaignWorkspaceShell roleplay encounter routing", () => {
     expect(source).toContain("ScenarioPlayerCombatPageContent");
     expect(source).toContain('workspaceTab="player-combat"');
     expect(source).toContain("showParticipantSelector={false}");
-    expect(source).toContain("readOnlyInspection");
     expect(source).toContain(
       'selectInspectableParticipant({ participantId, tab: "player-combat" })',
     );
-    expect(source).toContain("No participant is available for player combat inspection.");
+    expect(source).toContain("No participant is available for player combat.");
   });
 });

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
@@ -650,14 +650,14 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
                   embedded
                   encounterId={workspaceState.activeEncounterId}
                   inspectionParticipantId={selectedGmInspectableCandidate.id}
-                  readOnlyInspection
                   scenarioId={workspaceState.activeScenarioId}
                   showWorkspaceHeader={false}
                   surface="skill-rolls"
+                  workspaceTab="player-skill-rolls"
                 />
               ) : (
                 <section style={panelStyle}>
-                  <div>No participant is available for player skill roll inspection.</div>
+                  <div>No participant is available for player skill rolls.</div>
                 </section>
               )}
             </>
@@ -668,6 +668,7 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
               encounterId={workspaceState.activeEncounterId}
               scenarioId={workspaceState.activeScenarioId}
               surface="skill-rolls"
+              workspaceTab="player-skill-rolls"
               workspaceScreenName="Player skill rolls"
             />
           ) : (
@@ -848,7 +849,6 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
                   embedded
                   encounterTitle={activeEncounter.title}
                   participantId={selectedGmInspectableCandidate.id}
-                  readOnlyInspection
                   scenarioId={workspaceState.activeScenarioId}
                   showParticipantSelector={false}
                   showWorkspaceHeader={false}
@@ -856,13 +856,13 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
                 />
               ) : (
                 <section style={panelStyle}>
-                  <div>No participant is available for player combat inspection.</div>
+                  <div>No participant is available for player combat.</div>
                 </section>
               )}
             </>
           ) : canAccessGmEncounter ? (
             <section style={panelStyle}>
-              <strong>Select an encounter to inspect player combat.</strong>
+              <strong>Select an encounter to open player combat.</strong>
               {sortedActiveScenarioEncounters.length > 0 ? (
                 <div style={{ display: "grid", gap: "0.5rem" }}>
                   {sortedActiveScenarioEncounters.map((encounter) => (

--- a/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CampaignWorkspaceShell.tsx
@@ -757,6 +757,7 @@ export default function CampaignWorkspaceShell({ campaignId }: CampaignWorkspace
                     ),
                   );
                 }}
+                scenarioParticipants={scenarioParticipants}
               />
             </>
           ) : canAccessGmEncounter ? (

--- a/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.test.ts
@@ -17,6 +17,7 @@ describe("CharacterWorkspacePanel", () => {
     expect(source).toContain("physicalStateGeneralHitpoints");
     expect(source).toContain("physicalStateCurrentRoundNumber={currentRoundNumber}");
     expect(source).toContain("selectedCandidate.scenarioParticipant.state.health.maxHp");
+    expect(source).toContain("physicalStateCombatContext={selectedCandidate.scenarioParticipant.state.combat.combatContext}");
     expect(source).not.toContain("Combat arena");
   });
 

--- a/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/CharacterWorkspacePanel.tsx
@@ -147,6 +147,7 @@ export default function CharacterWorkspacePanel({
             canEditCombatEffects={isGameMaster}
             characterId={selectedCandidate.characterId}
             onCombatEffectsChange={isGameMaster ? updateSelectedCombatEffects : undefined}
+            physicalStateCombatContext={selectedCandidate.scenarioParticipant.state.combat.combatContext}
             physicalStateCombatEffects={selectedCandidate.scenarioParticipant.state.combatEffects}
             physicalStateCurrentRoundNumber={currentRoundNumber}
             physicalStateEncounterId={activeEncounter?.id}

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.test.ts
@@ -22,6 +22,9 @@ describe("ScenarioPlayerCombatPageContent", () => {
     expect(source).toContain("PlayerCombatModifierPanel");
     expect(source).toContain("PlayerCombatPhasePanel");
     expect(source).toContain("buildPlayerCombatModifierRows");
+    expect(source).toContain("buildEncounterLiveCombatModifierSummary");
+    expect(source).toContain("combatEffects: selectedParticipant?.state.combatEffects");
+    expect(source).toContain("liveCombatModifiers");
     expect(source).toContain('workspaceTab = "player-encounter"');
     expect(source).toContain("displayedParticipant?.displayName ? ` — ${displayedParticipant.displayName}`");
     expect(source).toContain("showParticipantSelector = true");

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.test.ts
@@ -19,6 +19,9 @@ describe("ScenarioPlayerCombatPageContent", () => {
     expect(source).toContain("export default function ScenarioPlayerCombatPageContent");
     expect(source).toContain("Action selector");
     expect(source).toContain("EquipmentLoadoutModule");
+    expect(source).toContain("PlayerCombatModifierPanel");
+    expect(source).toContain("PlayerCombatPhasePanel");
+    expect(source).toContain("buildPlayerCombatModifierRows");
     expect(source).toContain('workspaceTab = "player-encounter"');
     expect(source).toContain("displayedParticipant?.displayName ? ` — ${displayedParticipant.displayName}`");
     expect(source).toContain("showParticipantSelector = true");

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.test.ts
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.test.ts
@@ -23,7 +23,7 @@ describe("ScenarioPlayerCombatPageContent", () => {
     expect(source).toContain("displayedParticipant?.displayName ? ` — ${displayedParticipant.displayName}`");
     expect(source).toContain("showParticipantSelector = true");
     expect(source).toContain("readOnlyInspection = false");
-    expect(source).toContain("GM player-view inspection is read-only.");
+    expect(source).not.toContain("GM player-view inspection is read-only.");
     expect(source).toContain("controlsDisabled || savingCombatContext");
     expect(source).not.toContain("will appear here in the next phase");
     expect(source).not.toContain("will expand into this area");

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.tsx
@@ -32,7 +32,6 @@ import {
   createEmptyPlayerEncounterCombatContext,
   evaluatePlayerEncounterParryLegality,
   getPlayerEncounterAccessibleParticipants,
-  getPlayerEncounterCombatModifierTotals,
   getPlayerEncounterMovementLabel,
   getPlayerEncounterParrySourceLabel,
   isPlayerEncounterActionId,
@@ -60,6 +59,7 @@ import {
 } from "@/lib/browser/rememberedSelection";
 import RememberedCampaignWorkspaceEffect from "@/lib/campaigns/RememberedCampaignWorkspaceEffect";
 import { buildCampaignWorkspaceHref, type CampaignWorkspaceTabId } from "@/lib/campaigns/workspace";
+import { buildEncounterLiveCombatModifierSummary } from "@/lib/campaigns/liveCombatModifiers";
 
 interface ScenarioPlayerCombatPageContentProps {
   campaignId: string;
@@ -482,13 +482,21 @@ export default function ScenarioPlayerCombatPageContent({
     return isEquipmentFeatureState(candidate) ? candidate : null;
   }, [displayedParticipant]);
 
-  const modifierTotals = useMemo(
-    () => getPlayerEncounterCombatModifierTotals(combatContextDraft),
-    [combatContextDraft],
+  const liveCombatModifiers = useMemo(
+    () =>
+      buildEncounterLiveCombatModifierSummary({
+        combatContext: combatContextDraft,
+        combatEffects: selectedParticipant?.state.combatEffects,
+      }),
+    [combatContextDraft, selectedParticipant?.state.combatEffects],
   );
   const modifierRows = useMemo(
-    () => buildPlayerCombatModifierRows({ combatContext: combatContextDraft }),
-    [combatContextDraft],
+    () =>
+      buildPlayerCombatModifierRows({
+        combatContext: combatContextDraft,
+        liveModifiers: liveCombatModifiers,
+      }),
+    [combatContextDraft, liveCombatModifiers],
   );
 
   const loadoutFieldValueMap = useMemo(
@@ -548,13 +556,13 @@ export default function ScenarioPlayerCombatPageContent({
                 : "none",
       },
       situationalModifiers: {
-        attack: modifierTotals.attackTotal,
-        defense: modifierTotals.defenseTotal,
+        attack: 0,
+        defense: 0,
         movement: 0,
         perception: 0,
       },
     }),
-    [modifierTotals.attackTotal, modifierTotals.defenseTotal, parryLegality, selectedActionId],
+    [parryLegality, selectedActionId],
   );
 
   const loadoutModel = useMemo(
@@ -571,6 +579,7 @@ export default function ScenarioPlayerCombatPageContent({
             : null,
         characterId: displayedParticipant?.characterId ?? "",
         combatAllocationInputs,
+        liveCombatModifiers,
         state: controlledEquipmentState,
         throwingWeaponItemId: null,
       }),
@@ -580,6 +589,7 @@ export default function ScenarioPlayerCombatPageContent({
       controlledBuild,
       controlledEquipmentState,
       displayedParticipant,
+      liveCombatModifiers,
     ],
   );
 

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.tsx
@@ -18,6 +18,12 @@ import {
   buildEquipmentLoadoutModuleModel,
   EquipmentLoadoutModule,
 } from "@/features/equipment/loadoutModule";
+import {
+  buildPlayerCombatModifierRows,
+  PlayerCombatModifierPanel,
+  PlayerCombatPhasePanel,
+  playerCombatPanelsGridStyle,
+} from "@/features/player-combat/PlayerCombatPanels";
 import type { EquipmentFeatureState } from "@/features/equipment/types";
 import { useSessionUser } from "@/lib/auth/SessionUserContext";
 import type { CombatAllocationState } from "@glantri/rules-engine";
@@ -478,6 +484,10 @@ export default function ScenarioPlayerCombatPageContent({
 
   const modifierTotals = useMemo(
     () => getPlayerEncounterCombatModifierTotals(combatContextDraft),
+    [combatContextDraft],
+  );
+  const modifierRows = useMemo(
+    () => buildPlayerCombatModifierRows({ combatContext: combatContextDraft }),
     [combatContextDraft],
   );
 
@@ -1067,133 +1077,33 @@ export default function ScenarioPlayerCombatPageContent({
                 />
               </label>
 
-              <section
-                style={{
-                  background: "#fffdf8",
-                  border: "1px solid #d9ddd8",
-                  borderRadius: 10,
-                  display: "grid",
-                  gap: "0.6rem",
-                  padding: "0.75rem",
-                }}
-              >
-                <strong>Combat modifiers</strong>
-                {(
-                  [
-                    ["general", "General", combatContextDraft.modifierBuckets.general],
-                    [
-                      "situation_ob_skill",
-                      "Situation OB/Skill",
-                      combatContextDraft.modifierBuckets.situationObSkill,
-                    ],
-                    [
-                      "situation_db",
-                      "Situation DB",
-                      combatContextDraft.modifierBuckets.situationDb,
-                    ],
-                  ] as const
-                ).map(([bucketKey, label, entries]) => (
-                  <div key={bucketKey} style={{ display: "grid", gap: "0.35rem" }}>
-                    <div style={{ fontSize: "0.9rem", fontWeight: 600 }}>{label}</div>
-                    {entries.map((entry) => (
-                      <div
-                        key={entry.id}
-                        style={{
-                          display: "grid",
-                          gap: "0.35rem",
-                          gridTemplateColumns: "70px 88px minmax(0, 1fr) auto",
-                        }}
-                      >
-                        <input
-                          disabled={controlsDisabled}
-                          onChange={(event) =>
-                            updateModifierBucket(bucketKey, (current) =>
-                              current.map((currentEntry) =>
-                                currentEntry.id === entry.id
-                                  ? {
-                                      ...currentEntry,
-                                      value:
-                                        event.target.value.length > 0
-                                          ? Number(event.target.value)
-                                          : 0,
-                                    }
-                                  : currentEntry,
-                              ),
-                            )
+              <PlayerCombatModifierPanel
+                controlsDisabled={controlsDisabled}
+                onAddEntry={(bucketKey) =>
+                  updateModifierBucket(bucketKey, (current) => [
+                    ...current,
+                    createModifierEntryDraft(),
+                  ])
+                }
+                onRemoveEntry={(bucketKey, entryId) =>
+                  updateModifierBucket(bucketKey, (current) =>
+                    current.filter((currentEntry) => currentEntry.id !== entryId),
+                  )
+                }
+                onUpdateEntry={(bucketKey, entryId, patch) =>
+                  updateModifierBucket(bucketKey, (current) =>
+                    current.map((currentEntry) =>
+                      currentEntry.id === entryId
+                        ? {
+                            ...currentEntry,
+                            ...patch,
                           }
-                          type="number"
-                          value={entry.value}
-                        />
-                        <select
-                          disabled={controlsDisabled}
-                          onChange={(event) =>
-                            updateModifierBucket(bucketKey, (current) =>
-                              current.map((currentEntry) =>
-                                currentEntry.id === entry.id
-                                  ? {
-                                      ...currentEntry,
-                                      scope: event.target.value as "until" | "save",
-                                    }
-                                  : currentEntry,
-                              ),
-                            )
-                          }
-                          value={entry.scope}
-                        >
-                          <option value="until">Until</option>
-                          <option value="save">Save</option>
-                        </select>
-                        <input
-                          disabled={controlsDisabled}
-                          onChange={(event) =>
-                            updateModifierBucket(bucketKey, (current) =>
-                              current.map((currentEntry) =>
-                                currentEntry.id === entry.id
-                                  ? {
-                                      ...currentEntry,
-                                      notes: event.target.value,
-                                    }
-                                  : currentEntry,
-                              ),
-                            )
-                          }
-                          placeholder="Notes"
-                          type="text"
-                          value={entry.notes ?? ""}
-                        />
-                        <button
-                          disabled={controlsDisabled}
-                          onClick={() =>
-                            updateModifierBucket(bucketKey, (current) =>
-                              current.filter((currentEntry) => currentEntry.id !== entry.id),
-                            )
-                          }
-                          type="button"
-                        >
-                          Remove
-                        </button>
-                      </div>
-                    ))}
-                    <button
-                      disabled={controlsDisabled}
-                      onClick={() =>
-                        updateModifierBucket(bucketKey, (current) => [
-                          ...current,
-                          createModifierEntryDraft(),
-                        ])
-                      }
-                      style={{ justifySelf: "start" }}
-                      type="button"
-                    >
-                      Add {label}
-                    </button>
-                  </div>
-                ))}
-                <div style={{ color: "#5e5a50", fontSize: "0.92rem" }}>
-                  General {modifierTotals.generalTotal} · Attack {modifierTotals.attackTotal} ·
-                  Defense {modifierTotals.defenseTotal}
-                </div>
-              </section>
+                        : currentEntry,
+                    ),
+                  )
+                }
+                rows={modifierRows}
+              />
 
               {selectedActionId === "attack_parry" ? (
                 <section
@@ -1285,23 +1195,9 @@ export default function ScenarioPlayerCombatPageContent({
         </div>
 
         <div style={{ display: "grid", gap: "0.9rem" }}>
-          <div style={{ display: "grid", gap: "0.75rem", gridTemplateColumns: "1fr 1fr" }}>
+          <div style={playerCombatPanelsGridStyle}>
             {phaseCards.map((phaseCard) => (
-              <section
-                key={phaseCard.phaseLabel}
-                style={{
-                  background: "#fffdf8",
-                  border: "1px solid #d9ddd8",
-                  borderRadius: 10,
-                  display: "grid",
-                  gap: "0.5rem",
-                  minHeight: 210,
-                  padding: "0.85rem",
-                }}
-              >
-                <strong>{phaseCard.phaseLabel}</strong>
-                <div style={{ fontSize: "1.05rem", fontWeight: 600 }}>{phaseCard.title}</div>
-                <div style={{ color: "#5e5a50" }}>{phaseCard.description}</div>
+              <PlayerCombatPhasePanel key={phaseCard.phaseLabel} phaseCard={phaseCard}>
                 {selectedActionId === "attack_parry" &&
                 phaseCard.phaseLabel === "Phase 1" &&
                 selectedCombatReference ? (
@@ -1326,14 +1222,7 @@ export default function ScenarioPlayerCombatPageContent({
                     </select>
                   </label>
                 ) : null}
-                {phaseCard.stats.length > 0 ? (
-                  <div style={{ display: "grid", gap: "0.25rem", fontSize: "0.95rem" }}>
-                    {phaseCard.stats.map((stat) => (
-                      <div key={stat}>{stat}</div>
-                    ))}
-                  </div>
-                ) : null}
-              </section>
+              </PlayerCombatPhasePanel>
             ))}
           </div>
 

--- a/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.tsx
+++ b/apps/web/app/(app)/campaigns/[campaignId]/scenarios/[scenarioId]/player/combat/ScenarioPlayerCombatPageContent.tsx
@@ -972,7 +972,6 @@ export default function ScenarioPlayerCombatPageContent({
           </h1>
         ) : null}
         {encounterTitle ? <div>Encounter: {encounterTitle}</div> : null}
-        {readOnlyInspection ? <div>GM player-view inspection is read-only.</div> : null}
         {showParticipantSelector ? (
           <label style={{ display: "grid", gap: "0.25rem", maxWidth: 360 }}>
             <span>Character</span>

--- a/apps/web/app/(app)/characters/CharacterControlRoutes.test.ts
+++ b/apps/web/app/(app)/characters/CharacterControlRoutes.test.ts
@@ -23,6 +23,9 @@ describe("character control routes", () => {
 
     expect(sharedViewSource).toContain("Equip items -");
     expect(sharedViewSource).toContain("PhysicalStateSection");
+    expect(sharedViewSource).toContain("buildEncounterLiveCombatModifierSummary");
+    expect(sharedViewSource).toContain("showPhysicalState");
+    expect(sharedViewSource).toContain("liveCombatModifiers");
     expect(sharedViewSource).toContain("calculateCharacterGeneralHitpoints");
     expect(sharedViewSource).toContain("saveCombatEffect");
     expect(sharedViewSource).toContain("draft.sourceEventId");

--- a/apps/web/app/(app)/characters/[id]/components/CharacterLoadoutView.tsx
+++ b/apps/web/app/(app)/characters/[id]/components/CharacterLoadoutView.tsx
@@ -7,6 +7,7 @@ import {
   type CombatEffect,
   type CombatEffectEvent,
   type CombatEffectsState,
+  type ScenarioParticipantCombatContext,
 } from "@glantri/domain";
 
 import type { CombatEffectEditorDraft } from "@/features/equipment/components/PhysicalStateSection";
@@ -28,11 +29,13 @@ import {
 } from "@/lib/api/localServiceClient";
 import { loadLocalCharacterContext } from "@/lib/characters/loadLocalCharacterContext";
 import { buildCharacterPhysicalStateView } from "@/lib/characters/physicalState";
+import { buildEncounterLiveCombatModifierSummary } from "@/lib/campaigns/liveCombatModifiers";
 
 interface CharacterLoadoutViewProps {
   canEditCombatEffects?: boolean;
   characterId: string;
   onCombatEffectsChange?: (nextState: CombatEffectsState) => Promise<void> | void;
+  physicalStateCombatContext?: ScenarioParticipantCombatContext;
   physicalStateCombatEffects?: CombatEffectsState;
   physicalStateEncounterId?: string;
   physicalStateGeneralHitpoints?: number | null;
@@ -64,6 +67,7 @@ export default function CharacterLoadoutView({
   canEditCombatEffects = false,
   characterId,
   onCombatEffectsChange,
+  physicalStateCombatContext,
   physicalStateCombatEffects,
   physicalStateCurrentRoundNumber,
   physicalStateEncounterId,
@@ -143,8 +147,15 @@ export default function CharacterLoadoutView({
   }, [state, throwingWeaponItemId]);
 
   const model = useMemo(
-    () =>
-      buildEquipmentLoadoutModuleModel({
+    () => {
+      const liveCombatModifiers = showPhysicalState
+        ? buildEncounterLiveCombatModifierSummary({
+            combatContext: physicalStateCombatContext,
+            combatEffects: physicalStateCombatEffects,
+          })
+        : undefined;
+
+      return buildEquipmentLoadoutModuleModel({
         characterContext:
           characterContext?.record && characterContext.content
             ? {
@@ -154,10 +165,21 @@ export default function CharacterLoadoutView({
             : null,
         characterId,
         errors,
+        liveCombatModifiers,
         state,
         throwingWeaponItemId
-      }),
-    [characterContext, errors, characterId, state, throwingWeaponItemId]
+      });
+    },
+    [
+      characterContext,
+      errors,
+      characterId,
+      physicalStateCombatContext,
+      physicalStateCombatEffects,
+      showPhysicalState,
+      state,
+      throwingWeaponItemId,
+    ]
   );
   const physicalStateModel = useMemo(
     () =>

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
@@ -44,13 +44,16 @@ describe("CombatRoundManagerPanel", () => {
     const source = readSource();
 
     expect(source).toContain("Combat round inspector");
-    expect(source).toContain("Combat inspector");
-    expect(source).toContain("Selected cell:");
-    expect(source).toContain("This is the current step. Advance commits this step");
+    expect(source).toContain("Combat inspector —");
+    expect(source).toContain("COMBAT_ROUND_STEP_ABBREVIATIONS[inspector.step]");
+    expect(source).toContain("COMBAT_ROUND_STEP_LABELS[inspector.step]");
     expect(source).toContain("buildCombatRoundInspector");
-    expect(source).toContain("Phase 1 initiative:");
-    expect(source).toContain("Phase 2 initiative:");
-    expect(source).toContain("No data recorded for this step.");
+    expect(source).toContain("PlayerCombatModifierPanel");
+    expect(source).toContain("PlayerCombatPhasePanel");
+    expect(source).toContain("readOnly");
+    expect(source).toContain("Phase 1 action");
+    expect(source).toContain("Phase 2 action");
+    expect(source).toContain("Select a participant step to inspect combat details.");
     expect(source).toContain("Previous participant");
     expect(source).toContain("Next participant");
     expect(source).toContain("Previous step");

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
@@ -50,6 +50,8 @@ describe("CombatRoundManagerPanel", () => {
     expect(source).toContain("buildCombatRoundInspector");
     expect(source).toContain("PlayerCombatModifierPanel");
     expect(source).toContain("PlayerCombatPhasePanel");
+    expect(source).toContain("buildEncounterLiveCombatModifierSummary");
+    expect(source).toContain("selectedScenarioParticipant?.state.combatEffects");
     expect(source).toContain("readOnly");
     expect(source).toContain("Phase 1 action");
     expect(source).toContain("Phase 2 action");
@@ -66,7 +68,6 @@ describe("CombatRoundManagerPanel", () => {
     expect(source).toContain("updateEncounterOnServer");
     expect(source).toContain("combatRoundState: nextRoundState");
     expect(source).toContain("currentRound: nextRoundState.roundNumber");
-    expect(source).not.toContain("combatEffects");
     expect(source).not.toContain("actionLog:");
   });
 });

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.test.ts
@@ -32,8 +32,8 @@ describe("CombatRoundManagerPanel", () => {
     expect(source).toContain("COMBAT_ROUND_STEP_ABBREVIATIONS[step]");
     expect(source).toContain("COMBAT_ROUND_STEP_LABELS[step]");
     expect(source).toContain("Participant");
-    expect(source).toContain("activeParticipantId");
-    expect(source).toContain("Set active");
+    expect(source).not.toContain("Set active");
+    expect(source).not.toContain("▶ Active");
     expect(source).toContain("getStatusMarker");
     expect(source).toContain("participant.stepStatuses[step]");
     expect(source).toContain("step === roundState.currentStep");

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
@@ -10,7 +10,6 @@ import {
   advanceCombatRoundStep,
   buildCombatRoundInspector,
   initializeCombatRoundState,
-  setCombatRoundActiveParticipant,
   setCombatRoundSelection,
   sortCombatRoundParticipantsByInitiative,
 } from "@glantri/domain";
@@ -343,24 +342,6 @@ export default function CombatRoundManagerPanel({
                   >
                     <div style={{ display: "grid", gap: "0.25rem" }}>
                       <strong>{participant.label}</strong>
-                      {roundState.activeParticipantId === participant.participantId ? (
-                        <span aria-label={`${participant.label} is active`}>▶ Active</span>
-                      ) : (
-                        <button
-                          disabled={saving}
-                          onClick={() =>
-                            void persistRoundState(
-                              setCombatRoundActiveParticipant(
-                                roundState,
-                                participant.participantId,
-                              ),
-                            )
-                          }
-                          type="button"
-                        >
-                          Set active
-                        </button>
-                      )}
                     </div>
                   </td>
                   {timelineRoundNumbers.flatMap((roundNumber) =>

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 
-import type { CombatRoundStep, EncounterSession } from "@glantri/domain";
+import type { CombatRoundStep, EncounterSession, ScenarioParticipant } from "@glantri/domain";
 import {
   COMBAT_ROUND_STEP_ABBREVIATIONS,
   COMBAT_ROUND_STEP_LABELS,
@@ -22,10 +22,12 @@ import {
   playerCombatPanelsGridStyle,
   type PlayerCombatPhaseCardView,
 } from "@/features/player-combat/PlayerCombatPanels";
+import { buildEncounterLiveCombatModifierSummary } from "@/lib/campaigns/liveCombatModifiers";
 
 interface CombatRoundManagerPanelProps {
   encounter: EncounterSession;
   onEncounterUpdated?: (encounter: EncounterSession) => void;
+  scenarioParticipants?: ScenarioParticipant[];
 }
 
 const panelStyle = {
@@ -129,6 +131,7 @@ function shouldSortByInitiative(step: CombatRoundStep): "phase1" | "phase2" | un
 export default function CombatRoundManagerPanel({
   encounter,
   onEncounterUpdated,
+  scenarioParticipants = [],
 }: CombatRoundManagerPanelProps) {
   const initialRoundState = useMemo(() => initializeCombatRoundState({ encounter }), [encounter]);
   const [roundState, setRoundState] = useState(initialRoundState);
@@ -161,7 +164,34 @@ export default function CombatRoundManagerPanel({
     state: roundState,
     step: roundState.selectedStep,
   });
-  const inspectorModifierRows = useMemo(() => buildPlayerCombatModifierRows({}), []);
+  const selectedEncounterParticipant = encounter.participants.find(
+    (participant) => participant.id === inspector.participant?.participantId,
+  );
+  const selectedScenarioParticipant = selectedEncounterParticipant
+    ? scenarioParticipants.find(
+        (participant) =>
+          participant.id === selectedEncounterParticipant.scenarioParticipantId ||
+          participant.id === selectedEncounterParticipant.id ||
+          (participant.characterId &&
+            participant.characterId === selectedEncounterParticipant.characterId),
+      )
+    : undefined;
+  const inspectorLiveModifiers = useMemo(
+    () =>
+      buildEncounterLiveCombatModifierSummary({
+        combatContext: selectedScenarioParticipant?.state.combat.combatContext,
+        combatEffects: selectedScenarioParticipant?.state.combatEffects,
+      }),
+    [selectedScenarioParticipant],
+  );
+  const inspectorModifierRows = useMemo(
+    () =>
+      buildPlayerCombatModifierRows({
+        combatContext: selectedScenarioParticipant?.state.combat.combatContext,
+        liveModifiers: inspectorLiveModifiers,
+      }),
+    [inspectorLiveModifiers, selectedScenarioParticipant],
+  );
   const inspectorPhaseCards = useMemo<readonly PlayerCombatPhaseCardView[]>(() => {
     if (!inspector.participant) {
       return [];

--- a/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
+++ b/apps/web/src/features/combat-round-manager/CombatRoundManagerPanel.tsx
@@ -15,6 +15,13 @@ import {
 } from "@glantri/domain";
 
 import { updateEncounterOnServer } from "@/lib/api/encounterClient";
+import {
+  buildPlayerCombatModifierRows,
+  PlayerCombatModifierPanel,
+  PlayerCombatPhasePanel,
+  playerCombatPanelsGridStyle,
+  type PlayerCombatPhaseCardView,
+} from "@/features/player-combat/PlayerCombatPanels";
 
 interface CombatRoundManagerPanelProps {
   encounter: EncounterSession;
@@ -73,6 +80,20 @@ function getAdvanceButtonLabel(step: CombatRoundStep): string {
 
 function formatInitiative(value: number | undefined): string {
   return value === undefined ? "init --" : `init ${value}`;
+}
+
+function formatStepStatus(status: string | undefined): string {
+  switch (status) {
+    case "complete":
+      return "Complete";
+    case "ready":
+      return "Ready";
+    case "skipped":
+      return "Skipped";
+    case "pending":
+    default:
+      return "Pending";
+  }
 }
 
 function getStatusMarker(input: { current: boolean; status: string | undefined }): string {
@@ -140,6 +161,39 @@ export default function CombatRoundManagerPanel({
     state: roundState,
     step: roundState.selectedStep,
   });
+  const inspectorModifierRows = useMemo(() => buildPlayerCombatModifierRows({}), []);
+  const inspectorPhaseCards = useMemo<readonly PlayerCombatPhaseCardView[]>(() => {
+    if (!inspector.participant) {
+      return [];
+    }
+
+    return [
+      {
+        description: "Current phase 1 action context for the selected participant.",
+        phaseLabel: "Phase 1",
+        stats: [
+          `Initiative: ${formatInitiative(inspector.participant.initiatives.phase1)}`,
+          `Action status: ${formatStepStatus(inspector.participant.stepStatuses.phase_1_actions)}`,
+          `Damage review: ${formatStepStatus(
+            inspector.participant.stepStatuses.review_phase_2_actions,
+          )}`,
+        ],
+        title: "Phase 1 action",
+      },
+      {
+        description: "Current phase 2 action context for the selected participant.",
+        phaseLabel: "Phase 2",
+        stats: [
+          `Initiative: ${formatInitiative(inspector.participant.initiatives.phase2)}`,
+          `Action status: ${formatStepStatus(inspector.participant.stepStatuses.phase_2_actions)}`,
+          `Damage review: ${formatStepStatus(
+            inspector.participant.stepStatuses.review_phase_2_damage,
+          )}`,
+        ],
+        title: "Phase 2 action",
+      },
+    ];
+  }, [inspector.participant]);
 
   useEffect(() => {
     setRoundState(initialRoundState);
@@ -420,48 +474,56 @@ export default function CombatRoundManagerPanel({
           border: "1px solid #e3e1dc",
           borderRadius: 10,
           display: "grid",
-          gap: "0.5rem",
+          gap: "0.75rem",
           padding: "0.75rem",
         }}
       >
-        <h3 style={{ margin: 0 }}>Combat inspector</h3>
         {inspector.participant ? (
           <>
-            <div>
-              Selected cell: <strong>{inspector.participant.label}</strong> · Round{" "}
-              {selectedRoundNumber} · {COMBAT_ROUND_STEP_ABBREVIATIONS[inspector.step]} (
-              {COMBAT_ROUND_STEP_LABELS[inspector.step]})
+            <div
+              style={{
+                alignItems: "center",
+                display: "flex",
+                flexWrap: "wrap",
+                gap: "0.75rem",
+                justifyContent: "space-between",
+              }}
+            >
+              <div>
+                <h3 style={{ margin: 0 }}>
+                  Combat inspector — {inspector.participant.label} · Round {selectedRoundNumber} ·{" "}
+                  {COMBAT_ROUND_STEP_ABBREVIATIONS[inspector.step]}
+                </h3>
+                <div style={{ color: "#5e5a50", fontSize: "0.92rem" }}>
+                  {COMBAT_ROUND_STEP_LABELS[inspector.step]} ·{" "}
+                  {formatStepStatus(inspector.status)}
+                </div>
+              </div>
+              <div style={inspectorNavStyle}>
+                <button onClick={() => moveSelection({ participantOffset: -1 })} type="button">
+                  Previous participant
+                </button>
+                <button onClick={() => moveSelection({ participantOffset: 1 })} type="button">
+                  Next participant
+                </button>
+                <button onClick={() => moveSelection({ stepOffset: -1 })} type="button">
+                  Previous step
+                </button>
+                <button onClick={() => moveSelection({ stepOffset: 1 })} type="button">
+                  Next step
+                </button>
+              </div>
             </div>
-            <div>Status: {inspector.status ?? "pending"}</div>
-            <div>
-              {inspector.step === roundState.currentStep
-                ? "This is the current step. Advance commits this step and moves the process forward."
-                : "This is a timeline cell for review or preparation."}
-            </div>
-            <div>
-              Phase 1 initiative: {formatInitiative(inspector.participant.initiatives.phase1)}
-            </div>
-            <div>
-              Phase 2 initiative: {formatInitiative(inspector.participant.initiatives.phase2)}
-            </div>
-            <div>No data recorded for this step.</div>
-            <div style={inspectorNavStyle}>
-              <button onClick={() => moveSelection({ participantOffset: -1 })} type="button">
-                Previous participant
-              </button>
-              <button onClick={() => moveSelection({ participantOffset: 1 })} type="button">
-                Next participant
-              </button>
-              <button onClick={() => moveSelection({ stepOffset: -1 })} type="button">
-                Previous step
-              </button>
-              <button onClick={() => moveSelection({ stepOffset: 1 })} type="button">
-                Next step
-              </button>
+
+            <div style={playerCombatPanelsGridStyle}>
+              <PlayerCombatModifierPanel readOnly rows={inspectorModifierRows} />
+              {inspectorPhaseCards.map((phaseCard) => (
+                <PlayerCombatPhasePanel key={phaseCard.phaseLabel} phaseCard={phaseCard} />
+              ))}
             </div>
           </>
         ) : (
-          <div>No participant selected.</div>
+          <div>Select a participant step to inspect combat details.</div>
         )}
       </section>
     </section>

--- a/apps/web/src/features/equipment/combatStatePanel.test.ts
+++ b/apps/web/src/features/equipment/combatStatePanel.test.ts
@@ -231,6 +231,18 @@ describe("combatStatePanel throwing row reliability", () => {
     expect(source).toContain("input.characterContext.record.build.profile.distractionLevel");
   });
 
+  it("keeps live encounter combat modifiers behind an explicit loadout model option", () => {
+    const source = readFileSync(join(featurePath, "loadoutModule.tsx"), "utf8");
+
+    expect(source).toContain("liveCombatModifiers?: EncounterLiveCombatModifierSummary");
+    expect(source).toContain("applyLiveRawModifierToCombatValue");
+    expect(source).toContain("input.liveCombatModifiers");
+    expect(source).toContain('Modified by: ${input.liveCombatModifiers.modifierNoteLabels.join(", ")}');
+    expect(source).toContain('columnLabels: ["OB", "OB2", "OB3", "Parry"]');
+    expect(source).toContain('columnLabels: ["DB"]');
+    expect(source).toContain('columnLabels: ["Skill level", "Encumbered"]');
+  });
+
   it("includes the throwing row whenever the same valid throwing selection is recomputed", () => {
     const state = createState();
 

--- a/apps/web/src/features/equipment/combatStatePanel.ts
+++ b/apps/web/src/features/equipment/combatStatePanel.ts
@@ -26,6 +26,7 @@ export interface CombatStateTableModel {
 export interface CombatStatePanelModel {
   title: string;
   description: string;
+  modifierSourceNote?: string;
   statsRows: CombatStateDetailRow[];
   statsTable?: CombatStateTableModel;
   armorRows?: CombatStateDetailRow[];

--- a/apps/web/src/features/equipment/components/CombatStatePanel.tsx
+++ b/apps/web/src/features/equipment/components/CombatStatePanel.tsx
@@ -113,6 +113,12 @@ function TableCard(input: {
 export function CombatStatePanel(input: { model: CombatStatePanelModel }) {
   return (
     <SectionCard title={input.model.title} description={input.model.description}>
+      {input.model.modifierSourceNote ? (
+        <div style={{ color: "#5e5a50", fontSize: "0.92rem" }}>
+          {input.model.modifierSourceNote}
+        </div>
+      ) : null}
+
       <StatGrid>
         <BattleStatCard
           title="Combat stats and skills"

--- a/apps/web/src/features/equipment/loadoutModule.tsx
+++ b/apps/web/src/features/equipment/loadoutModule.tsx
@@ -30,6 +30,10 @@ import {
 import { CombatStatePanel } from "./components/CombatStatePanel";
 import type { EquipmentFeatureState } from "./types";
 import { lookupWorkbookCompositeAdjustment } from "./workbookCompositeTable";
+import {
+  applyLiveRawModifierToCombatValue,
+  type EncounterLiveCombatModifierSummary,
+} from "@/lib/campaigns/liveCombatModifiers";
 import styles from "./loadoutModule.module.css";
 
 type EncumbranceDependentSkillType = "combat" | "covert" | "physical";
@@ -61,6 +65,58 @@ export interface EquipmentLoadoutModuleModel {
   combatStatePanelModel: ReturnType<typeof buildCombatStatePanelModel> | null;
   encumbranceSkillsTable: CombatStateTableModel | null;
   fields: EquipmentLoadoutFieldModel[];
+}
+
+function getIntegerCombatPanelValue(value: string | number): number | null {
+  if (typeof value === "number") {
+    return Number.isInteger(value) ? value : null;
+  }
+
+  if (!/^-?\d+$/.test(value)) {
+    return null;
+  }
+
+  return Number(value);
+}
+
+function applyLiveModifierToPanelValue(
+  value: string | number,
+  rawModifier: number,
+): string | number {
+  const numericValue = getIntegerCombatPanelValue(value);
+  if (numericValue == null) {
+    return value;
+  }
+
+  return applyLiveRawModifierToCombatValue({
+    baseValue: numericValue,
+    rawModifier,
+  });
+}
+
+function applyLiveModifierToTableColumns(input: {
+  columnLabels: string[];
+  rawModifier: number;
+  table: CombatStateTableModel;
+}): CombatStateTableModel {
+  const columnIndexes = input.columnLabels
+    .map((label) => input.table.columns.indexOf(label))
+    .filter((index) => index >= 0);
+
+  if (columnIndexes.length === 0 || input.rawModifier === 0) {
+    return input.table;
+  }
+
+  return {
+    ...input.table,
+    rows: input.table.rows.map((row) =>
+      row.map((cell, index) =>
+        columnIndexes.includes(index)
+          ? applyLiveModifierToPanelValue(cell, input.rawModifier)
+          : cell,
+      ),
+    ),
+  };
 }
 
 function getItemName(input: {
@@ -351,6 +407,7 @@ export function buildEquipmentLoadoutModuleModel(input: {
   characterId: string;
   combatAllocationInputs?: typeof defaultCombatAllocationState;
   errors?: Partial<Record<Exclude<LoadoutFieldId, "throwing">, string | undefined>>;
+  liveCombatModifiers?: EncounterLiveCombatModifierSummary;
   state: EquipmentFeatureState | null;
   throwingWeaponItemId?: string | null;
 }): EquipmentLoadoutModuleModel {
@@ -363,6 +420,17 @@ export function buildEquipmentLoadoutModuleModel(input: {
   }
 
   const combatAllocationInputs = input.combatAllocationInputs ?? defaultCombatAllocationState;
+  const effectiveCombatAllocationInputs = input.liveCombatModifiers
+    ? {
+        ...combatAllocationInputs,
+        situationalModifiers: {
+          ...combatAllocationInputs.situationalModifiers,
+          attack: 0,
+          defense: 0,
+          perception: 0,
+        },
+      }
+    : combatAllocationInputs;
   const sheetSummary = buildCharacterSheetSummary({
     build: input.characterContext.record.build,
     content: input.characterContext.content
@@ -395,7 +463,7 @@ export function buildEquipmentLoadoutModuleModel(input: {
     input.state,
     input.characterId,
     characterCombatInputs,
-    combatAllocationInputs
+    effectiveCombatAllocationInputs
   );
   const throwingWeaponOptions = buildLoadoutThrowingWeaponOptions({
     characterId: input.characterId,
@@ -434,7 +502,7 @@ export function buildEquipmentLoadoutModuleModel(input: {
     input.state,
     input.characterId,
     characterCombatInputs,
-    combatAllocationInputs,
+    effectiveCombatAllocationInputs,
     input.throwingWeaponItemId || null
   );
   const statsRows: CombatStateDetailRow[] = [
@@ -460,10 +528,36 @@ export function buildEquipmentLoadoutModuleModel(input: {
     skills: input.characterContext.content.skills,
     workbookPerceptionValue
   });
+  const liveObSkillRaw =
+    (input.liveCombatModifiers?.generalFatigueRaw ?? 0) +
+    (input.liveCombatModifiers?.obSkillRaw ?? 0);
+  const liveDbRaw =
+    (input.liveCombatModifiers?.generalFatigueRaw ?? 0) +
+    (input.liveCombatModifiers?.dbRaw ?? 0);
   const combatStatePanelModel = {
     ...baseModel,
+    modifierSourceNote: input.liveCombatModifiers
+      ? `Modified by: ${input.liveCombatModifiers.modifierNoteLabels.join(", ")}`
+      : undefined,
     statsRows,
-    statsTable
+    statsTable: input.liveCombatModifiers
+      ? applyLiveModifierToTableColumns({
+          columnLabels: ["Skill level", "Encumbered"],
+          rawModifier: liveObSkillRaw,
+          table: statsTable,
+        })
+      : statsTable,
+    weaponModeTable: input.liveCombatModifiers
+      ? applyLiveModifierToTableColumns({
+          columnLabels: ["OB", "OB2", "OB3", "Parry"],
+          rawModifier: liveObSkillRaw,
+          table: applyLiveModifierToTableColumns({
+            columnLabels: ["DB"],
+            rawModifier: liveDbRaw,
+            table: baseModel.weaponModeTable,
+          }),
+        })
+      : baseModel.weaponModeTable,
   };
 
   const movementModifier =

--- a/apps/web/src/features/player-combat/PlayerCombatPanels.test.ts
+++ b/apps/web/src/features/player-combat/PlayerCombatPanels.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const sourcePath = join(dirname(fileURLToPath(import.meta.url)), "PlayerCombatPanels.tsx");
+
+function readSource(): string {
+  return readFileSync(sourcePath, "utf8");
+}
+
+describe("PlayerCombatPanels", () => {
+  it("exposes reusable combat modifier rows with the shared player combat buckets", () => {
+    const source = readSource();
+
+    expect(source).toContain("buildPlayerCombatModifierRows");
+    expect(source).toContain("getPlayerEncounterCombatModifierTotals");
+    expect(source).toContain("General/Fatigue");
+    expect(source).toContain("Skill/OB");
+    expect(source).toContain("DB");
+  });
+
+  it("keeps player combat modifiers editable while allowing read-only inspector use", () => {
+    const source = readSource();
+
+    expect(source).toContain("PlayerCombatModifierPanel");
+    expect(source).toContain("readOnly");
+    expect(source).toContain("onAddEntry");
+    expect(source).toContain("onRemoveEntry");
+    expect(source).toContain("onUpdateEntry");
+    expect(source).toContain("disabled={controlsDisabled}");
+  });
+
+  it("renders reusable phase panels for Phase 1 and Phase 2 combat summaries", () => {
+    const source = readSource();
+
+    expect(source).toContain("PlayerCombatPhasePanel");
+    expect(source).toContain("phaseCard.phaseLabel");
+    expect(source).toContain("phaseCard.title");
+    expect(source).toContain("phaseCard.description");
+    expect(source).toContain("phaseCard.stats");
+  });
+});

--- a/apps/web/src/features/player-combat/PlayerCombatPanels.test.ts
+++ b/apps/web/src/features/player-combat/PlayerCombatPanels.test.ts
@@ -16,6 +16,7 @@ describe("PlayerCombatPanels", () => {
     expect(source).toContain("buildPlayerCombatModifierRows");
     expect(source).toContain("getPlayerEncounterCombatModifierTotals");
     expect(source).toContain("General/Fatigue");
+    expect(source).toContain("liveModifiers?.generalFatigueRaw");
     expect(source).toContain("Skill/OB");
     expect(source).toContain("DB");
   });
@@ -29,6 +30,7 @@ describe("PlayerCombatPanels", () => {
     expect(source).toContain("onRemoveEntry");
     expect(source).toContain("onUpdateEntry");
     expect(source).toContain("disabled={controlsDisabled}");
+    expect(source).toContain("row.locked");
   });
 
   it("renders reusable phase panels for Phase 1 and Phase 2 combat summaries", () => {

--- a/apps/web/src/features/player-combat/PlayerCombatPanels.tsx
+++ b/apps/web/src/features/player-combat/PlayerCombatPanels.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import type {
+  ScenarioCombatModifierBucket,
+  ScenarioCombatModifierEntry,
+  ScenarioParticipantCombatContext,
+} from "@glantri/domain";
+
+import {
+  createEmptyPlayerEncounterCombatContext,
+  getPlayerEncounterCombatModifierTotals,
+} from "@/lib/campaigns/playerEncounter";
+
+export interface PlayerCombatModifierBucketView {
+  bucketKey: ScenarioCombatModifierBucket;
+  entries: ScenarioCombatModifierEntry[];
+  fatigueTotal?: number;
+  label: string;
+  total: number;
+}
+
+export interface PlayerCombatPhaseCardView {
+  description: string;
+  phaseLabel: string;
+  stats: readonly string[];
+  title: string;
+}
+
+interface PlayerCombatModifierPanelProps {
+  controlsDisabled?: boolean;
+  onAddEntry?: (bucketKey: ScenarioCombatModifierBucket) => void;
+  onRemoveEntry?: (bucketKey: ScenarioCombatModifierBucket, entryId: string) => void;
+  onUpdateEntry?: (
+    bucketKey: ScenarioCombatModifierBucket,
+    entryId: string,
+    patch: Partial<Pick<ScenarioCombatModifierEntry, "notes" | "scope" | "value">>,
+  ) => void;
+  readOnly?: boolean;
+  rows: readonly PlayerCombatModifierBucketView[];
+}
+
+interface PlayerCombatPhasePanelProps {
+  children?: ReactNode;
+  phaseCard: PlayerCombatPhaseCardView;
+}
+
+export const playerCombatPanelCardStyle = {
+  background: "#fffdf8",
+  border: "1px solid #d9ddd8",
+  borderRadius: 10,
+  display: "grid",
+  gap: "0.6rem",
+  padding: "0.75rem",
+} as const;
+
+export const playerCombatPanelsGridStyle = {
+  display: "grid",
+  gap: "0.75rem",
+  gridTemplateColumns: "repeat(auto-fit, minmax(14rem, 1fr))",
+} as const;
+
+function getDisplayTotal(row: PlayerCombatModifierBucketView | undefined): number {
+  return row ? row.total + (row.fatigueTotal ?? 0) : 0;
+}
+
+export function buildPlayerCombatModifierRows(input: {
+  combatContext?: ScenarioParticipantCombatContext;
+  fatigueTotal?: number;
+}): PlayerCombatModifierBucketView[] {
+  const combatContext = input.combatContext ?? createEmptyPlayerEncounterCombatContext();
+  const totals = getPlayerEncounterCombatModifierTotals(combatContext);
+
+  return [
+    {
+      bucketKey: "general",
+      entries: combatContext.modifierBuckets.general,
+      fatigueTotal: input.fatigueTotal ?? 0,
+      label: "General/Fatigue",
+      total: totals.generalTotal,
+    },
+    {
+      bucketKey: "situation_ob_skill",
+      entries: combatContext.modifierBuckets.situationObSkill,
+      label: "Skill/OB",
+      total: totals.situationObSkillTotal,
+    },
+    {
+      bucketKey: "situation_db",
+      entries: combatContext.modifierBuckets.situationDb,
+      label: "DB",
+      total: totals.situationDbTotal,
+    },
+  ];
+}
+
+export function PlayerCombatModifierPanel({
+  controlsDisabled = false,
+  onAddEntry,
+  onRemoveEntry,
+  onUpdateEntry,
+  readOnly = false,
+  rows,
+}: PlayerCombatModifierPanelProps) {
+  const editable = !readOnly && onAddEntry && onRemoveEntry && onUpdateEntry;
+  const generalTotal = getDisplayTotal(rows.find((row) => row.bucketKey === "general") ?? rows[0]);
+  const skillObTotal = getDisplayTotal(
+    rows.find((row) => row.bucketKey === "situation_ob_skill") ?? rows[1],
+  );
+  const dbTotal = getDisplayTotal(rows.find((row) => row.bucketKey === "situation_db") ?? rows[2]);
+
+  return (
+    <section style={playerCombatPanelCardStyle}>
+      <strong>Combat modifiers</strong>
+      {rows.map((row) => (
+        <div key={row.bucketKey} style={{ display: "grid", gap: "0.35rem" }}>
+          <div style={{ alignItems: "center", display: "flex", gap: "0.5rem" }}>
+            <span style={{ fontSize: "0.9rem", fontWeight: 600 }}>{row.label}</span>
+            <span style={{ color: "#5e5a50", fontSize: "0.9rem" }}>
+              {getDisplayTotal(row) >= 0 ? "+" : ""}
+              {getDisplayTotal(row)}
+            </span>
+          </div>
+
+          {editable
+            ? row.entries.map((entry) => (
+                <div
+                  key={entry.id}
+                  style={{
+                    display: "grid",
+                    gap: "0.35rem",
+                    gridTemplateColumns: "70px 88px minmax(0, 1fr) auto",
+                  }}
+                >
+                  <input
+                    disabled={controlsDisabled}
+                    onChange={(event) =>
+                      onUpdateEntry(row.bucketKey, entry.id, {
+                        value: event.target.value.length > 0 ? Number(event.target.value) : 0,
+                      })
+                    }
+                    type="number"
+                    value={entry.value}
+                  />
+                  <select
+                    disabled={controlsDisabled}
+                    onChange={(event) =>
+                      onUpdateEntry(row.bucketKey, entry.id, {
+                        scope: event.target.value as "until" | "save",
+                      })
+                    }
+                    value={entry.scope}
+                  >
+                    <option value="until">Until</option>
+                    <option value="save">Save</option>
+                  </select>
+                  <input
+                    disabled={controlsDisabled}
+                    onChange={(event) =>
+                      onUpdateEntry(row.bucketKey, entry.id, {
+                        notes: event.target.value,
+                      })
+                    }
+                    placeholder="Notes"
+                    type="text"
+                    value={entry.notes ?? ""}
+                  />
+                  <button
+                    disabled={controlsDisabled}
+                    onClick={() => onRemoveEntry(row.bucketKey, entry.id)}
+                    type="button"
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))
+            : row.entries.map((entry) => (
+                <div key={entry.id} style={{ color: "#5e5a50", fontSize: "0.9rem" }}>
+                  {entry.value >= 0 ? "+" : ""}
+                  {entry.value} · {entry.scope}
+                  {entry.notes ? ` · ${entry.notes}` : ""}
+                </div>
+              ))}
+
+          {editable ? (
+            <button
+              disabled={controlsDisabled}
+              onClick={() => onAddEntry(row.bucketKey)}
+              style={{ justifySelf: "start" }}
+              type="button"
+            >
+              Add {row.label}
+            </button>
+          ) : null}
+        </div>
+      ))}
+
+      <div style={{ color: "#5e5a50", fontSize: "0.92rem" }}>
+        General/Fatigue {generalTotal} · Attack {generalTotal + skillObTotal} · Defense{" "}
+        {generalTotal + dbTotal}
+      </div>
+    </section>
+  );
+}
+
+export function PlayerCombatPhasePanel({ children, phaseCard }: PlayerCombatPhasePanelProps) {
+  return (
+    <section
+      style={{
+        ...playerCombatPanelCardStyle,
+        minHeight: 210,
+        padding: "0.85rem",
+      }}
+    >
+      <strong>{phaseCard.phaseLabel}</strong>
+      <div style={{ fontSize: "1.05rem", fontWeight: 600 }}>{phaseCard.title}</div>
+      <div style={{ color: "#5e5a50" }}>{phaseCard.description}</div>
+      {children}
+      {phaseCard.stats.length > 0 ? (
+        <div style={{ display: "grid", gap: "0.25rem", fontSize: "0.95rem" }}>
+          {phaseCard.stats.map((stat) => (
+            <div key={stat}>{stat}</div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/features/player-combat/PlayerCombatPanels.tsx
+++ b/apps/web/src/features/player-combat/PlayerCombatPanels.tsx
@@ -12,12 +12,14 @@ import {
   createEmptyPlayerEncounterCombatContext,
   getPlayerEncounterCombatModifierTotals,
 } from "@/lib/campaigns/playerEncounter";
+import type { EncounterLiveCombatModifierSummary } from "@/lib/campaigns/liveCombatModifiers";
 
 export interface PlayerCombatModifierBucketView {
   bucketKey: ScenarioCombatModifierBucket;
   entries: ScenarioCombatModifierEntry[];
   fatigueTotal?: number;
   label: string;
+  locked?: boolean;
   total: number;
 }
 
@@ -67,7 +69,7 @@ function getDisplayTotal(row: PlayerCombatModifierBucketView | undefined): numbe
 
 export function buildPlayerCombatModifierRows(input: {
   combatContext?: ScenarioParticipantCombatContext;
-  fatigueTotal?: number;
+  liveModifiers?: EncounterLiveCombatModifierSummary;
 }): PlayerCombatModifierBucketView[] {
   const combatContext = input.combatContext ?? createEmptyPlayerEncounterCombatContext();
   const totals = getPlayerEncounterCombatModifierTotals(combatContext);
@@ -75,22 +77,22 @@ export function buildPlayerCombatModifierRows(input: {
   return [
     {
       bucketKey: "general",
-      entries: combatContext.modifierBuckets.general,
-      fatigueTotal: input.fatigueTotal ?? 0,
+      entries: [],
       label: "General/Fatigue",
-      total: totals.generalTotal,
+      locked: true,
+      total: input.liveModifiers?.generalFatigueRaw ?? 0,
     },
     {
       bucketKey: "situation_ob_skill",
       entries: combatContext.modifierBuckets.situationObSkill,
       label: "Skill/OB",
-      total: totals.situationObSkillTotal,
+      total: input.liveModifiers?.obSkillRaw ?? totals.situationObSkillTotal,
     },
     {
       bucketKey: "situation_db",
       entries: combatContext.modifierBuckets.situationDb,
       label: "DB",
-      total: totals.situationDbTotal,
+      total: input.liveModifiers?.dbRaw ?? totals.situationDbTotal,
     },
   ];
 }
@@ -123,7 +125,7 @@ export function PlayerCombatModifierPanel({
             </span>
           </div>
 
-          {editable
+          {editable && !row.locked
             ? row.entries.map((entry) => (
                 <div
                   key={entry.id}
@@ -183,7 +185,7 @@ export function PlayerCombatModifierPanel({
                 </div>
               ))}
 
-          {editable ? (
+          {editable && !row.locked ? (
             <button
               disabled={controlsDisabled}
               onClick={() => onAddEntry(row.bucketKey)}

--- a/apps/web/src/features/roleplay/RoleplayEncounterScreens.test.ts
+++ b/apps/web/src/features/roleplay/RoleplayEncounterScreens.test.ts
@@ -131,17 +131,19 @@ describe("RoleplayEncounterScreens", () => {
     expect(source).toContain("resolveEncounterParticipantByRollParticipantId");
   });
 
-  it("supports read-only GM inspection of the player-facing Skill rolls screen", () => {
+  it("supports GM operation of the player-facing Skill rolls screen for selected participants", () => {
     const playerSource = readPlayerScreenSource();
 
     expect(playerSource).toContain("inspectionParticipantId");
     expect(playerSource).toContain("readOnlyInspection");
     expect(playerSource).toContain("controlledScenarioParticipantId: inspectedParticipantId");
-    expect(playerSource).toContain("GM player-view inspection is read-only.");
+    expect(playerSource).toContain("const inspectedParticipantId = isGameMaster");
     expect(playerSource).toContain("disabled={!canUsePlayerActions || Boolean(roll.result)}");
     expect(playerSource).toContain("showWorkspaceHeader");
+    expect(playerSource).toContain("workspaceTab");
     expect(playerSource).toContain('workspaceScreenName = "Skill rolls"');
     expect(playerSource).toContain("{workspaceScreenName}");
+    expect(playerSource).not.toContain("GM player-view inspection is read-only.");
   });
 
   it("preserves opposed result matching and player submitted roll identity", () => {

--- a/apps/web/src/features/roleplay/RoleplayEncounterScreens.tsx
+++ b/apps/web/src/features/roleplay/RoleplayEncounterScreens.tsx
@@ -112,6 +112,7 @@ interface PlayerRoleplayingEncounterScreenProps {
   scenarioId: string;
   showWorkspaceHeader?: boolean;
   surface?: "encounter" | "full" | "skill-rolls";
+  workspaceTab?: "encounter" | "player-skill-rolls" | "skill-rolls";
   workspaceScreenName?: string;
 }
 
@@ -1641,6 +1642,7 @@ export function PlayerRoleplayingEncounterScreen({
   scenarioId,
   showWorkspaceHeader = true,
   surface = "full",
+  workspaceTab,
   workspaceScreenName = "Skill rolls",
 }: PlayerRoleplayingEncounterScreenProps) {
   const [campaign, setCampaign] = useState<Campaign | null>(null);
@@ -1667,8 +1669,7 @@ export function PlayerRoleplayingEncounterScreen({
   const isGameMaster = Boolean(
     currentUser?.roles.includes("game_master") || currentUser?.roles.includes("admin"),
   );
-  const inspectedParticipantId =
-    readOnlyInspection && isGameMaster ? inspectionParticipantId : undefined;
+  const inspectedParticipantId = isGameMaster ? inspectionParticipantId : undefined;
   const situationRef = useRef<HTMLDivElement>(null);
 
   const fetchRoleplayEncounter = useCallback(async () => {
@@ -1793,7 +1794,7 @@ export function PlayerRoleplayingEncounterScreen({
   });
   const showEncounterContext = surface !== "skill-rolls";
   const showSkillRollTools = surface !== "encounter";
-  const rememberedTab = surface === "skill-rolls" ? "skill-rolls" : "encounter";
+  const rememberedTab = workspaceTab ?? (surface === "skill-rolls" ? "skill-rolls" : "encounter");
 
   if (currentUser && playerView.controlledParticipantIds.length === 0) {
     return (
@@ -2071,7 +2072,6 @@ export function PlayerRoleplayingEncounterScreen({
             {workspaceScreenName}
             {selectedPlayerFacingName ? ` — ${selectedPlayerFacingName}` : ""}
           </h2>
-          {readOnlyInspection ? <div>GM player-view inspection is read-only.</div> : null}
         </section>
       ) : null}
       {feedback ? <section style={panelStyle}>{feedback}</section> : null}

--- a/apps/web/src/lib/campaigns/liveCombatModifiers.test.ts
+++ b/apps/web/src/lib/campaigns/liveCombatModifiers.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import type { CombatEffectsState } from "@glantri/domain";
+import { lookupWorkbookPercentageAdjustment } from "@glantri/rules-engine";
+
+import {
+  applyLiveRawModifierToCombatValue,
+  buildEncounterLiveCombatModifierSummary,
+  sumEncounterCombatEffectModifiers,
+} from "./liveCombatModifiers";
+
+function effect(overrides: Partial<CombatEffectsState["effects"][number]>) {
+  return {
+    createdAt: "2026-05-19T00:00:00.000Z",
+    damage: 0,
+    effectGroup: "general",
+    generalDamage: 0,
+    id: `effect-${overrides.type ?? "general"}-${overrides.status ?? "active"}`,
+    modifierValue: -1,
+    sourceEventId: "event-1",
+    status: "active",
+    targetParticipantId: "participant-1",
+    type: "general_modifier",
+    updatedAt: "2026-05-19T00:00:00.000Z",
+    ...overrides,
+  } satisfies CombatEffectsState["effects"][number];
+}
+
+describe("live combat modifiers", () => {
+  it("sums active general and fatigue effects into General/Fatigue", () => {
+    const sums = sumEncounterCombatEffectModifiers({
+      effects: [
+        effect({ effectGroup: "general", modifierValue: -4, type: "stun" }),
+        effect({ effectGroup: "fatigue", modifierValue: -2, type: "fatigue" }),
+        effect({ effectGroup: "general", modifierValue: -99, status: "resolved" }),
+        effect({ effectGroup: "fatigue", modifierValue: -99, status: "expired", type: "fatigue" }),
+      ],
+      events: [],
+    });
+
+    expect(sums.general).toBe(-4);
+    expect(sums.fatigue).toBe(-2);
+    expect(sums.generalFatigue).toBe(-6);
+  });
+
+  it("keeps resolved, expired, and superseded effects out of live summaries", () => {
+    const summary = buildEncounterLiveCombatModifierSummary({
+      combatEffects: {
+        effects: [
+          effect({ effectGroup: "obSkill", modifierValue: 3, status: "resolved" }),
+          effect({ effectGroup: "db", modifierValue: 4, status: "expired" }),
+          effect({ effectGroup: "fatigue", modifierValue: -5, status: "superseded", type: "fatigue" }),
+        ],
+        events: [],
+      },
+    });
+
+    expect(summary.generalFatigueRaw).toBe(0);
+    expect(summary.obSkillRaw).toBe(0);
+    expect(summary.dbRaw).toBe(0);
+  });
+
+  it("uses the workbook percentage modifier table for live combat value adjustments", () => {
+    const expectedAdjustment = lookupWorkbookPercentageAdjustment(20, 6);
+
+    expect(expectedAdjustment).not.toBeNull();
+    expect(
+      applyLiveRawModifierToCombatValue({
+        baseValue: 20,
+        rawModifier: -6,
+      }),
+    ).toBe(20 - expectedAdjustment!);
+  });
+
+  it("adds manual OB/Skill and DB context totals while keeping General/Fatigue effect-owned", () => {
+    const summary = buildEncounterLiveCombatModifierSummary({
+      combatContext: {
+        modifierBuckets: {
+          general: [{ id: "old-general", scope: "until", value: -99 }],
+          situationDb: [{ id: "manual-db", scope: "until", value: 2 }],
+          situationObSkill: [{ id: "manual-ob", scope: "until", value: 3 }],
+        },
+      },
+      combatEffects: {
+        effects: [
+          effect({ effectGroup: "general", modifierValue: -4, type: "stun" }),
+          effect({ effectGroup: "fatigue", modifierValue: -2, type: "fatigue" }),
+          effect({ effectGroup: "obSkill", modifierValue: 1, type: "morale" }),
+          effect({ effectGroup: "db", modifierValue: -1, type: "fear" }),
+        ],
+        events: [],
+      },
+    });
+
+    expect(summary.generalFatigueRaw).toBe(-6);
+    expect(summary.obSkillRaw).toBe(4);
+    expect(summary.dbRaw).toBe(1);
+    expect(summary.modifierNoteLabels).toEqual(["Gen/Fatigue", "OB/Skill", "DB", "Enc", "Equipment"]);
+  });
+});

--- a/apps/web/src/lib/campaigns/liveCombatModifiers.test.ts
+++ b/apps/web/src/lib/campaigns/liveCombatModifiers.test.ts
@@ -72,6 +72,32 @@ describe("live combat modifiers", () => {
     ).toBe(20 - expectedAdjustment!);
   });
 
+  it("documents workbook live modifier results for zero, shield, and combined defense bases", () => {
+    expect(lookupWorkbookPercentageAdjustment(0, 1)).toBe(0);
+    expect(
+      applyLiveRawModifierToCombatValue({
+        baseValue: 0,
+        rawModifier: -1,
+      }),
+    ).toBe(0);
+
+    expect(lookupWorkbookPercentageAdjustment(14, 1)).toBe(1);
+    expect(
+      applyLiveRawModifierToCombatValue({
+        baseValue: 14,
+        rawModifier: -1,
+      }),
+    ).toBe(13);
+
+    expect(lookupWorkbookPercentageAdjustment(15, 1)).toBe(2);
+    expect(
+      applyLiveRawModifierToCombatValue({
+        baseValue: 15,
+        rawModifier: -1,
+      }),
+    ).toBe(13);
+  });
+
   it("adds manual OB/Skill and DB context totals while keeping General/Fatigue effect-owned", () => {
     const summary = buildEncounterLiveCombatModifierSummary({
       combatContext: {

--- a/apps/web/src/lib/campaigns/liveCombatModifiers.test.ts
+++ b/apps/web/src/lib/campaigns/liveCombatModifiers.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { CombatEffectsState } from "@glantri/domain";
-import { lookupWorkbookPercentageAdjustment } from "@glantri/rules-engine";
+import {
+  calculateWorkbookDefensePair,
+  lookupWorkbookPercentageAdjustment,
+} from "@glantri/rules-engine";
 
 import {
   applyLiveRawModifierToCombatValue,
@@ -73,13 +76,31 @@ describe("live combat modifiers", () => {
   });
 
   it("documents workbook live modifier results for zero, shield, and combined defense bases", () => {
-    expect(lookupWorkbookPercentageAdjustment(0, 1)).toBe(0);
+    expect(lookupWorkbookPercentageAdjustment(0, 1)).toBe(1);
     expect(
       applyLiveRawModifierToCombatValue({
         baseValue: 0,
         rawModifier: -1,
       }),
-    ).toBe(0);
+    ).toBe(-1);
+    expect(
+      applyLiveRawModifierToCombatValue({
+        baseValue: 0,
+        rawModifier: 1,
+      }),
+    ).toBe(1);
+    expect(
+      applyLiveRawModifierToCombatValue({
+        baseValue: 0,
+        rawModifier: 3,
+      }),
+    ).toBe(3);
+    expect(
+      applyLiveRawModifierToCombatValue({
+        baseValue: 0,
+        rawModifier: 100,
+      }),
+    ).toBe(100);
 
     expect(lookupWorkbookPercentageAdjustment(14, 1)).toBe(1);
     expect(
@@ -96,6 +117,33 @@ describe("live combat modifiers", () => {
         rawModifier: -1,
       }),
     ).toBe(13);
+  });
+
+  it("documents current defense overlay versus summed raw modifier strategy", () => {
+    const baseDb = 10;
+    const equipmentModifier = 5;
+    const liveDbModifier = -1;
+    const theoreticalDefense = calculateWorkbookDefensePair({
+      baseDb,
+      equipmentModifier,
+      toHitModifier: 0,
+    });
+    const currentLiveOverlay =
+      theoreticalDefense == null
+        ? null
+        : applyLiveRawModifierToCombatValue({
+            baseValue: theoreticalDefense.db,
+            rawModifier: liveDbModifier,
+          });
+    const summedRawModifier = calculateWorkbookDefensePair({
+      baseDb,
+      equipmentModifier: equipmentModifier + liveDbModifier,
+      toHitModifier: 0,
+    });
+
+    expect(theoreticalDefense?.db).toBe(15);
+    expect(currentLiveOverlay).toBe(13);
+    expect(summedRawModifier?.db).toBe(14);
   });
 
   it("adds manual OB/Skill and DB context totals while keeping General/Fatigue effect-owned", () => {

--- a/apps/web/src/lib/campaigns/liveCombatModifiers.ts
+++ b/apps/web/src/lib/campaigns/liveCombatModifiers.ts
@@ -1,0 +1,114 @@
+import type {
+  CombatEffect,
+  CombatEffectsState,
+  ScenarioParticipantCombatContext,
+} from "@glantri/domain";
+import { lookupWorkbookPercentageAdjustment } from "@glantri/rules-engine";
+
+import { getPlayerEncounterCombatModifierTotals } from "./playerEncounter";
+
+export interface EncounterCombatEffectModifierSums {
+  db: number;
+  fatigue: number;
+  general: number;
+  generalFatigue: number;
+  obSkill: number;
+}
+
+export interface EncounterLiveCombatModifierSummary {
+  dbRaw: number;
+  generalFatigueRaw: number;
+  modifierNoteLabels: string[];
+  obSkillRaw: number;
+}
+
+function isActiveCombatEffect(effect: CombatEffect): boolean {
+  return effect.status === "active";
+}
+
+function getEffectMagnitude(effect: CombatEffect): number {
+  if (effect.modifierValue != null) {
+    return effect.modifierValue;
+  }
+
+  if (effect.damage !== 0) {
+    return effect.damage;
+  }
+
+  return effect.generalDamage;
+}
+
+function contributesToModifier(effect: CombatEffect): boolean {
+  return (
+    effect.type !== "physical_damage" &&
+    effect.type !== "general_damage" &&
+    effect.type !== "bleed" &&
+    effect.type !== "internal_bleed"
+  );
+}
+
+export function sumEncounterCombatEffectModifiers(
+  combatEffects?: CombatEffectsState,
+): EncounterCombatEffectModifierSums {
+  const activeEffects = combatEffects?.effects.filter(isActiveCombatEffect) ?? [];
+  const fatigue = activeEffects
+    .filter((effect) => contributesToModifier(effect) && (effect.type === "fatigue" || effect.effectGroup === "fatigue"))
+    .reduce((total, effect) => total + getEffectMagnitude(effect), 0);
+  const general = activeEffects
+    .filter(
+      (effect) =>
+        contributesToModifier(effect) &&
+        effect.effectGroup === "general" &&
+        effect.type !== "fatigue",
+    )
+    .reduce((total, effect) => total + getEffectMagnitude(effect), 0);
+  const obSkill = activeEffects
+    .filter((effect) => contributesToModifier(effect) && effect.effectGroup === "obSkill")
+    .reduce((total, effect) => total + getEffectMagnitude(effect), 0);
+  const db = activeEffects
+    .filter((effect) => contributesToModifier(effect) && effect.effectGroup === "db")
+    .reduce((total, effect) => total + getEffectMagnitude(effect), 0);
+
+  return {
+    db,
+    fatigue,
+    general,
+    generalFatigue: general + fatigue,
+    obSkill,
+  };
+}
+
+export function buildEncounterLiveCombatModifierSummary(input: {
+  combatContext?: ScenarioParticipantCombatContext;
+  combatEffects?: CombatEffectsState;
+}): EncounterLiveCombatModifierSummary {
+  const effectSums = sumEncounterCombatEffectModifiers(input.combatEffects);
+  const contextTotals = getPlayerEncounterCombatModifierTotals(input.combatContext);
+
+  return {
+    dbRaw: effectSums.db + contextTotals.situationDbTotal,
+    generalFatigueRaw: effectSums.generalFatigue,
+    modifierNoteLabels: ["Gen/Fatigue", "OB/Skill", "DB", "Enc", "Equipment"],
+    obSkillRaw: effectSums.obSkill + contextTotals.situationObSkillTotal,
+  };
+}
+
+export function applyLiveRawModifierToCombatValue(input: {
+  baseValue: number;
+  rawModifier: number;
+}): number {
+  if (input.rawModifier === 0) {
+    return input.baseValue;
+  }
+
+  const adjustment = lookupWorkbookPercentageAdjustment(
+    input.baseValue,
+    Math.abs(input.rawModifier),
+  );
+
+  if (adjustment == null) {
+    return input.baseValue;
+  }
+
+  return input.rawModifier > 0 ? input.baseValue + adjustment : input.baseValue - adjustment;
+}

--- a/docs/product/campaign-scenario-encounter-workflows.md
+++ b/docs/product/campaign-scenario-encounter-workflows.md
@@ -111,17 +111,17 @@ The current workspace tabs should read:
 
 Skill rolls is the GM encounter roll manager. It owns GM skill roll assignment, calculations, ranked roll results, and the GM action log.
 
-Player skill rolls is the player-facing roll view. Players see their own assigned rolls, ranked results, and character roll log. GMs can open the same player-facing screen for a selected participant through the participant picker/shuffler; this inspection is read-only and is not player impersonation.
+Player skill rolls is the player-facing roll view. Players see their own assigned rolls, ranked results, and character roll log. GMs can open the same player-facing screen for a selected participant through the participant picker/shuffler and operate it as a GM-authorized action for NPCs, absent players, testing, or player assistance.
 
 Character is the encounter participant state/control tool. It owns the current character loadout and Physical state panel for the selected/controlled participant.
 
 Combat is the GM encounter round/action manager tool. It should be reachable for the selected encounter when the GM wants to use combat flow; roleplay and combat are not separate encounter universes.
 
-Player combat is the player-facing combat/action view. Players see their own combat controls and context. GMs can inspect that same player-facing screen for a selected participant through the participant picker/shuffler; this is read-only unless a future GM-safe edit path is added.
+Player combat is the player-facing combat/action view. Players see their own combat controls and context. GMs can operate that same player-facing screen for a selected participant through the participant picker/shuffler as a GM-authorized action.
 
 Combat Panel is part of the Encounter workflow. It is separate from Character control for now: Character control tracks the current character/loadout/physical state, while the Combat Panel is the scenario or encounter workspace for combat action context. Future damage tracking, round recording, and combat-effect automation should build on these workflows without rendering inactive placeholders.
 
-GM player-facing inspection is separate from GM tooling. Player skill rolls is not embedded inside the GM Skill rolls manager, and Player combat is not embedded inside the GM Combat Round Manager. Inspection uses the same participant picker/shuffler pattern as Character control and does not require logging in as that player. Inspection is a role-safe aid for reviewing what the selected participant can see; player-facing behavior remains controlled by normal access and visibility rules.
+GM player-facing operation is separate from GM tooling. Player skill rolls is not embedded inside the GM Skill rolls manager, and Player combat is not embedded inside the GM Combat Round Manager. GM operation uses the same participant picker/shuffler pattern as Character control and does not require logging in as that player. Player-facing behavior remains controlled by normal access and visibility rules; normal players can only operate their own controlled participant.
 
 Current design rules:
 

--- a/packages/rules-engine/src/combat/workbookCombatMath.test.ts
+++ b/packages/rules-engine/src/combat/workbookCombatMath.test.ts
@@ -15,6 +15,7 @@ import {
   calculateWorkbookMovement,
   calculateWorkbookMovementModifier,
   getWorkbookStatGm,
+  lookupWorkbookPercentageAdjustment,
   lookupWorkbookToHitModifier,
   lookupWorkbookMovementAdjustment,
   lookupWorkbookSkillInitiativeModifier,
@@ -276,6 +277,15 @@ describe("workbookCombatMath", () => {
     expect(getWorkbookStatGm(17)).toBe(3);
     expect(getWorkbookStatGm(11)).toBe(0);
     expect(getWorkbookStatGm(null)).toBeNull();
+  });
+
+  it("applies the low-base minimum percentage adjustment to zero-base combat values", () => {
+    expect(lookupWorkbookPercentageAdjustment(0, 1)).toBe(1);
+    expect(lookupWorkbookPercentageAdjustment(0, 3)).toBe(3);
+    expect(lookupWorkbookPercentageAdjustment(0, 10)).toBe(10);
+    expect(lookupWorkbookPercentageAdjustment(0, 100)).toBe(100);
+    expect(lookupWorkbookPercentageAdjustment(1, 1)).toBe(1);
+    expect(lookupWorkbookPercentageAdjustment(2, 1)).toBe(1);
   });
 
   it("matches the workbook's melee initiative formula for weapon and brawling rows", () => {

--- a/packages/rules-engine/src/combat/workbookCombatMath.ts
+++ b/packages/rules-engine/src/combat/workbookCombatMath.ts
@@ -273,6 +273,18 @@ export function lookupWorkbookPercentageAdjustment(
     return null;
   }
 
+  if (rawOb < 0 || absoluteModifier < 0) {
+    return null;
+  }
+
+  if (rawOb === 0) {
+    // The hardcoded workbook table row for 0 imported as all zeroes, but the
+    // surrounding low-base rows encode a minimum one-point effect per raw step.
+    // Treat base 0 as the same low-base minimum rule so combat values can move
+    // away from zero under live modifiers.
+    return absoluteModifier;
+  }
+
   return WORKBOOK_PERCENTAGE_ADJUSTMENT_TABLE[rawOb]?.[absoluteModifier] ?? null;
 }
 


### PR DESCRIPTION
## Update

Pushed the latest combat modifier and round-manager refinements.

### Included in this push

- Added GM-operable Player skill rolls and Player combat tabs.
  - GM can select/shuffle participants and operate the player-facing screens for NPCs, absent players, or testing.
  - Player users still only operate their own participant.
- Removed embedded player-inspection sections from GM Skill rolls and GM Combat.
  - Skill rolls = GM roll manager.
  - Player skill rolls = player-facing roll screen, GM-operable by selected participant.
  - Combat = GM Combat Round Manager.
  - Player combat = player-facing combat screen, GM-operable by selected participant.
- Removed misleading active-participant controls from the Combat Round Manager.
  - GM advances the round step, not a manually selected “active” participant.
- Added the first Combat inspector action panels.
  - Inspector now shows selected participant/step plus Combat modifiers, Phase 1, and Phase 2 panels.
- Applied live combat-effect modifiers into encounter-context combat panels.
  - General/Fatigue now comes from active Combat Effects and is read-only.
  - Skill/OB and DB remain editable.
  - Live modifiers are applied through the workbook percentage modifier helper.
  - Theoretical `/characters/[id]/loadout` remains unchanged.
- Fixed the zero-base percentage modifier behavior.
  - Base `0` no longer ignores all modifiers.
  - `0 + raw +1 => +1`
  - `0 + raw -1 => -1`
  - `0 + raw +100 => +100`
- Added investigation tests documenting current Shield/Combined DB behavior.
  - Current production order remains unchanged; a future refactor may sum raw modifiers first and apply the percentage table once.

### Verification

Passed locally:

- `pnpm typecheck`
- `pnpm test`
- `pnpm lint`
- `pnpm build`